### PR TITLE
Refactor Invoker/Tracer class to accept Any instead of Tuple[Any] as *inputs

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -6,5 +6,8 @@ def pytest_generate_tests(metafunc):
     # This is called for every test. Only get/set command line arguments
     # if the argument is specified in the list of test "fixturenames".
     option_value = metafunc.config.option.device
-    if 'device' in metafunc.fixturenames and option_value is not None:
-        metafunc.parametrize("device", [option_value], scope='module')
+    if "device" in metafunc.fixturenames and option_value is not None:
+        metafunc.parametrize("device", [option_value], scope="module")
+
+
+collect_ignore = ["examples/test_server.py", "examples/test_server_llama.py"]

--- a/src/nnsight/contexts/Invoker.py
+++ b/src/nnsight/contexts/Invoker.py
@@ -28,7 +28,7 @@ class Invoker(AbstractContextManager):
     def __init__(
         self,
         tracer: "Tracer",
-        *inputs: Tuple[Any],
+        *inputs: Any,
         scan: bool = True,
         **kwargs,
     ) -> None:
@@ -52,9 +52,7 @@ class Invoker(AbstractContextManager):
 
         self.tracer._invoker = self
 
-        self.inputs, batch_size = self.tracer._model._prepare_inputs(
-            *self.inputs, **self.kwargs
-        )
+        self.inputs, batch_size = self.tracer._model._prepare_inputs(*self.inputs, **self.kwargs)
 
         if self.scan:
             self.tracer._model._envoy._clear()

--- a/src/nnsight/contexts/Invoker.py
+++ b/src/nnsight/contexts/Invoker.py
@@ -17,7 +17,7 @@ class Invoker(AbstractContextManager):
 
     Attributes:
         tracer (nnsight.contexts.Tracer.Tracer): Tracer object to enter input and manage context.
-        inputs (Tuple[Any]): Initially entered inputs, then post-processed inputs from model's ._prepare_inputs(...) method.
+        inputs (tuple[Any]): Initially entered inputs, then post-processed inputs from model's ._prepare_inputs(...) method.
         scan (bool): If to execute the model using `FakeTensor` in order to update the potential sizes/dtypes of all modules' Envoys' inputs/outputs as well as validate things work correctly.
             Scanning is not free computation wise so you may want to turn this to false when running in a loop.
             When making interventions, you made get shape errors if scan is false as it validates operations based on shapes so

--- a/src/nnsight/contexts/Tracer.py
+++ b/src/nnsight/contexts/Tracer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import weakref
-from typing import TYPE_CHECKING, Any, Callable, List, Tuple
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple
 
 from ..intervention import InterventionProxy
 from ..tracing.Graph import Graph
@@ -39,7 +39,7 @@ class Tracer:
             self._model._envoy, proxy_class=model.proxy_class, validate=validate
         )
 
-        self._invoker: Invoker = None
+        self._invoker: Optional[Invoker] = None
 
         self._batch_size: int = 0
         self._batch_start: int = 0
@@ -74,7 +74,7 @@ class Tracer:
         self._graph.tracing = False
         self._graph = None
 
-    def invoke(self, *inputs: Tuple[Any], **kwargs) -> Invoker:
+    def invoke(self, *inputs: Any, **kwargs) -> Invoker:
         """Create an Invoker context dor a given input.
 
         Raises:


### PR DESCRIPTION
Hello! 👋 

This tiny PR refactors the Invoker class in order to change the *inputs parameter to accept Any instead of Tuple[Any]. 
(Discussed with JadenFK in NDIF discord server)

Additionally, it uses conftest to ignore the example files which start with the prefix `test`.
- These files don't seem to be pytest files but were being picked up due to their naming convention. There are other solutions including renaming the files but this approach seemed the least invasive, happy to take this part out of the PR if you have another approach in mind though!

There are no changes to functionality and all the tests are green 👌 

Thanks @JadenFiotto-Kaufman! 