### PR TITLE
Save Intervention Graph

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,3 +6,4 @@ sphinx-design
 nbsphinx
 plotly
 ipython
+graphviz

--- a/src/nnsight/contexts/Runner.py
+++ b/src/nnsight/contexts/Runner.py
@@ -43,6 +43,9 @@ class Runner(Tracer):
         if self.remote:
             self.run_server()
 
+            if self._visualize:
+                self._graph.vis(**self._visualize)
+
             self._graph.tracing = False
             self._graph = None
         else:

--- a/src/nnsight/contexts/Tracer.py
+++ b/src/nnsight/contexts/Tracer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 import weakref
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Optional, Dict
 
 from ..intervention import InterventionProxy
 from ..tracing.Graph import Graph
@@ -18,6 +18,7 @@ class Tracer:
     Attributes:
         _model (nnsight.models.NNsightModel.NNsight): nnsight Model object that ths context manager traces and executes.
         _graph (nnsight.tracing.Graph.Graph): Graph which traces operations performed on the input and output of modules' Envoys are added and later executed.
+        _visualize (Optional[Dict]): If specified, represents the parameters to save a graphical visualization of the Intervention Graph (_graph) generated during context.
         _args (List[Any]): Positional arguments to be passed to function that executes the model.
         _kwargs (Dict[str,Any]): Keyword arguments to be passed to function that executes the model.
         _batch_size (int): Batch size of the most recent input. Used by Envoy to create input/output proxies.
@@ -29,11 +30,14 @@ class Tracer:
     def __init__(
         self,
         model: "NNsight",
+        visualize: Optional[Dict] = None,
         validate: bool = True,
         **kwargs,
     ) -> None:
 
         self._model = model
+
+        self._visualize = visualize
 
         self._kwargs = kwargs
 
@@ -72,6 +76,9 @@ class Tracer:
             *self._batched_input,
             **self._kwargs,
         )
+
+        if self._visualize:
+            self._graph.vis(**self._visualize)
 
         self._graph.tracing = False
         self._graph = None

--- a/src/nnsight/tracing/Graph.py
+++ b/src/nnsight/tracing/Graph.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 import weakref
-from typing import Any, Callable, Dict, List, Type, Union
+from typing import Any, Callable, Dict, List, Type, Union, Optional
 
 import torch
 from torch._subclasses.fake_tensor import FakeCopyMode, FakeTensorMode
@@ -187,7 +187,15 @@ class Graph:
         # TODO
         pass
 
-    def vis(self, filename: str = "graph", format: str = "png"):
+    def vis(self, filename: str = "graph", format: str = "png", directory: Optional[str] = None):
+        """ Generates and saves a graphical visualization of the Intervention Graph using the graphviz library. 
+
+        Args:
+            filename (str): Name of the Intervention Graph. Defaults to "graph".
+            format (str): Image format of the graphic. Defaults to "png".
+            directory (Optional[str]): Directory path to save the graphic in. If None saves content to the current directory.
+        """
+
         import graphviz
 
         def style(value: Any) -> Dict[str, Any]:
@@ -269,7 +277,7 @@ class Graph:
 
                 graph.edge(name, node.name)
 
-        graph.render(filename=filename, format=format)
+        graph.render(filename=filename, format=format, directory=directory)
 
     def __str__(self) -> str:
         result = ""


### PR DESCRIPTION
Adding functionality to save the Intervention Graph generated during a tracing context. This is particularly useful for debugging and acquiring a better understanding of how the intervention graph is formed.

To save the graph locally, you can now add a `visualize` argument to `model.trace(...)` by passing it a dictionary with the following **kwargs**:

```
"""
filename (str): Name of the Intervention Graph. Defaults to "graph".
format (str): Image format of the graphic. Defaults to "png".
directory (Optional[str]): Directory path to save the graphic in. If None saves content to the current directory.
"""
```

Here is a coding example for how to use the feature:
``` Python
from collections import OrderedDict
from nnsight import NNsight
import torch

input_size = 5
hidden_dims = 10
output_size = 2

torch.manual_seed(423)

net = torch.nn.Sequential(
    OrderedDict(
        [
            ("layer1", torch.nn.Linear(input_size, hidden_dims)),
            ("layer2", torch.nn.Linear(hidden_dims, output_size))
        ]
    )
).requires_grad_(False)

input = torch.rand((1, input_size))

model = NNsight(net)

with model.trace(input, visualize={"filename": "Layer 1 Output Setting", "directory": "intervention-graphs"}):
    
    l1_output_before = model.layer1.output.clone().save()

    model.layer1.output[:, 2] = 0

    l1_output_after = model.layer1.output.save()

print("L1_Output_Before: ", l1_output_before)
print("L1_Output_After: ", l1_output_after)
```

with the following result being saved:

![Layer 1 Output Attribute Setting](https://github.com/ndif-team/nnsight/assets/57205266/e1d4693f-59fc-4699-8212-9cd2cfb09064)
