### PR TITLE
add separate logging for remote execution, resolves #127

### DIFF
--- a/src/nnsight/__init__.py
+++ b/src/nnsight/__init__.py
@@ -11,7 +11,7 @@ PATH = os.path.dirname(os.path.abspath(__file__))
 with open(os.path.join(PATH, "config.yaml"), "r") as file:
     CONFIG = ConfigModel(**yaml.safe_load(file))
 
-from .logger import logger
+from .logger import logger, remote_logger
 from .models.NNsightModel import NNsight
 from .models.LanguageModel import LanguageModel
 
@@ -19,6 +19,7 @@ from .patching import Patch, Patcher
 from .tracing.Proxy import proxy_wrapper
 
 logger.disabled = not CONFIG.APP.LOGGING
+remote_logger.disabled = not CONFIG.APP.REMOTE_LOGGING
 
 # Below do default patching:
 DEFAULT_PATCHER = Patcher()

--- a/src/nnsight/config.yaml
+++ b/src/nnsight/config.yaml
@@ -3,3 +3,4 @@ API:
   HOST: ndif.dev
 APP:
   LOGGING: false
+  REMOTE_LOGGING: true

--- a/src/nnsight/contexts/Runner.py
+++ b/src/nnsight/contexts/Runner.py
@@ -8,7 +8,7 @@ import torch
 from tqdm import tqdm
 
 from .. import CONFIG, pydantics
-from ..logger import logger
+from ..logger import logger, remote_logger
 from .Tracer import Tracer
 
 
@@ -66,8 +66,8 @@ class Runner(Tracer):
         # Load the data into the ResponseModel pydantic class.
         response = pydantics.ResponseModel(**data)
 
-        # Print response for user ( should be logger.info and have an info handler print to stdout)
-        print(str(response))
+        # Log response for user 
+        remote_logger.info(str(response))
 
         # If the status of the response is completed, update the local nodes that the user specified to save.
         # Then disconnect and continue.
@@ -145,7 +145,7 @@ class Runner(Tracer):
 
                 raise Exception(response.reason)
 
-            print(response)
+            remote_logger.info(response)
 
             while True:
                 if self.handle_response(*sio.receive()):

--- a/src/nnsight/logger.py
+++ b/src/nnsight/logger.py
@@ -22,3 +22,13 @@ logging_handler.setLevel(logging.INFO)
 logger = logging.getLogger("nnsight")
 logger.addHandler(logging_handler)
 logger.setLevel(logging.INFO)
+
+# set up a std out logger
+remote_logger = logging.getLogger("nnsight_remote")
+remote_handler = logging.StreamHandler()
+remote_handler.setFormatter(
+    logging.Formatter("%(asctime)s %(processName)-10s %(name)s %(levelname)-8s %(message)s")
+)
+remote_handler.setLevel(logging.INFO)
+remote_logger.addHandler(remote_handler)
+remote_logger.setLevel(logging.INFO)

--- a/src/nnsight/pydantics/Config.py
+++ b/src/nnsight/pydantics/Config.py
@@ -11,6 +11,7 @@ class ApiConfigModel(BaseModel):
 
 class AppConfigModel(BaseModel):
     LOGGING: bool
+    REMOTE_LOGGING: bool
 
 
 class ConfigModel(BaseModel):


### PR DESCRIPTION
Add a separate logger for remote execution. Now it will log on stdout (replacing the print() statement)