### PR TITLE
Fix Grad Setting Malfunctioning

### DIFF
--- a/src/nnsight/intervention.py
+++ b/src/nnsight/intervention.py
@@ -107,6 +107,8 @@ class InterventionProxy(Proxy):
         """
         self.node.add(target="swap", args=[self.grad.node, value], value=True)
 
+        self.__dict__["_grad"] = None
+
     def __call__(self, *args, **kwargs) -> Self:
 
         # We don't want to call backward on fake tensors
@@ -148,7 +150,7 @@ class InterventionProxy(Proxy):
     ) -> None:
 
         if key == "grad":
-            getattr(self.__class__, key).fset(self, value)
+            return getattr(self.__class__, key).fset(self, value)
 
         return super().__setattr__(key, value)
 

--- a/tests/test_tiny.py
+++ b/tests/test_tiny.py
@@ -39,3 +39,17 @@ def test_tiny(tiny_model: NNsight, tiny_input: torch.Tensor):
         hs = tiny_model.layer2.output.save()
 
     assert isinstance(hs.value, torch.Tensor)
+
+
+def test_grad_setting(tiny_model: NNsight, tiny_input: torch.Tensor):
+    with tiny_model.trace(tiny_input):
+        l1_grad = tiny_model.layer1.output.grad.clone().save()
+
+        tiny_model.layer1.output.grad = tiny_model.layer1.output.grad.clone() * 2
+
+        l1_grad_double = tiny_model.layer1.output.grad.save()
+
+        loss = tiny_model.output.sum()
+        loss.backward()
+
+    assert torch.equal(l1_grad.value * 2, l1_grad_double.value)


### PR DESCRIPTION
Previously, the grad setting operation involved both a "swap" and a "setattr" node operation which was rectified to only included "swap" node. In addition to that, the `InterventionProxy._grad` is now set to `None` at the end of the operation to allow the parent `InterventionProxy` node to fetch the updated value of the gradient when it is called again later by the Intervention Graph.