### PR TITLE
Save Intervention Graph Visual

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,3 +6,4 @@ sphinx-design
 nbsphinx
 plotly
 ipython
+graphviz

--- a/src/nnsight/contexts/Tracer.py
+++ b/src/nnsight/contexts/Tracer.py
@@ -119,3 +119,10 @@ class Tracer:
             args=args,
             kwargs=kwargs,
         )
+    
+    def save_intervention_graph(self, **kwargs) -> None:
+        """
+        Helper method to save a visualization of the current state of the intervention graph.
+        """
+
+        self._graph.vis(**kwargs)

--- a/src/nnsight/tracing/Graph.py
+++ b/src/nnsight/tracing/Graph.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 import weakref
-from typing import Any, Callable, Dict, List, Type, Union
+from typing import Any, Callable, Dict, List, Type, Union, Optional
 
 import torch
 from torch._subclasses.fake_tensor import FakeCopyMode, FakeTensorMode
@@ -187,7 +187,15 @@ class Graph:
         # TODO
         pass
 
-    def vis(self, filename: str = "graph", format: str = "png"):
+    def vis(self, filename: str = "graph", directory: Optional[str] = None, format: str = "png"):
+        """ Generates and saves a graphical visualization of the Intervention Graph using the graphviz library. 
+
+        Args:
+            filename (str): Name of the Intervention Graph. Defaults to "graph".
+            format (str): Image format of the graphic. Defaults to "png".
+            directory (Optional[str]): Directory path to save the graphic in. If None saves content to the current directory.
+        """
+
         import graphviz
 
         def style(value: Any) -> Dict[str, Any]:
@@ -269,7 +277,7 @@ class Graph:
 
                 graph.edge(name, node.name)
 
-        graph.render(filename=filename, format=format)
+        graph.render(filename=filename, format=format, directory=directory)
 
     def __str__(self) -> str:
         result = ""


### PR DESCRIPTION
Adding functionality to save the Intervention Graph generated at any stage during the tracing context. This is particularly useful for debugging and acquiring a better understanding of how the intervention graph is formed or impacted by certain operations.

To save the graph locally, you can now call `tracer.save_intervention_graph(...)` and pass it a number of arguments to configure how you would like to save the graph content. 

```
"""
filename (str): Name of the Intervention Graph. Defaults to "graph".
format (str): Image format of the graphic. Defaults to "png".
directory (Optional[str]): Directory path to save the graphic in. If None saves content to the current directory.
"""
```

Here is a coding example for how to use the feature:
``` Python
from collections import OrderedDict
from nnsight import NNsight
import torch

input_size = 5
hidden_dims = 10
output_size = 2

torch.manual_seed(423)

net = torch.nn.Sequential(
    OrderedDict(
        [
            ("layer1", torch.nn.Linear(input_size, hidden_dims)),
            ("layer2", torch.nn.Linear(hidden_dims, output_size))
        ]
    )
).requires_grad_(False)

input = torch.rand((1, input_size))

model = NNsight(net)

with model.trace(input) as tracer:
    
    l1_output_before = model.layer1.output.clone().save()

    tracer.save_intervention_graph(filename="L1_Out_Before", directory="intervention-graphs")

    model.layer1.output[:, 2] = 0

    l1_output_after = model.layer1.output.save()

    tracer.save_intervention_graph(filename="L1_Out_After", directory="intervention-graphs")
```

with the following results being saved:

**L1_Out_Before**
![L1_Out_Before](https://github.com/ndif-team/nnsight/assets/57205266/d53ce9f6-a698-47e6-abcf-f582a449fb0a)

**L1_Out_After**
![L1_Out_After](https://github.com/ndif-team/nnsight/assets/57205266/a50921b3-c449-4f3d-8c56-1ea3d01ec3ff)


