### PR TITLE
Fix missing parameter `names`

### DIFF
--- a/src/nnsight/envoy.py
+++ b/src/nnsight/envoy.py
@@ -240,7 +240,7 @@ class Envoy:
                 envoys.append(self)
 
         for sub_envoy in self._sub_envoys:
-            sub_envoy.modules(include_fn=include_fn, envoys=envoys)
+            sub_envoy.modules(include_fn=include_fn, names=names, envoys=envoys)
 
         return envoys
 


### PR DESCRIPTION
## What does this PR do?

Fix missing parameter `names` in the `named_parameters` method.
