### PR TITLE
Direct modules access when not tracing

### DIFF
--- a/src/nnsight/envoy.py
+++ b/src/nnsight/envoy.py
@@ -235,7 +235,7 @@ class Envoy:
 
         if included:
             if names:
-                envoys.append((self._module_path, self))
+                envoys.append((self._module_path.lstrip("."), self))
             else:
                 envoys.append(self)
 

--- a/src/nnsight/models/NNsightModel.py
+++ b/src/nnsight/models/NNsightModel.py
@@ -300,6 +300,9 @@ class NNsight:
 
         if key not in ('_model', '_model_key') and isinstance(value, torch.nn.Module):
             
+            if self._envoy._tracer is None:
+                setattr(self._model, key, value)
+                
             setattr(self._envoy, key, value)
 
         else:
@@ -312,6 +315,9 @@ class NNsight:
         Returns:
             Any: Attribute.
         """
+        if self._envoy._tracer is None:
+            return getattr(self._model, key)
+        
         return getattr(self._envoy, key)
 
     ### NNsight VIRTUAL METHODS BELOW #####################################


### PR DESCRIPTION
## What that this PR do?

Directly return the base model attributes when not tracing. (This is also how I understood the issue #156)

I propose to conditionally return and set attributes by checking the `_tracer` attribute of `Envoy`:

```py
if self._envoy._tracer is None:
    return getattr(self._model, key)

return getattr(self._envoy, key)
```

## PS

Adding `envoys.append((self._module_path.lstrip("."), self))` is necessary to then manipulate modules like:
```py
for name, module in model.named_modules():
    assert hasattr(model, name)
```
My bad for not including it in the first PR #165.
