### PR TITLE
Update Protocol

### DIFF
--- a/src/nnsight/contexts/session/Session.py
+++ b/src/nnsight/contexts/session/Session.py
@@ -32,7 +32,7 @@ class Session(GraphBasedContext, RemoteMixin):
 
         self.model = model
 
-        GraphBasedContext.__init__(self, backend, bridge=self.bridge, *args, **kwargs)
+        GraphBasedContext.__init__(self, backend, bridge=self.bridge, proxy_class=self.model.proxy_class, *args, **kwargs)
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
 

--- a/src/nnsight/intervention.py
+++ b/src/nnsight/intervention.py
@@ -83,6 +83,11 @@ class InterventionProxy(Proxy):
 
         Returns:
             InterventionProxy: Proxy.
+
+        .. codeb-block:: python
+            with model.trace(input) as tracer:
+                num = tracer.apply(int, 0)
+                num.update(5)
         """
 
         return protocols.UpdateProtocol.add(self.node.graph, self.node, value)

--- a/src/nnsight/intervention.py
+++ b/src/nnsight/intervention.py
@@ -75,6 +75,18 @@ class InterventionProxy(Proxy):
 
         return self
 
+    def update(self, value: Union[Node, Any]) -> InterventionProxy:
+        """ Updates the value of the Proxy via the creation of the UpdateProtocol node.
+
+        Args:
+            - value (Union[Node, Any]): New proxy value.
+
+        Returns:
+            InterventionProxy: Proxy.
+        """
+
+        return protocols.UpdateProtocol.add(self.node.graph, self.node, value)
+
     @property
     def grad(self) -> InterventionProxy:
         """

--- a/src/nnsight/intervention.py
+++ b/src/nnsight/intervention.py
@@ -90,7 +90,7 @@ class InterventionProxy(Proxy):
                 num.update(5)
         """
 
-        return protocols.UpdateProtocol.add(self.node.graph, self.node, value)
+        return protocols.UpdateProtocol.add(self.node, value)
 
     @property
     def grad(self) -> InterventionProxy:

--- a/src/nnsight/schema/format/functions.py
+++ b/src/nnsight/schema/format/functions.py
@@ -87,13 +87,7 @@ FUNCTIONS_WHITELIST.update(
         if isinstance(protocol, type) and issubclass(protocol, protocols.Protocol)
     }
 )
-FUNCTIONS_WHITELIST.update(
-    {
-        get_function_name(protocol): protocol
-        for key, protocol in getmembers(Iterator)
-        if isinstance(protocol, type) and issubclass(protocol, protocols.Protocol)
-    }
-)
+
 FUNCTIONS_WHITELIST.update(
     {
         get_function_name(protocol): protocol

--- a/src/nnsight/tracing/protocols.py
+++ b/src/nnsight/tracing/protocols.py
@@ -520,8 +520,7 @@ class UpdateProtocol(Protocol):
             target=cls,
             proxy_value=node.proxy_value,
             args=[
-                node.graph.id,
-                node.name,
+                node,
                 new_value,
             ],
         )
@@ -535,14 +534,11 @@ class UpdateProtocol(Protocol):
             node (Node): UpdateProtocol node.
         """
 
-        proxy_node_graph_id, proxy_node_name, new_value = node.args
+        value_node, new_value = node.args
 
-        if BridgeProtocol.has_bridge(node.graph):
-            bridge = BridgeProtocol.get_bridge(node.graph)
-            original_node: "Node" = bridge.id_to_graph[proxy_node_graph_id].nodes[proxy_node_name]
-        else:
-            original_node = node.graph.nodes[proxy_node_name]
+        if value_node.target == BridgeProtocol:
+            bridge = BridgeProtocol.get_bridge(value_node.graph)
+            lock_node = bridge.id_to_graph[value_node.args[0]].nodes[value_node.args[1]]
+            value_node = lock_node.args[0]
 
-        original_node._value = util.apply(
-            new_value, lambda x: x.value, type(original_node)
-        )
+        value_node._value = Node.prepare_inputs(new_value)

--- a/src/nnsight/tracing/protocols.py
+++ b/src/nnsight/tracing/protocols.py
@@ -541,4 +541,9 @@ class UpdateProtocol(Protocol):
             lock_node = bridge.id_to_graph[value_node.args[0]].nodes[value_node.args[1]]
             value_node = lock_node.args[0]
 
-        value_node._value = Node.prepare_inputs(new_value)
+        new_value = Node.prepare_inputs(new_value)
+
+        value_node._value = new_value
+
+        node.set_value(new_value)
+

--- a/src/nnsight/tracing/protocols.py
+++ b/src/nnsight/tracing/protocols.py
@@ -1,6 +1,6 @@
 import inspect
 import weakref
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, Union
 
 import torch
 from torch._subclasses.fake_tensor import FakeCopyMode, FakeTensorMode
@@ -343,6 +343,9 @@ class SwapProtocol(Protocol):
 
         return value
 
+class BridgeException(Exception):
+    def __init__(self):
+        super.__init__("Must define a Session context to make use of the Bridge")
 
 class BridgeProtocol(Protocol):
     """Protocol to connect two Graphs by grabbing a value from one and injecting it into another.
@@ -413,8 +416,7 @@ class BridgeProtocol(Protocol):
         """
 
         if not cls.has_bridge(graph):
-            # TODO error
-            pass
+            raise BridgeException()
 
         return graph.attachments[cls.attachment_name]
 

--- a/src/nnsight/tracing/protocols.py
+++ b/src/nnsight/tracing/protocols.py
@@ -504,11 +504,10 @@ class UpdateProtocol(Protocol):
     """
 
     @classmethod
-    def add(cls, graph: "Graph", node: "Node", new_value: Union[Node, Any]) -> "InterventionProxy":
+    def add(cls, node: "Node", new_value: Union[Node, Any]) -> "InterventionProxy":
         """ Creates an UpdateProtocol node.
 
         Args:
-            graph (Graph): Graph to create the protocol node on.
             node (Node): Original node.
             new_value (Union[Node, Any]): The update value.
         
@@ -516,7 +515,7 @@ class UpdateProtocol(Protocol):
             InterventionProxy: proxy.
         """
 
-        return graph.create(
+        return node.create(
             target=cls,
             proxy_value=node.proxy_value,
             args=[

--- a/tests/test_tiny.py
+++ b/tests/test_tiny.py
@@ -77,4 +77,13 @@ def test_early_stop_protocol(tiny_model: NNsight, tiny_input: torch.Tensor):
 
     with pytest.raises(ValueError):
         l2_out.value
+
+def test_bridge_protocol(tiny_model: NNsight, tiny_input: torch.Tensor):
+    with tiny_model.session() as session:
+        val = session.apply(int, 0)
+        with tiny_model.trace(tiny_input):
+            tiny_model.layer1.output[:] = val # fetches the val proxy using the bridge protocol
+            l1_out = tiny_model.layer1.output.save()
+
+    assert torch.all(l1_out.value == 0).item()
     

--- a/tests/test_tiny.py
+++ b/tests/test_tiny.py
@@ -86,4 +86,14 @@ def test_bridge_protocol(tiny_model: NNsight, tiny_input: torch.Tensor):
             l1_out = tiny_model.layer1.output.save()
 
     assert torch.all(l1_out.value == 0).item()
+
+def test_update_protocol(tiny_model: NNsight):
+    with tiny_model.session() as session:
+        sum = session.apply(int, 0).save()
+        with session.iter([0, 1, 2]) as (item, iterator):
+            sum.update(sum + item)
+
+        sum.update(sum + 4)
+
+    assert sum.value == 7
     


### PR DESCRIPTION
**New Feature!** You can now mutate the value of an InterventionProxy.

Call `InterventionProxy.update(<value>)` and pass it the new value to set.

```python
with model.trace(input) as tracer:
    num = tracer.apply(int, 0).save()
    num.update(5)
    
print(num) #5
```

This is particularly useful for running in-place cumulative operations, like computing a running average or saving a hidden state across multiple iterations.

### Implementation

The UpdateProtocol is context agnostic and can be called on any Intervention Proxy, even if defined outside of the current context. It is introduced as a refactoring of the StatUpdateProtocol, previously reserved for the Iterator context’s Stat mechanism. 

The `GraphBasedContext.apply(Callable, *args)` eliminates the need for the Stat mechanism as it allows to create Intervention Proxies at any point. If the proxy to be updated is a Bridge Protocol node, then the external node is fetched to complete the operation, using the global Bridge.

### Examples

##### (Running sum)

```python
with model.session() as session:
    sum = session.apply(int, 0).save()
    with session.iter([0, 1, 2]) as (item, iterator):
        sum.update(sum + item)

print(sum) # 3
```
![Iterator](https://github.com/user-attachments/assets/61350f48-2baf-4b73-86cc-5ee646b69b5c)


##### (Save output across multiple iterations)

```python

with model.session() as session:
    l = session.apply(list).save()
    with session.iter([0, 1, 2]) as (item, iterator):
        with model.trace(input) as tracer:
            model.layer1.output = model.layer1.output * item
            l.update(l + [model.output])
```

### Notes

1. Should we add a check in `UpdateProtocol.execute(...)` to ensure that the new_value is of the same type as the current value?
2.  I observe that the Bridge Protocol and Update Protocol are essentially conducting Get and Set operations on Node values globally using the Bridge respectively. Additionally, the Bridge Protocol is no longer the only Protocol to interact directly with the Bridge object, and so, I would suggest to rename these protocols to Fetch/Get Protocol and Set Protocol respectively for better functional description.
