### PR TITLE
Unique Bridge Nodes

### DIFF
--- a/src/nnsight/tracing/Bridge.py
+++ b/src/nnsight/tracing/Bridge.py
@@ -94,7 +94,7 @@ class Bridge:
             Optional[Node]: Bridge Node if it exists.
         """
 
-        for bridge_node in self.bridged_nodes_dict[node]:
+        for bridge_node in self.bridged_nodes[node]:
             if bridge_node.graph.id == graph_id:
                 return bridge_node
 

--- a/src/nnsight/tracing/Bridge.py
+++ b/src/nnsight/tracing/Bridge.py
@@ -1,10 +1,11 @@
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from . import protocols
 
 if TYPE_CHECKING:
     from .Graph import Graph
+    from .Node import Node
 
 
 class Bridge:
@@ -14,6 +15,7 @@ class Bridge:
     Attributes:
         id_to_graph (Dict[int, Graph]): Mapping of graph id to Graph.
         graph_stack (List[Graph]): Stack of visited Intervention Graphs.
+        bridged_nodes (defaultdict[Node, List[Node]]): Mapping of bridged Nodes to the BridgeProtocol nodes representing them on different graphs. 
         locks (int): Count of how many entities are depending on ties between graphs not to be released.
     """
 
@@ -23,6 +25,7 @@ class Bridge:
         self.id_to_graph: Dict[int, "Graph"] = OrderedDict()
         # Stack to keep track of most inner current graph
         self.graph_stack: List["Graph"] = list()
+        self.bridged_nodes: defaultdict[Node, List[Node]] = defaultdict(lambda: list())
 
         self.locks = 0
 
@@ -69,3 +72,30 @@ class Bridge:
         """
 
         return self.id_to_graph[id]
+    
+    def add_bridge_node(self, node: "Node", bridge_node: "Node") -> None:
+        """ Adds a BridgeProtocol to the bridged nodes attribute.
+
+        Args:
+            - node (Node): Bridged Node.
+            - bridge_node (Node): BridgeProtocol node of the bridged node.
+        """ 
+
+        self.bridged_nodes[node].append(bridge_node)
+
+    def get_bridge_node(self, node: "Node", graph_id: int) -> Optional["Node"]:
+        """ Check if the argument Node is bridged within the specified graph and returns its corresponding BridgeProtocol node.
+
+        Args:
+            - node (Node): Node.
+            - graph_id (int): Graph id.
+
+        Returns: 
+            Optional[Node]: Bridge Node if it exists.
+        """
+
+        for bridge_node in self.bridged_nodes_dict[node]:
+            if bridge_node.graph.id == graph_id:
+                return bridge_node
+
+        return None

--- a/src/nnsight/tracing/Node.py
+++ b/src/nnsight/tracing/Node.py
@@ -105,7 +105,7 @@ class Node:
 
             if self.attached() and self.graph.id != node.graph.id:
 
-                node = protocols.BridgeProtocol.bridge_node(node, self.graph.id)
+                node = protocols.BridgeProtocol.add(node).node
 
             self.arg_dependencies.append(node)
             # Weakref so no reference loop

--- a/src/nnsight/tracing/Node.py
+++ b/src/nnsight/tracing/Node.py
@@ -103,7 +103,7 @@ class Node:
 
             if self.attached() and self.graph.id != node.graph.id:
 
-                node = protocols.BridgeProtocol.add(node).node
+                node = protocols.BridgeProtocol.bridge_node(node, self.graph.id)
 
             self.arg_dependencies.append(node)
             # Weakref so no reference loop

--- a/src/nnsight/tracing/protocols.py
+++ b/src/nnsight/tracing/protocols.py
@@ -443,7 +443,7 @@ class BridgeProtocol(Protocol):
                                 proxy_value=node.proxy_value,
                                 args=[node.graph.id, lock_node.name],
                             )
-            bridge.add_bridge_proxy(node, curr_graph.id, bridge_proxy)
+            bridge.add_bridge_proxy(node, bridge_proxy)
         
         return bridge_proxy
 

--- a/src/nnsight/tracing/protocols.py
+++ b/src/nnsight/tracing/protocols.py
@@ -454,6 +454,29 @@ class BridgeProtocol(Protocol):
         else:
             bridge = BridgeProtocol.get_bridge(graph)
             return bridge.peek_graph()
+        
+    @classmethod
+    def bridge_node(cls, node: "Node", graph_id: int) -> "Node":
+        """ Creates a reference to an external proxy node by creating a BridgeProtocol node or returning an existing one from the same graph.
+
+        Args:
+            - node (Node): Node to bridge.
+            - graph_id (int): Graph id.
+
+        Returns:
+            Node: BridgeProtocol node.        
+        """
+
+        bridge = cls.get_bridge(node.graph)
+        bridge_node = bridge.get_bridge_node(node, graph_id) # a bridged node has a unique bridge node per graph reference
+
+        # if the bridge node does not exist, create one
+        if bridge_node:
+            return bridge_node
+        else:
+            bridge_node = cls.add(node).node
+            bridge.add_bridge_node(node, bridge_node)
+            return bridge_node
 
 
 class EarlyStopException(Exception):

--- a/src/nnsight/tracing/protocols.py
+++ b/src/nnsight/tracing/protocols.py
@@ -742,13 +742,13 @@ class UpdateProtocol(Protocol):
         """
 
         value_node, new_value = node.args
+        new_value = Node.prepare_inputs(new_value)
 
         if value_node.target == BridgeProtocol:
+            value_node._value = new_value
             bridge = BridgeProtocol.get_bridge(value_node.graph)
             lock_node = bridge.id_to_graph[value_node.args[0]].nodes[value_node.args[1]]
             value_node = lock_node.args[0]
-
-        new_value = Node.prepare_inputs(new_value)
 
         value_node._value = new_value
 

--- a/src/nnsight/tracing/protocols.py
+++ b/src/nnsight/tracing/protocols.py
@@ -537,12 +537,11 @@ class BridgeProtocol(Protocol):
         bridge_node = bridge.get_bridge_node(node, graph_id) # a bridged node has a unique bridge node per graph reference
 
         # if the bridge node does not exist, create one
-        if bridge_node:
-            return bridge_node
-        else:
+        if bridge_node is None:
             bridge_node = cls.add(node).node
             bridge.add_bridge_node(node, bridge_node)
-            return bridge_node
+            
+        return bridge_node
 
     @classmethod
     def style(cls) -> Dict[str, Any]:

--- a/tests/test_tiny.py
+++ b/tests/test_tiny.py
@@ -184,7 +184,7 @@ def test_bridge_protocol(tiny_model: NNsight, tiny_input: torch.Tensor):
 
     assert torch.all(l1_out.value == 0).item()
 
-def test_update_protocol(tiny_model: NNsight):
+def test_update_protocol(tiny_model: NNsight, tiny_input: torch.Tensor):
     with tiny_model.session() as session:
         sum = session.apply(int, 0).save()
         with session.iter([0, 1, 2]) as (item, iterator):
@@ -192,4 +192,8 @@ def test_update_protocol(tiny_model: NNsight):
 
         sum.update(sum + 4)
 
-    assert sum.value == 7
+        with tiny_model.trace(tiny_input):
+            sum.update(sum + 3)
+            double_sum = (sum * 2).save()
+
+    assert double_sum.value == 20


### PR DESCRIPTION
Adding functionality for optimizing bridged Intervention Graphs.

### Motivation

Previously, a `BridgeProtocol` node was created at each reference of an external proxy within the same graph. But optimally, all operations on the same proxy should all be linked to a single corresponding `BridgeProtocol` node.

#### Example

```python
from collections import OrderedDict
from nnsight import NNsight
import torch

input_size = 5
hidden_dims = 10
output_size = 2

net = torch.nn.Sequential(
    OrderedDict(
        [
            ("layer1", torch.nn.Linear(input_size, hidden_dims)),
            ("layer2", torch.nn.Linear(hidden_dims, output_size)),
        ]
    )
).requires_grad_(False)

input = torch.rand((1, input_size))

with model.session() as session:
    with model.trace(input) as tracer:
        l1_out = model.layer1.output

    with model.trace(input) as tracer_2:
        l1_out_double = l1_out * 2
        
        l1_out_sum = torch.sum(l1_out)

        tracer_2.graph.vis("Tracer_2")
```

![Tracer_2](https://github.com/user-attachments/assets/ff808fc4-2df9-4ec1-ba2f-7e4b11eb6627)


### Implementation

The `Bridge` structure tracks the bridge nodes created for a certain proxy, for every context it was externally referenced from.

Preprocessing of a `Node`'s arguments during instantiation no longer automatically creates a BridgeProtocol node in the case of an external reference to an argument. The `BridgeProtocol` handles directly bridging a node (creating a local reference) by checking first if the external node has been bridged previously before creating a new `BridgeProtocol` node.

When the `UpdateProtocol` is called on an external proxy node, the value of its local `BridgeProtocol` reference is also updated to reflect the new change.

### Results

![Tracer_2](https://github.com/user-attachments/assets/855b2a56-8006-46fe-a27c-8ac018222eb9)

 