### PR TITLE
Early Exit of Sequential Graph Based Contexts

### DIFF
--- a/src/nnsight/contexts/GraphBasedContext.py
+++ b/src/nnsight/contexts/GraphBasedContext.py
@@ -57,7 +57,10 @@ class GraphBasedContext(AbstractContextManager, BridgeMixin):
             InterventionProxy: Proxy of the EarlyStopProtocol node.
         """
 
-        return protocols.EarlyStopProtocol.add(self.graph)
+        if self.graph.sequential:
+            return protocols.EarlyStopProtocol.add(self.graph)
+        else:
+            raise Exception("Early exit is only supported for sequential graph-based contexts.")
 
     def vis(self, **kwargs) -> None:
         """

--- a/src/nnsight/contexts/Tracer.py
+++ b/src/nnsight/contexts/Tracer.py
@@ -14,6 +14,7 @@ from .Invoker import Invoker
 if TYPE_CHECKING:
     from ..models.mixins import RemoteableMixin
     from ..models.NNsightModel import NNsight
+    from ..intervention import InterventionProxy
 
 
 class Tracer(GraphBasedContext, RemoteMixin, BridgeMixin, EditMixin):
@@ -107,6 +108,15 @@ class Tracer(GraphBasedContext, RemoteMixin, BridgeMixin, EditMixin):
         """
 
         self.model._envoy.next(increment=increment, propagate=True)
+
+    def exit(self) -> "InterventionProxy":
+        """ Exits the execution of a sequential intervention graph.
+        
+        Returns:
+            InterventionProxy: Proxy of the EarlyStopProtocol node.
+        """
+        raise Exception(".exit() not supported on the Tracer entity.\n" + \
+                        "Refer to the .stop() functionaly on Envoys for an early stop of the Tracer execution.")
 
     ##### BACKENDS ###############################
 

--- a/src/nnsight/contexts/Tracer.py
+++ b/src/nnsight/contexts/Tracer.py
@@ -109,15 +109,6 @@ class Tracer(GraphBasedContext, RemoteMixin, BridgeMixin, EditMixin):
 
         self.model._envoy.next(increment=increment, propagate=True)
 
-    def exit(self) -> "InterventionProxy":
-        """ Exits the execution of a sequential intervention graph.
-        
-        Returns:
-            InterventionProxy: Proxy of the EarlyStopProtocol node.
-        """
-        raise Exception(".exit() not supported on the Tracer entity.\n" + \
-                        "Refer to the .stop() functionaly on Envoys for an early stop of the Tracer execution.")
-
     ##### BACKENDS ###############################
 
     def local_backend_execute(self) -> Graph:

--- a/src/nnsight/contexts/session/Iterator.py
+++ b/src/nnsight/contexts/session/Iterator.py
@@ -56,7 +56,7 @@ class Iterator(GraphBasedContext):
 
             try:
                 super().local_backend_execute()
-            except:
+            except protocols.EarlyStopProtocol.EarlyStopException:
                 break
 
     def __repr__(self) -> str:

--- a/src/nnsight/contexts/session/Iterator.py
+++ b/src/nnsight/contexts/session/Iterator.py
@@ -54,7 +54,10 @@ class Iterator(GraphBasedContext):
                 self.graph.nodes[f"{protocols.ValueProtocol.__name__}_0"], item
             )
 
-            super().local_backend_execute()
+            try:
+                super().local_backend_execute()
+            except:
+                break
 
     def __repr__(self) -> str:
         return f"&lt;{self.__class__.__name__} at {hex(id(self))}&gt;"

--- a/src/nnsight/contexts/session/Session.py
+++ b/src/nnsight/contexts/session/Session.py
@@ -8,6 +8,7 @@ from ...tracing.Graph import Graph
 from ..backends import Backend, BridgeBackend, RemoteMixin
 from ..GraphBasedContext import GraphBasedContext
 from .Iterator import Iterator
+from ...tracing.protocols import EarlyStopProtocol
 
 if TYPE_CHECKING:
     from ...models.mixins import RemoteableMixin
@@ -55,7 +56,10 @@ class Session(GraphBasedContext, RemoteMixin):
 
     def local_backend_execute(self) -> Dict[int, Graph]:
 
-        super().local_backend_execute()
+        try:
+            super().local_backend_execute()
+        except EarlyStopProtocol.EarlyStopException:
+            pass
 
         local_result = self.bridge.id_to_graph
 

--- a/src/nnsight/intervention.py
+++ b/src/nnsight/intervention.py
@@ -79,7 +79,7 @@ class InterventionProxy(Proxy, Conditional):
             InterventionProxy: Proxy.
         """
 
-        protocols.EarlyStopProtocol.add(self.node)
+        protocols.EarlyStopProtocol.add(self.node.graph, self.node)
 
         return self
 

--- a/src/nnsight/models/NNsightModel.py
+++ b/src/nnsight/models/NNsightModel.py
@@ -392,7 +392,9 @@ class NNsight:
                 fn(*inputs, **kwargs)
             except protocols.EarlyStopProtocol.EarlyStopException:
                 # TODO: Log.
-                pass
+                for node in intervention_graph.nodes.values():
+                    if not node.fulfilled():
+                        node.clean()
 
         logger.info(f"Completed `{self._model_key}`")
 

--- a/src/nnsight/tracing/Graph.py
+++ b/src/nnsight/tracing/Graph.py
@@ -61,7 +61,8 @@ class Graph:
         if self.sequential:
 
             for node in self.nodes.values():
-                node.execute()
+                if node.fulfilled():
+                    node.execute()
 
         else:
 

--- a/src/nnsight/tracing/Node.py
+++ b/src/nnsight/tracing/Node.py
@@ -393,11 +393,11 @@ class Node:
             bridge = protocols.BridgeProtocol.get_bridge(self.graph)
             lock_node = bridge.get_graph(self.args[0]).nodes[self.args[1]]
             lock_dependency = lock_node.args[0]
-            if not lock_node.done():
-                lock_dependency.remaining_listeners -= 1
-                lock_node.destroy()
-                if lock_dependency.redundant():
-                    lock_dependency.destroy()
+            # if not lock_node.done():
+            lock_dependency.remaining_listeners -= 1
+            lock_node.destroy()
+            if lock_dependency.redundant():
+                lock_dependency.destroy()
         else:
             for dependency in self.arg_dependencies:
                 dependency.remaining_listeners -= 1

--- a/src/nnsight/tracing/Node.py
+++ b/src/nnsight/tracing/Node.py
@@ -393,7 +393,6 @@ class Node:
             bridge = protocols.BridgeProtocol.get_bridge(self.graph)
             lock_node = bridge.get_graph(self.args[0]).nodes[self.args[1]]
             lock_dependency = lock_node.args[0]
-            # if not lock_node.done():
             lock_dependency.remaining_listeners -= 1
             lock_node.destroy()
             if lock_dependency.redundant():

--- a/src/nnsight/tracing/protocols.py
+++ b/src/nnsight/tracing/protocols.py
@@ -1,7 +1,7 @@
 import inspect
 import weakref
 
-from typing import TYPE_CHECKING, Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Union, Optional
 from collections import defaultdict
 
 import torch
@@ -543,11 +543,11 @@ class EarlyStopProtocol(Protocol):
         pass
 
     @classmethod
-    def add(cls, node: "Node") -> "InterventionProxy":
-        return node.create(
+    def add(cls, graph: "Graph", stop_point_node: Optional["Node"] = None) -> "InterventionProxy":
+        return graph.create(
             target=cls,
             proxy_value=None,
-            args=[node],
+            args=([stop_point_node] if stop_point_node is not None else []),
         )
 
     @classmethod

--- a/tests/test_tiny.py
+++ b/tests/test_tiny.py
@@ -208,3 +208,23 @@ def test_sequential_graph_based_context_exit(tiny_model: NNsight):
         l.append(6)
 
     assert l.value == [0, 1, 2, 5]
+
+def test_tracer_stop(tiny_model: NNsight, tiny_input: torch.Tensor):
+    with tiny_model.trace(tiny_input):
+        l1_out = tiny_model.layer1.output
+        tiny_model.layer1.output.stop()
+        l1_out_double = l1_out * 2
+
+    with pytest.raises(ValueError):
+        l1_out.value
+
+def test_bridged_node_cleanup(tiny_model: NNsight):
+    with tiny_model.session() as session:
+        l = session.apply(list)
+        with session.iter([0, 1, 2]) as (item, iterator):
+            with item == 2:
+                iterator.exit()
+            l.append(item)
+
+    with pytest.raises(ValueError):
+        l.value

--- a/tests/test_tiny.py
+++ b/tests/test_tiny.py
@@ -193,3 +193,18 @@ def test_update_protocol(tiny_model: NNsight):
         sum.update(sum + 4)
 
     assert sum.value == 7
+
+def test_sequential_graph_based_context_exit(tiny_model: NNsight):
+    with tiny_model.session() as session:
+        l = session.apply(list).save()
+        l.append(0)
+
+        with session.iter([1, 2, 3, 4]) as (item, iterator):
+            with item == 3:
+                iterator.exit()
+            l.append(item)
+        l.append(5)
+        session.exit()
+        l.append(6)
+
+    assert l.value == [0, 1, 2, 5]


### PR DESCRIPTION
New feature! You can now terminate early the execution of sequential graph-based contexts. The contexts concerned by this feature include the `Session` and `Iterator` contexts,`Tracer`context does not support it. Call `GraphBasedContext.exit()` to skip the remaining execution.

## Examples

Terminating a Session:

```python
with model.session() as session:
    l = session.apply(list).save()

    l.append(0)
    l.append(1)
    session.exit()
    l.append(2)

print("Result: ", l)
```
```python
"Result: [0, 1]"
```

Terminating an Iterator loop:

```python
with model.session() as session:
    l = session.apply(list).save()

    with session.iter([0, 1, 2, 3]) as (item, iterator):
        with item == 2:
            iterator.exit()
        
        l.append(item)

print("Result: ", l)
```
```python
"Result: [0, 1]"
```

## Implementation

The Exit operation makes use of the `EarlyStopProtocol`, creating a node the moment it is called. The `EarlyStopException` is caught when the `EarlyStopProtocol` node is executed, with the `Iterator` breaking out of its loop.

## Notes

An improvement should be put in place for the graph visualization feature to reflect sequential positioning of nodes in the graph.