### PR TITLE
Conditional Context has a GraphBasedContext entry point

### DIFF
--- a/src/nnsight/contexts/Conditional.py
+++ b/src/nnsight/contexts/Conditional.py
@@ -8,6 +8,7 @@ from ..tracing import protocols
 if TYPE_CHECKING:
     from ..tracing.Node import Node
     from ..tracing.Graph import Graph
+    from ..intervention import InterventionProxy
 
 class ConditionalManager():
     """ A Graph attachement that manages the Conditional contexts defined within an Intervention Graph.
@@ -90,12 +91,12 @@ class Conditional(AbstractContextManager):
 
     Attributes:
         _graph (Graph): Conditional Context graph.
-        _condition (Node): Node with the condition value.
+        _condition (Union[InterventionProxy, Any]): Condition.
     """
 
-    def __init__(self, graph: "Graph", condition: Union["Node", Any]):
+    def __init__(self, graph: "Graph", condition: Union["InterventionProxy", Any]):
        self._graph = graph
-       self._condition: Union["Node", Any] = condition
+       self._condition: Union["InterventionProxy", Any] = condition
 
     def __enter__(self) -> Conditional:
 

--- a/src/nnsight/contexts/Conditional.py
+++ b/src/nnsight/contexts/Conditional.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 from contextlib import AbstractContextManager
-from typing import TYPE_CHECKING, Dict, List, Optional, Set
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Any, Union
 
 from ..tracing import protocols
 
 if TYPE_CHECKING:
     from ..tracing.Node import Node
+    from ..tracing.Graph import Graph
 
 class ConditionalManager():
     """ A Graph attachement that manages the Conditional contexts defined within an Intervention Graph.
@@ -88,15 +89,17 @@ class Conditional(AbstractContextManager):
     """ A context defined by a boolean condition, upon which the execution of all nodes defined from within is contingent. 
 
     Attributes:
+        _graph (Graph): Conditional Context graph.
         _condition (Node): Node with the condition value.
     """
 
-    def __init__(self, condition: "Node"):
-       self._condition: "Node" = condition
+    def __init__(self, graph: "Graph", condition: Union["Node", Any]):
+       self._graph = graph
+       self._condition: Union["Node", Any] = condition
 
     def __enter__(self) -> Conditional:
 
-        conditional_node = protocols.ConditionalProtocol.add(self._condition).node
+        conditional_node = protocols.ConditionalProtocol.add(self._graph, self._condition).node
 
         protocols.ConditionalProtocol.push_conditional(conditional_node)
 
@@ -104,4 +107,4 @@ class Conditional(AbstractContextManager):
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
 
-        protocols.ConditionalProtocol.pop_conditional(protocols.BridgeProtocol.peek_graph(self._condition.graph))
+        protocols.ConditionalProtocol.pop_conditional(self._graph)

--- a/src/nnsight/contexts/GraphBasedContext.py
+++ b/src/nnsight/contexts/GraphBasedContext.py
@@ -102,9 +102,6 @@ class GraphBasedContext(AbstractContextManager, BridgeMixin):
                         out = model.output.save()
         """
 
-        if isinstance(condition, InterventionProxy):
-            condition = condition.node
-
         return Conditional(self.graph, condition)
 
     def exit(self) -> InterventionProxy:

--- a/src/nnsight/intervention.py
+++ b/src/nnsight/intervention.py
@@ -28,7 +28,7 @@ from .tracing.protocols import Protocol
 from .tracing.Proxy import Proxy
 
 
-class InterventionProxy(Proxy, Conditional):
+class InterventionProxy(Proxy):
     """Sub-class for Proxy that adds additional user functionality to proxies.
 
     Examples:
@@ -51,11 +51,6 @@ class InterventionProxy(Proxy, Conditional):
         self.__dict__["_grad"] = None
 
         self._grad: InterventionProxy
-
-    def __enter__(self) -> Conditional:
-        self.__dict__["_condition"] = self.node
-
-        return Conditional.__enter__(self)
 
     def save(self) -> InterventionProxy:
         """Method when called, indicates to the intervention graph to not delete the tensor values of the result.

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -323,7 +323,7 @@ def test_batched_editing(gpt2: nnsight.LanguageModel):
 def test_conditional_interventions(gpt2: nnsight.LanguageModel):
     with gpt2.session() as session:
         with gpt2.trace("Hello World") as tracer:
-            with torch.all(gpt2.transformer.h[5].output[0] < 100000):
+            with tracer.cond(torch.all(gpt2.transformer.h[5].output[0] < 100000)):
                 gpt2.transformer.h[-1].output[0][:] = 0
 
             output = gpt2.transformer.h[-1].output[0].save()


### PR DESCRIPTION
Reverting to the previous API design for creating Conditional contexts, using any graph-based context.

## Implementation Changes

`ConditionalProtocol` nodes don't have to strictly depend on Intervention Proxies anymore, as the condition input can be of any data type and will be evaluated with `bool()`. This means that you can have `ConditionalProtocol` nodes directly depend on other `ConditionalProtocol` nodes.

`InterventionProxy` is no longer a `ContextManager` for the moment.

## Usage

```python
with tiny_model.trace(tiny_input) as tracer:
        num = 5
        with tracer.cond(num > 0):
            tiny_model.layer1.output[:] = 1
            l1_out = tiny_model.layer1.output.save()
```

 
