### PR TITLE
global nnsight support of python builtins

### DIFF
--- a/src/nnsight/__init__.py
+++ b/src/nnsight/__init__.py
@@ -28,9 +28,19 @@ from .models.NNsightModel import NNsight
 from .models.LanguageModel import LanguageModel
 from .patching import Patch, Patcher
 from .tracing.Proxy import proxy_wrapper
-# from .globals import GlobalTracingContext
+from .contexts.GraphBasedContext import GlobalTracingContext
 
-# ops = GlobalTracingContext.GLOBAL_TRACING_CONTEXT
+bool = GlobalTracingContext.GLOBAL_TRACING_CONTEXT.bool
+bytes = GlobalTracingContext.GLOBAL_TRACING_CONTEXT.bytes
+int = GlobalTracingContext.GLOBAL_TRACING_CONTEXT.int
+float = GlobalTracingContext.GLOBAL_TRACING_CONTEXT.float
+str = GlobalTracingContext.GLOBAL_TRACING_CONTEXT.str
+complex = GlobalTracingContext.GLOBAL_TRACING_CONTEXT.complex
+bytearray = GlobalTracingContext.GLOBAL_TRACING_CONTEXT.bytearray
+tuple = GlobalTracingContext.GLOBAL_TRACING_CONTEXT.tuple
+list = GlobalTracingContext.GLOBAL_TRACING_CONTEXT.list
+set = GlobalTracingContext.GLOBAL_TRACING_CONTEXT.set
+dict = GlobalTracingContext.GLOBAL_TRACING_CONTEXT.dict
 
 logger.disabled = not CONFIG.APP.LOGGING
 remote_logger.disabled = not CONFIG.APP.REMOTE_LOGGING

--- a/src/nnsight/contexts/GraphBasedContext.py
+++ b/src/nnsight/contexts/GraphBasedContext.py
@@ -78,6 +78,83 @@ class GraphBasedContext(AbstractContextManager, BridgeMixin):
         """
         self.apply(print, *data)
 
+    def bool(self, *args, **kwargs) -> InterventionProxy:
+        """
+        
+        """
+
+        return self.apply(bool, *args, **kwargs)
+
+    def bytes(self, *args, **kwargs) -> InterventionProxy:
+        """
+        
+        """
+
+        return self.apply(bytes, *args, **kwargs)
+
+    def int(self, *args, **kwargs) -> InterventionProxy:
+        """
+        
+        """
+
+        return self.apply(int, *args, **kwargs)
+
+    def float(self, *args, **kwargs) -> InterventionProxy:
+        """
+        
+        """
+
+        return self.apply(float, *args, **kwargs)
+
+    def str(self, *args, **kwargs) -> InterventionProxy:
+        """
+        
+        """
+
+        return self.apply(str, *args, **kwargs)
+
+    def complex(self, *args, **kwargs) -> InterventionProxy:
+        """
+        
+        """
+
+        return self.apply(complex, *args, **kwargs)
+
+    def bytearray(self, *args, **kwargs) -> InterventionProxy:
+        """
+        
+        """
+
+        return self.apply(bytearray, *args, **kwargs)
+
+    def tuple(self, *args, **kwargs) -> InterventionProxy:
+        """
+        
+        """
+
+        return self.apply(tuple, *args, **kwargs)
+
+    def list(self, *args, **kwargs) -> InterventionProxy:
+        """
+        
+        """
+
+        return self.apply(list, *args, **kwargs)
+    
+    def set(self, *args, **kwargs) -> InterventionProxy:
+        """
+        
+        """
+
+        return self.apply(set, *args, **kwargs)
+    
+    def dict(self, *args, **kwargs) -> InterventionProxy:
+        """
+        
+        """
+
+        return self.apply(dict, *args, **kwargs)
+
     def vis(self, **kwargs) -> None:
         """
         Helper method to save a visualization of the current state of the intervention graph.


### PR DESCRIPTION
**New feature!** You can now globally trace some Python builtin classes irrespective of the context you are in.

Here is the list of supported builtins:

- bool
- bytes
- int
- float
- str
- complex
- bytearray
- tuple
- list
- set
- dict

Here is how you can use it:

```python
import nnsight
from nnsight import LanguageModel

model = LanguageModel("openai-community/gpt2", device_map=True)

with model.session() as session:
    nn_list = nnsight.list().save()
    with session.iter([0, 1, 2]) as item:
        nn_list.append(nnsight.int(item))

print("List: ", nn_list)
import nnsight
from nnsight import LanguageModel

model = LanguageModel("openai-community/gpt2, device_map=True)

with model.session() as session:
    nn_list = nnsight.list()
    with session.iter([0, 1, 2]) as item:
        nn_list.append(nnsight.int(item))

print("List: ", nn_list)
```

```python
"List: [0, 1, 2]"
```
