### PR TITLE
Envoy input access syntactic change

### DIFF
--- a/src/nnsight/envoy.py
+++ b/src/nnsight/envoy.py
@@ -481,7 +481,7 @@ class Envoy:
         self._output = None
 
     @property
-    def input(self) -> InterventionProxy:
+    def inputs(self) -> InterventionProxy:
         """
         Calling denotes the user wishes to get the input of the underlying module and therefore we create a Proxy of that request.
         Only generates a proxy the first time it is references otherwise return the already set one.
@@ -519,8 +519,8 @@ class Envoy:
 
         return self._input
 
-    @input.setter
-    def input(self, value: Union[InterventionProxy, Any]) -> None:
+    @inputs.setter
+    def inputs(self, value: Union[InterventionProxy, Any]) -> None:
         """
         Calling denotes the user wishes to set the input of the underlying module and therefore we create a Proxy of that request.
 
@@ -528,6 +528,26 @@ class Envoy:
             value (Union[InterventionProxy, Any]): Value to set input to.
         """
 
-        protocols.SwapProtocol.add(self.input.node, value)
+        protocols.SwapProtocol.add(self.inputs.node, value)
 
         self._input = None
+
+    @property
+    def input(self) -> InterventionProxy:
+        """Getting the first positional argument input of the model's module.
+
+        Returns:
+            InterventionProxy: Input proxy.
+        """
+
+        return self.inputs[0][0]
+    
+    @input.setter
+    def input(self, value: Union[InterventionProxy, Any]) -> None:
+        """Setting the value of the input's first positionl argument in the model's module.
+        
+        Args;
+            value (Union[InterventionProxy, Any]): Value to set the input to.
+        """
+        
+        self.inputs = ((value,) + self.inputs[0][1:],) + (self.inputs[1:])


### PR DESCRIPTION
**NNsight syntactic change!** 

`Envoy.input` now points directly to the first positional argument of a module, i.e. the first tensor input.

```python
from nnsight import LanguageModel

model = LanguageModel("openai-community/gpt2", device_map="auto")

with model.trace("Hello World"):
        hs = model.transformer.h[6].input.save()

print("Tensor: ", hs)
```

```python
"""
Tensor: tensor([[[ 0.9839, -2.3671,  0.9822,  ..., -1.1355, -0.6406, -1.1865],
         [-0.6150, -0.0651,  2.2578,  ..., -0.2923, -1.8130,  2.8994]]],
       device='mps:0', grad_fn=<AddBackward0>)
"""
```

If you still wish to access to full module input, you can use `Envoy.inputs`:

```python
from nnsight import LanguageModel

model = LanguageModel("openai-community/gpt2", device_map="auto")

with model.trace("Hello World"):
        hs = model.transformer.h[6].inputs.save()

print("Input: ", hs)
```

```python
"""
Input: ((tensor([[[ 0.9839, -2.3671,  0.9822,  ..., -1.1355, -0.6406, -1.1865],
         [-0.6150, -0.0651,  2.2578,  ..., -0.2923, -1.8130,  2.8994]]],
       device='mps:0', grad_fn=<AddBackward0>),), {'layer_past': None, 'attention_mask': None, 'head_mask': None, 'encoder_hidden_states': None, 'encoder_attention_mask': None, 'use_cache': True, 'output_attentions': False})
"""
```



