### PR TITLE
Non inplace model editing

### DIFF
--- a/src/nnsight/contexts/Tracer.py
+++ b/src/nnsight/contexts/Tracer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import weakref
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, Tuple
 
 from typing_extensions import Self
 
@@ -38,10 +38,13 @@ class Tracer(GraphBasedContext, RemoteMixin, BridgeMixin, EditMixin):
         validate: bool = False,
         graph: Graph = None,
         bridge: Bridge = None,
+        return_context: bool = False,
         **kwargs,
     ) -> None:
 
         self.model = model
+
+        self.return_context = return_context
 
         GraphBasedContext.__init__(
             self,
@@ -72,7 +75,7 @@ class Tracer(GraphBasedContext, RemoteMixin, BridgeMixin, EditMixin):
         """
         return getattr(self.model._envoy, key)
 
-    def __enter__(self) -> Union[Self, "NNsight"]:
+    def __enter__(self) -> Union[Self, "NNsight", Tuple["NNsight", Self]]:
 
         tracer = super().__enter__()
 
@@ -81,6 +84,9 @@ class Tracer(GraphBasedContext, RemoteMixin, BridgeMixin, EditMixin):
             self.invoker.__enter__()
 
         if isinstance(self.backend, EditBackend):
+            if self.return_context:
+                return self.model, self
+            
             return self.model
 
         return tracer

--- a/src/nnsight/contexts/Tracer.py
+++ b/src/nnsight/contexts/Tracer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import weakref
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from typing_extensions import Self
 
@@ -9,7 +9,7 @@ from ..tracing import protocols
 from ..tracing.Bridge import Bridge
 from ..tracing.Graph import Graph
 from . import resolve_dependencies
-from .backends import Backend, BridgeMixin, EditMixin, RemoteMixin
+from .backends import Backend, EditBackend, BridgeMixin, EditMixin, RemoteMixin
 from .GraphBasedContext import GraphBasedContext
 from .Invoker import Invoker
 
@@ -72,13 +72,16 @@ class Tracer(GraphBasedContext, RemoteMixin, BridgeMixin, EditMixin):
         """
         return getattr(self.model._envoy, key)
 
-    def __enter__(self) -> Self:
+    def __enter__(self) -> Union[Self, "NNsight"]:
 
         tracer = super().__enter__()
 
         if self.invoker is not None:
 
             self.invoker.__enter__()
+
+        if isinstance(self.backend, EditBackend):
+            return self.model
 
         return tracer
 

--- a/src/nnsight/contexts/Tracer.py
+++ b/src/nnsight/contexts/Tracer.py
@@ -93,8 +93,6 @@ class Tracer(GraphBasedContext, RemoteMixin, BridgeMixin, EditMixin):
 
         self.model._envoy._reset()
 
-        if len(self._invoker_inputs) == 0:
-            raise ValueError("No input was provided to the tracing context.")
 
         super().__exit__(exc_type, exc_val, exc_tb)
 

--- a/src/nnsight/models/NNsightModel.py
+++ b/src/nnsight/models/NNsightModel.py
@@ -496,6 +496,10 @@ class NNsight:
         self._model = self._model.to(*args, **kwargs)
 
         return self
+    
+    def clear_edits(self) -> None:
+        """Resets the default graph of this model."""
+        self._default_graph = None
 
     def __repr__(self) -> str:
         """Wrapper of ._model's representation as the NNsight model's representation.

--- a/src/nnsight/models/NNsightModel.py
+++ b/src/nnsight/models/NNsightModel.py
@@ -299,6 +299,8 @@ class NNsight:
     def edit(
         self,
         *inputs: Any,
+        inplace: bool = False,
+        return_context: bool = False,
         **kwargs: Dict[str, Any],
     ) -> Union[Tracer, Any]:
         """Create a trace context with an edit backend and apply a list of edits.
@@ -310,6 +312,8 @@ class NNsight:
 
         Args:
             inputs (tuple[Any])
+            inplace (bool): If True, makes edits in-place.
+            return_context (bool): If True, returns the editor Tracer context.
             kwargs (Dict[str, Any]): Keyword arguments passed to Tracer initialization, and then downstream to the model's ._execute(...) method.
 
         Returns:
@@ -349,12 +353,14 @@ class NNsight:
             print(original_output)
             print(edited_output)
         """
+        model_to_edit = self
+        if not inplace:
+            model_to_edit = self._shallow_copy()
 
-        model_copy = self._shallow_copy()
-
-        return model_copy.trace(
+        return model_to_edit.trace(
             *inputs,
             validate=kwargs.pop("validate", False),
+            return_context=return_context,
             **kwargs,
             backend=EditBackend(),
         )

--- a/src/nnsight/models/NNsightModel.py
+++ b/src/nnsight/models/NNsightModel.py
@@ -431,6 +431,7 @@ class NNsight:
         batch_groups = []
         batch_start = 0
         batched_input = None
+        batch_size = 0
 
         for _inputs in inputs:
 
@@ -441,7 +442,8 @@ class NNsight:
 
             batched_input = self._batch_inputs(batched_input, *_inputs)
 
-        inputs, batch_size = self._prepare_inputs(*batched_input)
+        if len(inputs) > 0:
+            inputs, batch_size = self._prepare_inputs(*batched_input)
 
         intervention_handler = InterventionHandler(
             intervention_graph, batch_groups, batch_size

--- a/src/nnsight/models/mixins/Generation.py
+++ b/src/nnsight/models/mixins/Generation.py
@@ -10,14 +10,14 @@ class GenerationMixin(NNsight):
         return self.trace(*args, generate=True, **kwargs)
 
     def _execute(
-        self, prepared_inputs: Any, *args, generate: bool = False, **kwargs
+        self, *args, generate: bool = False, **kwargs
     ) -> Any:
 
         if generate:
 
-            return self._execute_generate(prepared_inputs, *args, **kwargs)
+            return self._execute_generate(*args, **kwargs)
 
-        return self._execute_forward(prepared_inputs, *args, **kwargs)
+        return self._execute_forward(*args, **kwargs)
 
     def _scan(
         self, prepared_inputs: Any, *args, generate: bool = False, **kwargs

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -285,17 +285,17 @@ def test_editing(gpt2: nnsight.LanguageModel, MSG_prompt: str):
     l0 = gpt2.transformer.h[0]
     l0.attachment = ComplexModule()
 
+    with gpt2.edit("test") as gpt2_edited:
+        acts = l0.output[0]
+        l0.output[0][:] = l0.attachment(acts, hook=True)
+
     # Get values pre editing
     with gpt2.trace(MSG_prompt):
         original = l0.output[0].clone().save()
         l0.output[0][:] *= 0.0
         original_output = gpt2.output.logits.save()
 
-    with gpt2.edit("test"):
-        acts = l0.output[0]
-        l0.output[0][:] = l0.attachment(acts, hook=True)
-
-    with gpt2.trace(MSG_prompt):
+    with gpt2_edited.trace(MSG_prompt):
         one = l0.attachment.one.output.clone().save()
         l0.attachment.output *= 0.0
         edited_output = gpt2.output.logits.save()
@@ -305,6 +305,21 @@ def test_editing(gpt2: nnsight.LanguageModel, MSG_prompt: str):
     assert torch.equal(original, one)
     # Check that edits propagate from attached module
     assert torch.equal(original_output, edited_output)
+
+
+def test_non_inplace_editing(gpt2: nnsight.LanguageModel, MSG_prompt: str):
+
+    with gpt2.edit("") as gpt2_edited:
+        gpt2.transformer.h[1].output[0][:] = 0
+
+    with gpt2.trace(MSG_prompt):
+        l1_out = gpt2.transformer.h[1].output[0].save()
+
+    with gpt2_edited.trace(MSG_prompt):
+        l1_out_edited = gpt2_edited.transformer.h[1].output[0].save()
+
+    assert torch.all(l1_out != 0)
+    assert torch.all(l1_out_edited == 0)
 
 
 def test_batched_editing(gpt2: nnsight.LanguageModel):
@@ -324,11 +339,11 @@ def test_batched_editing(gpt2: nnsight.LanguageModel):
     batch = ["a", "b"]
     single = "a"
 
-    with gpt2.edit(single):
+    with gpt2.edit(single) as gpt2_edited:
         acts = l0.output[0]
         l0.output[0][:] = l0.attachment(acts, hook=True)
 
-    with gpt2.trace(batch):
+    with gpt2_edited.trace(batch):
         edited = l0.attachment.output.save()
 
     # Check that the batch size does not narrow

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -322,6 +322,22 @@ def test_non_inplace_editing(gpt2: nnsight.LanguageModel, MSG_prompt: str):
     assert torch.all(l1_out_edited == 0)
 
 
+def test_clear_edits(gpt2: nnsight.LanguageModel, MSG_prompt: str):
+    with gpt2.edit("") as gpt2:
+        gpt2.transformer.h[1].output[0][:] = 0
+
+    with gpt2.trace(MSG_prompt):
+        l1_out = gpt2.transformer.h[1].output[0].save()
+
+    gpt2.clear_edits()
+
+    with gpt2.trace(MSG_prompt):
+        l1_out_unedited = gpt2.transformer.h[1].output[0].save()
+
+    assert torch.all(l1_out == 0)
+    assert torch.all(l1_out_unedited != 0)
+
+
 def test_batched_editing(gpt2: nnsight.LanguageModel):
     from nnsight.util import WrapperModule
 


### PR DESCRIPTION
**Improvement!** Edits defined within an edit context don't affect the base model by default. This means that the edits are not in-place.

```python
from nnsight import LanguageModel

gpt2 = LanguageModel("openai-community/gpt2", device_map="auto")

with gpt2.edit("") as gpt2_edited:
        gpt2.transformer.h[1].output[0][:] = 0

with gpt2.trace("Hello World"):
    l1_out = gpt2.transformer.h[1].output[0].save()

with gpt2_edited.trace("Hello World"):
    l1_out_edited = gpt2_edited.transformer.h[1].output[0].save()

print("L1 - Out: ", l1_out)
print("L1 - Out (edited): ", l1_out_edited)
```

```python
"""
L1 - Out: tensor([[[ 1.0967, -1.8792,  1.0121,  ..., -1.0442, -0.5490, -1.1239],
         [-0.2300,  0.5204,  0.4756,  ..., -1.6795, -0.5285,  0.4190]]],
       device='mps:0', grad_fn=<AddBackward0>)

L1 - Out (edited): tensor([[[0., 0., 0.,  ..., 0., 0., 0.],
         [0., 0., 0.,  ..., 0., 0., 0.]]], device='mps:0',
       grad_fn=<CopySlices>)
"""
```

If you wish to make in-place edits, simply set `inplace=True`:

```python
with model.edit(inplace=True):
    pass
```

**New Feature!** If you wish to access the `Tracer` context responsible for the edits, simply set `return_context=True`:

```python
with model.edit(return_context=True) as (edited_model, editor):
    pass
```

Note that the `return_context` flag is only relevant when creating an <ins>edit</ins> context.

**New feature!** You can now <ins>clear edits</ins> from a model. Particularly useful if you run in-place edits on a model.

```python
from nnsight import LanguageModel

gpt2 = LanguageModel("openai-community/gpt2", device_map="auto")

with gpt2.edit() as gpt2:
    gpt2.transformer.h[1].output[0][:] = 0

gpt2.clear_edits()

with gpt2.trace("Hello World"):
    l1_out_unedited = gpt2.transformer.h[1].output[0].save()

print("L1 - Out (unedited): ", l1_out_unedited)
```

```python
"""
L1 - Out (unedited): tensor([[[ 1.0967, -1.8792,  1.0121,  ..., -1.0442, -0.5490, -1.1239],
         [-0.2300,  0.5204,  0.4756,  ..., -1.6795, -0.5285,  0.4190]]],
       device='mps:0', grad_fn=<AddBackward0>)
"""
```