### PR TITLE
tracer has a logged_request arg, remote backend no execute

### DIFF
--- a/src/nnsight/contexts/Tracer.py
+++ b/src/nnsight/contexts/Tracer.py
@@ -66,6 +66,8 @@ class Tracer(GraphBasedContext, RemoteMixin, BridgeMixin, EditMixin):
         # Module Envoys need to know about the current Tracer to create the correct proxies.
         self.model._envoy._set_tracer(weakref.proxy(self))
 
+        self.logged_request = None
+
     def __getattr__(self, key: Any) -> Any:
         """Wrapper of .model._envoy's attributes to access module Envoy inputs and outputs.
 
@@ -176,9 +178,7 @@ class Tracer(GraphBasedContext, RemoteMixin, BridgeMixin, EditMixin):
 
     def remote_backend_handle_result_value(self, value: Dict[str, Any]) -> None:
 
-        # TODO : graph mismatch handle. hash json ?
-        for node_name, node_value in value.items():
-            self.graph.nodes[node_name]._value = node_value
+        self.logged_request = value
 
     def remote_backend_cleanup(self):
         

--- a/src/nnsight/contexts/backends/RemoteBackend.py
+++ b/src/nnsight/contexts/backends/RemoteBackend.py
@@ -247,33 +247,7 @@ class RemoteBackend(LocalBackend):
             request (RequestModel): Request.
         """
 
-        from ...schema.Response import ResponseModel
-
-        # Create a socketio connection to the server.
-        with socketio.SimpleClient(
-            logger=logger, reconnection_attempts=10
-        ) as sio:
-            # Connect
-            sio.connect(
-                self.ws_address,
-                socketio_path="/ws/socket.io",
-                transports=["websocket"],
-                wait_timeout=10,
-            )
-
-            # Give request session ID so server knows to respond via websockets to us.
-            request.session_id = sio.sid
-
-            # Submit request via
-            self.submit_request(request)
-
-            # Loop until
-            while True:
-                if (
-                    self.handle_response(sio.receive()[1]).status
-                    == ResponseModel.JobStatus.COMPLETED
-                ):
-                    break
+        self.handle_result(request)
 
     def non_blocking_request(self, request: "RequestModel" = None):
         """Send intervention request to the remote service if request provided. Otherwise get job status.


### PR DESCRIPTION
```python
# %%

from nnsight import LanguageModel

model = LanguageModel("gpt2")

with model.trace("hello", remote=True) as tracer:

    # Do some stuff...

    for layer in model.transformer.h:
        layer.output *= 1

    model.output.save()

# %%

print(type(tracer.logged_request))
print(tracer.logged_request)
```