### PR TITLE
NNsight <> vLLM

### DIFF
--- a/src/nnsight/models/NNsightModel.py
+++ b/src/nnsight/models/NNsightModel.py
@@ -105,9 +105,7 @@ class NNsight:
             self._custom_model = True
             self._dispatched = True
             self._model = model_key
-
-        # Otherwise load from _load(...).
-        if not self._custom_model:
+        else: # Otherwise load from _load(...).
             # Load skeleton of model by putting all tensors on meta.
             with init_empty_weights(include_buffers=meta_buffers):
                 self._model = self._load(self._model_key, *args, **kwargs)

--- a/src/nnsight/models/VLLM.py
+++ b/src/nnsight/models/VLLM.py
@@ -1,10 +1,16 @@
-from typing import Any, List, Tuple, Union, Optional
+from typing import List, Optional, Tuple, Union
 
 from ..util import WrapperModule
 from .mixins import GenerationMixin
 
 try:
     from vllm import LLM, RequestOutput
+    from vllm.distributed import (destroy_distributed_environment,
+                                  destroy_model_parallel,
+                                  init_distributed_environment,
+                                  initialize_model_parallel)
+    from vllm.engine.arg_utils import EngineArgs
+    from vllm.model_executor.model_loader.loader import _initialize_model
 except Exception as e:
 
     raise type(e)(
@@ -39,33 +45,84 @@ class VLLM(GenerationMixin):
         ''' Pytorch Wrapper for the vLLM engine to work seamlessly with NNsight.
 
         Attributes:
-            llm (vllm.LLM): vLLM inference engine instance.
             model (torch.nn.Module): Underlying model of the vLLM instance.
+            llm_engine (vllm.LLM): vLLM inference engine instance.
         '''
         
-        def __init__(self, *args, **kwargs) -> None:
+        def __init__(self, model, llm_engine = None) -> None:
 
             super().__init__()
 
-            self.llm = LLM(*args, dtype="half", **kwargs)
+            self.model = model
 
-            self.model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
+            self.llm_engine = llm_engine
 
     def __init__(self, model_key: str, *args, **kwargs) -> None:
-
-        model_key = self._load(model_key, **kwargs)
 
         super().__init__(model_key, *args, **kwargs)
 
     def _load(self, repo_id: str, **kwargs) -> VLLModel:
 
-        model = VLLM.VLLModel(model=repo_id, **kwargs)
+        if self._model is None:
 
-        return model
+            # no parallelism during initialization
+            kwargs["tensor_parallel_size"] = 1
+            kwargs["pipeline_parallel_size"] = 1
+
+            # creating vLLM Engine args
+            engine_args = EngineArgs(
+                model=repo_id,
+                **kwargs,
+            )
+
+            # creating the vllm engine configuration
+            engine_config_dict = engine_args.create_engine_config().to_dict()
+
+            # starting the distributed environment
+            init_distributed_environment(
+                engine_config_dict["parallel_config"].world_size, 
+                0,
+                'tcp://127.0.0.1:47303', 
+                0, 
+                backend="nccl"
+            )
+
+            # start tensor parallel group
+            initialize_model_parallel(
+                engine_config_dict["parallel_config"].tensor_parallel_size,
+                engine_config_dict["parallel_config"].pipeline_parallel_size, 
+                'nccl'
+            )
+            
+            # initialize the model
+            model = _initialize_model(
+                        model_config=engine_config_dict["model_config"], 
+                        load_config=engine_config_dict["load_config"],
+                        lora_config=None,
+                        cache_config=engine_config_dict["cache_config"],
+                        scheduler_config=engine_config_dict["scheduler_config"]
+            ) 
+
+            return VLLM.VLLModel(model)
+        else:
+
+            # destroy the distributed environment created from the initial model initialization
+            destroy_model_parallel()
+            destroy_distributed_environment()
+
+            if "tensor_parallel_size" in kwargs.keys():
+                if kwargs["tensor_parallel_size"] > 1:
+                    raise Exception("Tensor Parallelism currently not supported with nnsight.VLLM")
+
+            llm = LLM(repo_id, **kwargs)
+
+            model = llm.llm_engine.model_executor.driver_worker.model_runner.model
+
+            return VLLM.VLLModel(model, llm)
 
     def _execute(self, prepared_inputs: Union[List[str], str], *args, generate=True, **kwargs) -> List[RequestOutput]:
 
-        output = self._model.llm.generate(prepared_inputs, *args, use_tqdm=False, **kwargs)
+        output = self._model.llm_engine.generate(prepared_inputs, *args, use_tqdm=False, **kwargs)
 
         output = self._model(output)
 
@@ -82,7 +139,6 @@ class VLLM(GenerationMixin):
         batched_inputs: Optional[Tuple[List[str]]],
         prepared_inputs: List[str],
     ) -> Tuple[List[str]]:
-        breakpoint()
         if batched_inputs is None:
 
             return (prepared_inputs, )

--- a/src/nnsight/models/VLLM.py
+++ b/src/nnsight/models/VLLM.py
@@ -1,0 +1,90 @@
+from typing import Any, List, Tuple, Union, Optional
+
+from ..util import WrapperModule
+from .mixins import GenerationMixin
+
+try:
+    from vllm import LLM, RequestOutput
+except Exception as e:
+
+    raise type(e)(
+        "Install vllm in your environment to use it with NNsight. " + \
+        "https://docs.vllm.ai/en/latest/getting_started/installation.html"
+    ) from e
+
+class VLLM(GenerationMixin):
+    ''' NNsight wrapper to conduct interventions on a vLLM inference engine.
+
+    .. code-block:: python
+        from nnsight.models.VLLM import VLLM
+        from vllm import SamplingParams
+
+        model = VLLM("gpt2")
+
+        prompt = ["The Eiffel Tower is in the city of"]
+        sampling_params = SamplingParams(temperature=0.0, top_p=0.95, stop=["."])
+
+        with model.trace(prompt, sampling_params=sampling_params) as tracer:
+            model.model.transformer.h[8].output[-1][:] = 0
+
+            outputs = model.output.save()
+
+        for output in outputs.value:
+            prompt = output.prompt
+            generated_text = output.outputs[0].text
+            print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
+    '''
+
+    class VLLModel(WrapperModule):
+        ''' Pytorch Wrapper for the vLLM engine to work seamlessly with NNsight.
+
+        Attributes:
+            llm (vllm.LLM): vLLM inference engine instance.
+            model (torch.nn.Module): Underlying model of the vLLM instance.
+        '''
+        
+        def __init__(self, *args, **kwargs) -> None:
+
+            super().__init__()
+
+            self.llm = LLM(*args, dtype="half", **kwargs)
+
+            self.model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
+
+    def __init__(self, model_key: str, *args, **kwargs) -> None:
+
+        model_key = self._load(model_key, **kwargs)
+
+        super().__init__(model_key, *args, **kwargs)
+
+    def _load(self, repo_id: str, **kwargs) -> VLLModel:
+
+        model = VLLM.VLLModel(model=repo_id, **kwargs)
+
+        return model
+
+    def _execute(self, prepared_inputs: Union[List[str], str], *args, generate=True, **kwargs) -> List[RequestOutput]:
+
+        output = self._model.llm.generate(prepared_inputs, *args, use_tqdm=False, **kwargs)
+
+        output = self._model(output)
+
+        return output
+    
+    def _prepare_inputs(self, *inputs: Union[List[str], str]) -> Tuple[Tuple[List[str]], int]:
+        if isinstance(inputs[0], list):
+            return inputs, len(inputs[0])
+        else:
+            return ([inputs[0]],), 1
+    
+    def _batch_inputs(
+        self, 
+        batched_inputs: Optional[Tuple[List[str]]],
+        prepared_inputs: List[str],
+    ) -> Tuple[List[str]]:
+        breakpoint()
+        if batched_inputs is None:
+
+            return (prepared_inputs, )
+
+        return (batched_inputs[0] + prepared_inputs, )


### PR DESCRIPTION
`NNsight` wrapper to conduct interventions on the vLLM inference engine.

Example 1 - vLLM inference generation:

```python
from nnsight.models.VLLM import VLLM
from vllm import SamplingParams

model = VLLM("gpt2")

prompts = [
    "Hello, my name is",
    "The president of the United States is",
    "The capital of France is",
    "The future of AI is",
]

sampling_params = SamplingParams(temperature=0.8, top_p=0.95)

outputs = model.generate(prompts, sampling_params=sampling_params, trace=False)

for output in outputs.value:
    prompt = output.prompt
    generated_text = output.outputs[0].text
    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
```

Example 2 - intervention on vLLM inference model:

```python
from nnsight.models.VLLM import VLLM
from vllm import SamplingParams

model = VLLM("gpt2")

prompt = ["The Eiffel Tower is in the city of"]
sampling_params = SamplingParams(temperature=0.0, top_p=0.95, stop=["."])

with model.trace(prompt, sampling_params=sampling_params) as tracer:
      model.model.transformer.h[8].output[-1][:] = 0

      outputs = model.output.save()

for output in outputs.value:
    prompt = output.prompt
    generated_text = output.outputs[0].text
    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
```

```
>>> Prompt: 'The Eiffel Tower is in the city of', Generated text: ' and near the city of London'
```

Example 3 - initialization loads the model on the `meta` device:

**Tensor parallelism is currently not supported with this model type.**

```python 
from nnsight.models.VLLM import VLLM

vllm_model = VLLM("meta-llama/Meta-Llama-3.1-405B")
print(vllm_model)
```
```
>>> VLLModel(
  (model): LlamaForCausalLM(
    (model): LlamaModel(
      (embed_tokens): VocabParallelEmbedding(num_embeddings=128256, embedding_dim=16384, org_vocab_size=128256, num_embeddings_padded=128256, tp_size=1)
      (layers): ModuleList(
        (0-125): 126 x LlamaDecoderLayer(
          (self_attn): LlamaAttention(
            (qkv_proj): QKVParallelLinear(in_features=16384, output_features=18432, bias=False, tp_size=1, gather_output=False)
            (o_proj): RowParallelLinear(input_features=16384, output_features=16384, bias=False, tp_size=1, reduce_results=True)
            (rotary_emb): Llama3RotaryEmbedding(head_size=128, rotary_dim=128, max_position_embeddings=131072, base=500000.0, is_neox_style=True)
            (attn): Attention(head_size=128, num_heads=128, num_kv_heads=8, scale=0.08838834764831845, backend=XFormersImpl)
          )
          (mlp): LlamaMLP(
            (gate_up_proj): MergedColumnParallelLinear(in_features=16384, output_features=106496, bias=False, tp_size=1, gather_output=False)
            (down_proj): RowParallelLinear(input_features=53248, output_features=16384, bias=False, tp_size=1, reduce_results=True)
            (act_fn): SiluAndMul()
          )
          (input_layernorm): RMSNorm(hidden_size=16384, eps=1e-05)
          (post_attention_layernorm): RMSNorm(hidden_size=16384, eps=1e-05)
        )
      )
      (norm): RMSNorm(hidden_size=16384, eps=1e-05)
    )
    (lm_head): ParallelLMHead(num_embeddings=128256, embedding_dim=16384, org_vocab_size=128256, num_embeddings_padded=128256, tp_size=1)
    (logits_processor): LogitsProcessor(vocab_size=128256, forg_vocab_size=128256, scale=1.0, logits_as_input=False)
    (sampler): Sampler()
  )
)
```

Additional work must be introduced to provide full support for vLLM with `NNsight`:
- https://github.com/orgs/ndif-team/projects/3/views/7?pane=issue&itemId=80779861
- https://github.com/orgs/ndif-team/projects/3/views/7?pane=issue&itemId=80780266

