### PR TITLE
nnsight.__version__

### DIFF
--- a/src/nnsight/__init__.py
+++ b/src/nnsight/__init__.py
@@ -13,6 +13,13 @@ import os
 from functools import wraps
 from typing import Dict, Union
 
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("nnsight")
+except PackageNotFoundError:
+    __version__ = "unknown version"
+
 import torch
 import yaml
 


### PR DESCRIPTION
**New feature!** You can now know the version of your `nnsight` installation directly from your `Python` code.

Here is how to use it:

```python
import nnsight

print(nnsight.__version__)

>>> 0.3.4
```

## Resources:

- https://www.moritzkoerber.com/posts/versioning-with-setuptools_scm/