### PR TITLE
Update the model name in the about page

### DIFF
--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -53,7 +53,7 @@ Here is how it looks:
     :linenos:
 
     from nnsight import LanguageModel
-    model = LanguageModel('meta-llama/Llama-2-70b-hf')
+    model = LanguageModel('meta-llama/Meta-Llama-3.1-70B')
     with model.trace('The Eiffel Tower is in the city of ', remote=True):
         hidden_state = model.layers[10].input[0].save()  # save one hidden state
         model.layers[11].mlp.output = 0  # change one MLP module output


### PR DESCRIPTION
The model name for llama is `meta-llama/Meta-Llama-3.1-70B`, corrected it in the /about page.  Previously, it would report model not found.