### PR TITLE
Display error message from backend

### DIFF
--- a/src/nnsight/contexts/backends/RemoteBackend.py
+++ b/src/nnsight/contexts/backends/RemoteBackend.py
@@ -215,7 +215,8 @@ class RemoteBackend(LocalBackend):
 
         else:
 
-            raise Exception(response.reason)
+            msg = response.json()['detail']
+            raise ConnectionError(msg)
 
     def get_response(self) -> "ResponseModel":
         """Retrieves and handles the response object from the remote endpoint.


### PR DESCRIPTION
This updates RemoteBackend to display the error message raised in the backend when an API key is rejected.

Related PR: https://github.com/ndif-team/ndif/pull/59