### PR TITLE
Add a rename_modules_dict arg to Envoy that allows renaming modules

### DIFF
--- a/src/nnsight/envoy.py
+++ b/src/nnsight/envoy.py
@@ -26,9 +26,15 @@ class Envoy:
         _tracer (nnsight.context.Tracer.Tracer): Object which adds this Envoy's module's output and input proxies to an intervention graph. Must be set on Envoys objects manually by the Tracer.
     """
 
-    def __init__(self, module: torch.nn.Module, module_path: str = ""):
+    def __init__(
+        self,
+        module: torch.nn.Module,
+        module_path: str = "",
+        rename_modules_dict: Dict[str, str] | None = None,
+    ):
 
         self.path = module_path
+        self.rename_modules_dict = rename_modules_dict
 
         self._fake_outputs: List[torch.Tensor] = []
         self._fake_inputs: List[torch.Tensor] = []
@@ -77,9 +83,12 @@ class Envoy:
             name (str): name of envoy/attribute.
         """
 
-        envoy = Envoy(module, module_path=f"{self.path}.{name}")
+        envoy = Envoy(module, module_path=f"{self.path}.{name}", rename_modules_dict=self.rename_modules_dict)
 
         self._sub_envoys.append(envoy)
+
+        if self.rename_modules_dict is not None and name in self.rename_modules_dict:
+            name = self.rename_modules_dict[name]
 
         # If the module already has a sub-module named 'input' or 'output',
         # mount the proxy access to 'nns_input' or 'nns_output instead.

--- a/src/nnsight/models/NNsightModel.py
+++ b/src/nnsight/models/NNsightModel.py
@@ -81,6 +81,7 @@ class NNsight:
         *args,
         dispatch: bool = False,
         meta_buffers: bool = True,
+        rename_modules_dict: Dict[str, str] | None = None,
         **kwargs,
     ) -> None:
 
@@ -112,7 +113,7 @@ class NNsight:
             with init_empty_weights(include_buffers=meta_buffers):
                 self._model = self._load(self._model_key, *args, **kwargs)
 
-        self._envoy = Envoy(self._model)
+        self._envoy = Envoy(self._model, rename_modules_dict=rename_modules_dict)
 
         if dispatch and not self._dispatched:
             # Dispatch ._model on initialization vs lazy dispatching.


### PR DESCRIPTION
After discussing with @cadentj some alternatives to transformer_lens (which sometimes has a significant implementation gap with HuggingFace), he suggested adding a renaming feature to nnsight itself, as it might be useful not only for transformers.

The basic usage would be to convert module names from, e.g., GPT-2 to the standard LLaMA / Gemma format using:

The basic usage would be to convert module names from e.g. gpt2 to the standard llama / gemma format using 
```py
dict_change = {
    "transformer": "model",
    "self_attention": "self_attn",
    "attn": "self_attn",
    "h": "layers",
}
patched_model = LanguageModel("gpt2", rename_modules_dict=dict_change)
with patched_model.trace("hello"):
    out = patched_model.model.layers[0].output[0].save()
```