### PR TITLE
Add <3.10 compatibility to remote execution

### DIFF
--- a/src/nnsight/schema/Request.py
+++ b/src/nnsight/schema/Request.py
@@ -21,7 +21,7 @@ class RequestModel(BaseModel):
         arbitrary_types_allowed=True, protected_namespaces=()
     )
 
-    object: str | OBJECT_TYPES
+    object: Union[str, OBJECT_TYPES]
     model_key: str
 
     id: str = None

--- a/src/nnsight/schema/format/types.py
+++ b/src/nnsight/schema/format/types.py
@@ -77,8 +77,8 @@ class NodeModel(BaseNNsightModel):
     target: Union[FunctionModel, FunctionType]
     args: List[ValueTypes] = []
     kwargs: Dict[str, ValueTypes] = {}
-    condition: None | Union[
-        NodeReferenceType, NodeModel.Reference
+    condition: Union[
+        NodeReferenceType, NodeModel.Reference, None
     ] = None
     
     @model_serializer(mode='wrap')


### PR DESCRIPTION
Fixes https://github.com/ndif-team/nnsight/issues/258 by using `Union` instead of `|`