### PR TITLE
Fix padding token patching

### DIFF
--- a/src/nnsight/models/LanguageModel.py
+++ b/src/nnsight/models/LanguageModel.py
@@ -182,7 +182,7 @@ class LanguageModel(GenerationMixin, RemoteableMixin, NNsight):
                 repo_id, config=config, **tokenizer_kwargs
             )
 
-            if not hasattr(self.tokenizer.pad_token, "pad_token"):
+            if self.tokenizer.pad_token is None:
                 self.tokenizer.pad_token = self.tokenizer.eos_token
                 
         if self._model is None:


### PR DESCRIPTION
Currently, the condition to check if a model's tokenizer has a padding token is wrong and always evaluates to `True`, meaning all models get patched whether they require it or not.
```python
from nnsight import LanguageModel

model = LanguageModel('google/gemma-2-2b')
print(model.tokenizer.pad_token)
# <eos>
```
Normally, `hasattr()` should be used on an object to check whether it has a given attribute or not, while here it was used on the attribute directly (`hasattr(my_object, "my_attribute")` vs `hasattr(my_object.my_attribute, "my_attribute")`). But it shouldn't be used at all here because even models without a padding token have a `pad_token` attribute, it's just set to `None` which is what's tested for in this PR.

Maybe related to #177 but couldn't reproduce the error there.