### PR TITLE
Fix batch tokenization for multiple invoke

### DIFF
--- a/src/nnsight/modeling/language.py
+++ b/src/nnsight/modeling/language.py
@@ -276,7 +276,7 @@ class LanguageModel(RemoteableMixin):
 
             batched_labels = torch.cat((batched_labels, labels))
 
-        batched_inputs["attention_mask"][:1, : attention_mask.shape[1]] = attention_mask
+        batched_inputs["attention_mask"][:-1, : attention_mask.shape[1]] = attention_mask
 
         return ((batched_inputs,), {"labels": batched_labels})
 


### PR DESCRIPTION
Tweaked the indexing on `_batch` method in `LanguageModel`. 

In this line

```python
batched_inputs["attention_mask"][:1, : attention_mask.shape[1]] = attention_mask
```

The first `[:1]` batch index of the re-tokenized batch is set to the running batch's attention mask. This breaks for more than two invokes because `attention_mask` is shape `[n - 1, seq]` which is longer than the single index replacement. 

Fixed to use negative indexing

```python
batched_inputs["attention_mask"][:-1, : attention_mask.shape[1]] = attention_mask
```