### PR TITLE
fixed super() call in `BridgeException`

### DIFF
--- a/src/nnsight/tracing/protocols.py
+++ b/src/nnsight/tracing/protocols.py
@@ -442,7 +442,7 @@ class BridgeProtocol(Protocol):
 
     class BridgeException(Exception):
         def __init__(self):
-            super.__init__(
+            super().__init__(
                 "Must define a Session context to make use of the Bridge"
             )
 


### PR DESCRIPTION
`super` isn't actually called in `BridgeException`, the proposed change is a minor syntax correction to fix that.