### PR TITLE
Parameter Protocol

### DIFF
--- a/src/nnsight/intervention/base.py
+++ b/src/nnsight/intervention/base.py
@@ -336,6 +336,8 @@ class NNsight:
         elif isinstance(fn, str):
             fn = getattr(self, fn)
 
+        interleaver.graph.execute()
+
         with interleaver:
             return fn(*args, **kwargs)
 

--- a/src/nnsight/intervention/contexts/interleaving.py
+++ b/src/nnsight/intervention/contexts/interleaving.py
@@ -153,9 +153,7 @@ class InterleavingTracer(InterventionTracer):
         graph.compile()
 
         graph.reset()
-
-        graph.execute()
-                
+        
         interleaver = Interleaver(graph, batch_groups=batch_groups)
         
         graph.model.interleave(interleaver, *invoker_args, fn=method,**kwargs, **invoker_kwargs)

--- a/src/nnsight/intervention/envoy.py
+++ b/src/nnsight/intervention/envoy.py
@@ -631,17 +631,27 @@ class Envoy(Generic[InterventionProxyType, InterventionNodeType]):
 
         return len(self._module)
 
-    def __getattr__(self, key: str) -> Envoy[InterventionProxyType, InterventionNodeType]:
-        """Wrapper method for underlying module's attributes.
+    def __getattr__(self, key: str) -> Union[InterventionProxyType, Any]:
+        """Wrapper method for underlying module's attributes. 
+        If the attribute is a tensor (e.g. weights or bias) and accessed during tracing, then an InterventionProxy is created.
 
         Args:
             key (str): Key.
 
         Returns:
-            Any: Attribute.
+            Union[InterventionProxyType, Any]: Attribute.
         """
 
-        return getattr(self._module, key)
+        attr = getattr(self._module, key)
+ 
+        if self._tracing() and isinstance(attr, torch.Tensor):
+            # print("Hi ", key)
+            # print(self._tracer)
+            attr_proxy = protocols.ParameterProtocol.add(self._tracer.graph, self._path, key)
+
+            return attr_proxy
+
+        return attr
 
     def __setattr__(self, key: Any, value: Any) -> None:
         """Overload setattr to create and set an Envoy when trying to set a torch Module."""

--- a/src/nnsight/intervention/envoy.py
+++ b/src/nnsight/intervention/envoy.py
@@ -645,8 +645,6 @@ class Envoy(Generic[InterventionProxyType, InterventionNodeType]):
         attr = getattr(self._module, key)
  
         if self._tracing() and isinstance(attr, torch.Tensor):
-            # print("Hi ", key)
-            # print(self._tracer)
             attr_proxy = protocols.ParameterProtocol.add(self._tracer.graph, self._path, key)
 
             return attr_proxy

--- a/src/nnsight/intervention/protocols/__init__.py
+++ b/src/nnsight/intervention/protocols/__init__.py
@@ -3,4 +3,5 @@ from .module import ApplyModuleProtocol
 from .intervention import InterventionProtocol
 from .swap import SwapProtocol
 from .noop import NoopProtocol
+from .parameter import ParameterProtocol
 from .entrypoint import EntryPoint

--- a/src/nnsight/intervention/protocols/parameter.py
+++ b/src/nnsight/intervention/protocols/parameter.py
@@ -1,0 +1,40 @@
+from typing import Dict, Any
+
+import torch
+
+from ... import util
+from ...tracing.protocols import Protocol
+
+class ParameterProtocol(Protocol):
+    """ Protocol designed for safe access of model tensor parameter attributes (e.g. weights and biases).
+
+    When a model attribute that's a tensor is accessed, the attribute value is clone before being returned.
+    """
+
+    @classmethod
+    def execute(cls, node):
+
+        module: torch.nn.Module = util.fetch_attr(
+            node.graph.model._model, node.args[0]
+        )
+
+        attr = getattr(module, node.args[1]).clone()
+
+        node.set_value(attr)
+
+    @classmethod
+    def style(cls) -> Dict[str, Any]:
+        """Visualization style for this protocol node.
+
+        Returns:
+            - Dict: dictionary style.
+        """
+
+        default_style = super().style()
+
+        default_style["node"] = {"color": "green4", "shape": "box"}
+
+        default_style["arg_kname"][0] = "module_path"
+        default_style["arg_kname"][1] = "key"
+
+        return default_style


### PR DESCRIPTION
**New feature!** Accessing module parameters is now possible during tracing. 
 
Using the `ParameterProtocol`, the original parameter tensor is always cloned before being returned for the rest of the intervention graph execution, ensuring that no permanent modification to the model parameters is made .

Example:
```py
from nnsight import LanguageModel
import torch

gpt2 = LanguageModel("openai-community/gpt2")

with gpt2.trace("Hello World") as tracer:
    weights = gpt2.transformer.h[0].mlp.c_proj.weight
    weights[2000:, :100] = 0
    bias = gpt2.transformer.h[0].mlp.c_proj.bias

    c_proj_in = gpt2.transformer.h[0].mlp.c_proj.input

    c_proj_out = torch.addmm(bias, c_proj_in.view(-1, c_proj_in.size(-1)), weights).save()

    gpt2.transformer.h[0].mlp.c_proj.output = c_proj_out
```