### PR TITLE
ndif-status

### DIFF
--- a/src/nnsight/__init__.py
+++ b/src/nnsight/__init__.py
@@ -60,6 +60,8 @@ def ndif_status():
                     print("⚠️ NDIF is up, but no models are deployed!")
                 else:
                     print("✅ NDIF is up!\n\n" + "\n".join(f"- `{model}`" for model in data))
+
+                return data
             else:
                 print("Response Status: ", response.status_code)
                 raise Exception("🚫 NDIF is down!")


### PR DESCRIPTION
Users can now get the status of model deployments on NDIF from the nnsight api.

```py
import nnsight
nnsight.ndif_status()
```

```
✅ NDIF is up!

- `meta-llama/Meta-Llama-3.1-405B`
- `meta-llama/Meta-Llama-3.1-8B`
- `EleutherAI/gpt-j-6b`
- `meta-llama/Meta-Llama-3.1-70B`
- `deepseek-ai/DeepSeek-R1-Distill-Llama-8B`
- `deepseek-ai/DeepSeek-R1-Distill-Llama-70B`
```