### PR TITLE
Bug fix: ModuleList input and outputs

### DIFF
--- a/src/nnsight/intervention/envoy.py
+++ b/src/nnsight/intervention/envoy.py
@@ -109,7 +109,9 @@ class Envoy(Generic[InterventionProxyType, InterventionNodeType]):
 
             if isinstance(self._module, torch.nn.ModuleList):
 
-                output = [envoy.output for envoy in self._children]
+                from .. import list as nnsight_list
+                output = nnsight_list()
+                output.extend([envoy.output for envoy in self._children])
             else:
 
                 iteration = self._iteration_stack[-1]
@@ -165,7 +167,9 @@ class Envoy(Generic[InterventionProxyType, InterventionNodeType]):
 
             if isinstance(self._module, torch.nn.ModuleList):
 
-                input = [envoy.input for envoy in self._children]
+                from .. import list as nnsight_list
+                input = nnsight_list()
+                input.extend([envoy.input for envoy in self._children])
             else:
 
                 iteration = self._iteration_stack[-1]

--- a/src/nnsight/intervention/envoy.py
+++ b/src/nnsight/intervention/envoy.py
@@ -110,8 +110,6 @@ class Envoy(Generic[InterventionProxyType, InterventionNodeType]):
             if isinstance(self._module, torch.nn.ModuleList):
 
                 output = [envoy.output for envoy in self._children]
-
-                return output
             else:
 
                 iteration = self._iteration_stack[-1]
@@ -168,8 +166,6 @@ class Envoy(Generic[InterventionProxyType, InterventionNodeType]):
             if isinstance(self._module, torch.nn.ModuleList):
 
                 input = [envoy.input for envoy in self._children]
-
-                return input
             else:
 
                 iteration = self._iteration_stack[-1]


### PR DESCRIPTION
## Description:

`Envoy` had a small bug where modules of type `ModuleList` would have their inputs and outputs returned without first being appended to their respective stacks.