### PR TITLE
Diffusion Model -> `num_images_per_prompt` bug fix

### DIFF
--- a/src/nnsight/modeling/diffusion.py
+++ b/src/nnsight/modeling/diffusion.py
@@ -97,7 +97,7 @@ class DiffusionModel(RemoteableMixin):
         if seed is not None:
 
             if isinstance(prepared_inputs, list):
-                generator = [torch.Generator().manual_seed(seed) for _ in range(len(prepared_inputs))]
+                generator = [torch.Generator().manual_seed(seed) for _ in range(len(prepared_inputs) * kwargs.get('num_images_per_prompt', 1))]
             else:
                 generator = generator.manual_seed(seed)
             

--- a/tests/test_diffusion.py
+++ b/tests/test_diffusion.py
@@ -1,0 +1,28 @@
+import pytest
+import torch
+import PIL
+
+if not torch.cuda.is_available():
+    pytest.skip("no GPU available.", allow_module_level=True)
+
+from nnsight.modeling.diffusion import DiffusionModel
+
+@pytest.fixture(scope="module")
+def tiny_sd():
+    return DiffusionModel("segmind/tiny-sd", torch_dtype=torch.float16, dispatch=True).to("cuda")
+
+@pytest.fixture(scope="module")
+def cat_prompt():
+    return "A brown and white cat staring off with pretty green eyes"
+
+def test_generation(tiny_sd, cat_prompt):
+    num_images_per_prompt = 3
+
+    images = tiny_sd.generate(cat_prompt, 
+                              num_inference_steps=20, 
+                              num_images_per_prompt=num_images_per_prompt,
+                              seed=423, 
+                              trace=False).images
+
+    assert len(images) == num_images_per_prompt
+    assert all([type(img) == PIL.Image.Image for img in images])


### PR DESCRIPTION
The batch size in the DiffusionModel forward pass is equal to the number of prompts times the number of images to generate per prompt. In this PR, we handle an error related to the list of generators argument when `num_images_per_prompt` is specified. It may be possible that tracing needs to handle this argument more properly.

Source: 
https://github.com/huggingface/diffusers/blob/a7d53a59394d5d8367826663601b69828e9f74fc/src/diffusers/pipelines/lumina2/pipeline_lumina2.py#L660-L670