### PR TITLE
Better error messages for accessing outside of trace context

### DIFF
--- a/src/nnsight/intervention/envoy.py
+++ b/src/nnsight/intervention/envoy.py
@@ -113,6 +113,14 @@ class Envoy(Generic[InterventionProxyType, InterventionNodeType]):
         Returns:
             InterventionProxy: Output proxy.
         """
+        if not self._tracing():
+            raise RuntimeError(
+                "Property 'output' can only be accessed within a tracing context. "
+                "Make sure you're using the model within a Session or other appropriate context manager. "
+                "If you need to access the value outside of the tracing context, use '.save()' on the proxy "
+                "within the context (e.g., 'x = model.transformer.h[0].output.save()')."
+            )
+            
         output = self._output_stack.pop()
 
         if output is None:
@@ -170,6 +178,13 @@ class Envoy(Generic[InterventionProxyType, InterventionNodeType]):
         Returns:
             InterventionProxy: Input proxy.
         """
+        if not self._tracing():
+            raise RuntimeError(
+                "Property 'inputs' can only be accessed within a tracing context. "
+                "Make sure you're using the model within a Session or other appropriate context manager. "
+                "If you need to access the value outside of the tracing context, use '.save()' on the proxy "
+                "within the context (e.g., 'x = model.transformer.h[0].inputs.save()')."
+            )
 
         input = self._input_stack.pop()
 
@@ -226,6 +241,13 @@ class Envoy(Generic[InterventionProxyType, InterventionNodeType]):
         Returns:
             InterventionProxy: Input proxy.
         """
+        if not self._tracing():
+            raise RuntimeError(
+                "Property 'input' can only be accessed within a tracing context. "
+                "Make sure you're using the model within a Session or other appropriate context manager. "
+                "If you need to access the value outside of the tracing context, use '.save()' on the proxy "
+                "within the context (e.g., 'x = model.transformer.h[0].input.save()')."
+            )
 
         return self.inputs[0][0]
 

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -491,3 +491,17 @@ def test_undispatched_extra_module(device: str, MSG_prompt: str):
         output = model.generator.output.save()
 
     output.value
+
+
+def test_envoy_input_output_access(gpt2: nnsight.LanguageModel, MSG_prompt: str):
+    with gpt2.trace(MSG_prompt) as tracer:
+        l1_out = gpt2.transformer.h[0].output.save()
+
+    with pytest.raises(RuntimeError):
+        gpt2.transformer.h[0].output
+
+    with pytest.raises(RuntimeError):
+        gpt2.transformer.h[0].input
+
+    with pytest.raises(RuntimeError):
+        gpt2.transformer.h[0].inputs

--- a/tests/test_tiny.py
+++ b/tests/test_tiny.py
@@ -314,3 +314,17 @@ def test_torch_creation_operations_patch(tiny_model: NNsight, tiny_input: torch.
         torch.randn(l1_output.shape)
         torch.randperm(l1_output.shape[0])
         torch.zeros(l1_output.shape)
+
+
+def test_envoy_input_output_access(tiny_model: NNsight, tiny_input: torch.Tensor):
+    with tiny_model.trace(tiny_input) as tracer:
+        l1_out = tiny_model.layer1.output.save()
+
+    with pytest.raises(RuntimeError):
+        tiny_model.layer1.output
+
+    with pytest.raises(RuntimeError):
+        tiny_model.layer1.input
+
+    with pytest.raises(RuntimeError):
+        tiny_model.layer1.inputs


### PR DESCRIPTION
## Description

This PR introduces more informative error messages when trying to access `.input`, `.inputs` or `.output` outside of a trace context.