### PR TITLE
LOG responses don't get disabled by config

### DIFF
--- a/src/nnsight/schema/response.py
+++ b/src/nnsight/schema/response.py
@@ -40,6 +40,11 @@ class ResponseModel(BaseModel):
        
         if self.status == ResponseModel.JobStatus.STREAM:
             pass
+        elif self.status == ResponseModel.JobStatus.LOG:
+            disable_flag = logger.disabled
+            logger.disabled = False
+            logger.info(str(self))
+            logger.disabled = disable_flag
         else:
             logger.info(str(self))
 


### PR DESCRIPTION
To improve the user experience, disabling remote logging shouldn't affect LOG responses received as a result of explicit log calls defined by the user in the intervention graph.