### PR TITLE
Invoker Memory

### DIFF
--- a/src/nnsight/intervention/interleaver.py
+++ b/src/nnsight/intervention/interleaver.py
@@ -70,6 +70,8 @@ class Interleaver(AbstractContextManager):
             self.batch_size = (
                 sum(self.batch_groups[-1]) if batch_size is None else batch_size
             )
+        else:
+            self.batch_size = batch_size
 
     def __enter__(self) -> Interleaver:
         """Registers input and output hooks to modules involved in the `InterventionGraph`.

--- a/src/nnsight/intervention/protocols/intervention.py
+++ b/src/nnsight/intervention/protocols/intervention.py
@@ -179,7 +179,7 @@ class InterventionProtocol(EntryPoint):
                     # If we narrowed any data, we need to concat it with data before and after it.
                     if narrowed:
                         # Slicing a leaf tensor that requires grad will break the autograd graph, so we concatenate.
-                            if node.kwargs and (activations.is_leaf and activations.requires_grad):
+                            if activations.is_leaf and activations.requires_grad:
                                 activations = cls.concat(
                                     activations,
                                     value,

--- a/src/nnsight/intervention/protocols/intervention.py
+++ b/src/nnsight/intervention/protocols/intervention.py
@@ -176,20 +176,21 @@ class InterventionProtocol(EntryPoint):
                 if 'swap' in node.kwargs:
                     value:InterventionNodeType = node.kwargs.pop('swap')
 
-                # If we narrowed any data, we need to concat it with data before and after it.
-                if narrowed:
-
-                    activations = cls.concat(
-                        activations,
-                        value,
-                        batch_start,
-                        batch_size,
-                        interleaver.batch_size,
-                    )
-                # Otherwise just return the whole value as the activations.
-                else:
-
-                    activations = value
+                    # If we narrowed any data, we need to concat it with data before and after it.
+                    if narrowed:
+                        # Slicing a leaf tensor that requires grad will break the autograd graph, so we concatenate.
+                            if node.kwargs and (activations.is_leaf and activations.requires_grad):
+                                activations = cls.concat(
+                                    activations,
+                                    value,
+                                    batch_start,
+                                    batch_size,
+                                    interleaver.batch_size,
+                                )
+                            else:
+                                activations[batch_start:batch_start+batch_size][:] = value[:]
+                    else:
+                        activations = value
 
         return activations
 

--- a/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
+++ b/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
@@ -244,8 +244,6 @@ class NNsightGPUModelRunner(ModelRunner):
 
         def inner():
 
-            nonlocal interleaver
-
             with set_forward_context(model_input.attn_metadata):
                 hidden_or_intermediate_states = self.model._model(
                     input_ids=model_input.input_tokens,

--- a/src/nnsight/tracing/graph/viz.py
+++ b/src/nnsight/tracing/graph/viz.py
@@ -98,7 +98,6 @@ def viz_graph(
                 - pgv.AGraph: Graph Visualization Object.
             """
 
-            nonlocal subgraphs
             if group:
                 if id(node.graph) != id(graph):
                     if not id(node.graph) in subgraphs.keys():


### PR DESCRIPTION
This PR resolves the high memory usage of the `intervene` function when multiple invokers are defined during tracing. The high memory consumption was caused by the `.concat` operation at each batched narrowed view of the `activations` tensor being intervened on.


## Improvements

1. The original `activations` tensor obtained from the hooks should only be updated when there is a swap in the intervention graph.
2. When multiple invokers are defined, concatenation of an updated narrowed value is only necessary when the `activations` is a leaf in an `autograd` graph (i.e. `.is_leaf == True` and `.requires_grad` == True). Otherwise, we can simply index set the value into the complete activation tensor.


## Test

This test was taken from the previously raised issue #396. Prior to this PR, this code would reach a maximum memory consumption of more than 40GB.

```py
import torch
from nnsight import LanguageModel

model = LanguageModel("meta-llama/Llama-3.2-1B", device_map="auto", dispatch=True)

batch_size = 100
prompts = ["Amazon's former CEO attended Oscars"] * batch_size

torch.cuda.reset_peak_memory_stats()

print("Memory allocated before: ", f"{torch.cuda.memory_allocated() / 1e9} GB")
print("Memory reserved before: ", f"{torch.cuda.memory_reserved() / 1e9} GB")

logits = []
with torch.no_grad():
    with model.trace() as tracer:
        for i, p in enumerate(prompts):
            with tracer.invoke(p):
                logits.append(model.lm_head.output[0].save())
logits = torch.stack(logits, dim=0)

print("Memory allocated after: ", f"{torch.cuda.memory_allocated() / 1e9} GB")
print("Memory reserved after: ", f"{torch.cuda.memory_reserved() / 1e9} GB")
print(f"Memory allocated peak: {torch.cuda.max_memory_allocated() / 1e9} GB")
```

```
Memory allocated before:  4.943258112 GB
Memory reserved before:  4.961861632 GB
Memory allocated after:  5.310894592 GB
Memory reserved after:  5.838471168 GB
Memory allocated peak: 5.670011392 GB
```