### PR TITLE
Invoker Kwargs

### DIFF
--- a/src/nnsight/intervention/base.py
+++ b/src/nnsight/intervention/base.py
@@ -92,7 +92,7 @@ class NNsight:
             trace (bool, optional): If to open a tracing context. Otherwise immediately run the model and return the raw output. Defaults to True.
             scan (bool): Exposed invoker kwarg to scan for the provided input. No effect if there is no input.
             method (Optional[str]): String name of method to interleave with. Defaults to None and therefore NNsight._execute
-            invoker_args (Dict[str, Any], optional): Keyword arguments to pass to Invoker initialization, and then downstream to the model's .prepare_inputs(...) method. Used when giving input directly to `.trace(...)`. Defaults to None.
+            invoker_kwargs (Dict[str, Any], optional): Keyword arguments to pass to Invoker initialization, and then downstream to the model's .prepare_inputs(...) method. Used when giving input directly to `.trace(...)`. Defaults to None.
             kwargs (Dict[str, Any]): Keyword arguments passed to Tracer initialization, and then downstream to the model's execution method.
 
         Raises:


### PR DESCRIPTION
This PR results from investigating if `invoker_kwargs` passed to a `.trace(...)` call make it downstream to the Invoker object. The answer is Yes and was verified via the following test:

```py
from nnsight import LanguageModel

model = LanguageModel("openai-community/gpt2")

with model.trace("The Eiffel Tower is located in the city of", invoker_kwargs={'truncation': True, 'max_length': 8}):
    out = model.lm_head.output[0, -1, :].argmax(dim=-1).save()

print(model.tokenizer.decode(out))
```

```
>>> the
```

The generated token is " the" which is the 9-th token position in the original non-truncated input to the tracer.

The documentation was updated to talk about `invoker_kwargs` instead of `invoker_args`.