### PR TITLE
Provide option to set logger path via environment variable

### DIFF
--- a/src/nnsight/logger.py
+++ b/src/nnsight/logger.py
@@ -2,7 +2,14 @@ import logging
 import os
 from logging.handlers import RotatingFileHandler
 
-PATH = os.path.dirname(os.path.abspath(__file__))
+# Work out the log directory:
+# – Look for an environment variable called NNSIGHT_LOG_PATH (stripped of whitespace);
+# – if it’s unset or empty, fall back to the default.
+# Then make sure that directory actually exists, creating it if necessary.
+_DEFAULT_PATH = os.path.dirname(os.path.abspath(__file__))
+_env_path = os.getenv("NNSIGHT_LOG_PATH", "").strip()
+PATH = _env_path or _DEFAULT_PATH
+os.makedirs(PATH, exist_ok=True)
 
 logging_handler = RotatingFileHandler(
     os.path.join(PATH, f"nnsight.log"),


### PR DESCRIPTION
Make the log file location configurable to avoid read-only-FS crashes.

nnsight.logger currently writes nnsight.log next to the package, which fails in read-only environments (e.g. Singularity/ Docker images mounted read-only) with `OSError: [Errno 30] Read-only file system`.

This patch lets users override the log directory through the NNSIGHT_LOG_DIR environment variable, falling back to the previous behaviour when unset. Existing installs keep working, and containers without write access can point the logger to a writable path such as /tmp.