### PR TITLE
Cache Attribute Access

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 markers =
     config: mark a test as part of configuration tests
+    order: tests for out of order execution raising an error
     source: tests for module source tracing
     skips: tests for skipping modules
     iter: tests for iterating over forward passes

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,4 @@ markers =
     source: tests for module source tracing
     skips: tests for skipping modules
     iter: tests for iterating over forward passes
+    cache: tests for activations caching

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,10 @@
 [pytest]
 markers =
+    scan: tests for scan tracing
     config: mark a test as part of configuration tests
     order: tests for out of order execution raising an error
     source: tests for module source tracing
     skips: tests for skipping modules
     iter: tests for iterating over forward passes
     cache: tests for activations caching
+    rename: tests for renaming modules

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,6 @@
 [pytest]
 markers =
     config: mark a test as part of configuration tests
+    source: tests for module source tracing
+    skips: tests for skipping modules
+    iter: tests for iterating over forward passes

--- a/src/nnsight/intervention/envoy.py
+++ b/src/nnsight/intervention/envoy.py
@@ -938,18 +938,20 @@ class OperationEnvoy:
             An EnvoySource object containing the operation's source code and nested operations
         """
 
-        fn = self._interleaver.current.request(f"{self.name}.fn")
 
-        def wrap(fn: Callable, **kwargs):
-            return self._interleaver.wrap_operation(fn, **kwargs)
+        if self._source is None:
+            fn = self._interleaver.current.request(f"{self.name}.fn")
 
-        source, line_numbers, fn = inject(fn, wrap, self.name)
+            def wrap(fn: Callable, **kwargs):
+                return self._interleaver.wrap_operation(fn, **kwargs)
 
-        self._source = EnvoySource(
-            self.name, source, line_numbers, interleaver=self._interleaver
-        )
+            source, line_numbers, fn = inject(fn, wrap, self.name)
 
-        self._interleaver.current.swap(f"{self.name}.fn", fn)
+            self._source = EnvoySource(
+                self.name, source, line_numbers, interleaver=self._interleaver
+            )
+
+            self._interleaver.current.swap(f"{self.name}.fn", fn)
 
         return self._source
 

--- a/src/nnsight/intervention/interleaver.py
+++ b/src/nnsight/intervention/interleaver.py
@@ -630,10 +630,19 @@ class Mediator:
             raise SkipException(value)
         
         else:
-            self.history.add(provider)
-            self.event_queue.put((Events.SKIP, (requester, value)))
-            
-            return False
+            if requester in self.history:
+                self.respond(
+                    ValueError(
+                        f"Value was missed for {requester}. Did you call an Envoy out of order?"
+                    )
+                )
+
+                return True
+            else:
+                self.history.add(provider)
+                self.event_queue.put((Events.SKIP, (requester, value)))
+                
+                return False
         
     def handle_register_event(self, mediator: Mediator, fn: Optional[Callable] = None):
         """

--- a/src/nnsight/intervention/interleaver.py
+++ b/src/nnsight/intervention/interleaver.py
@@ -351,8 +351,9 @@ class Interleaver:
         
         self.batcher.current_value = old
 
-        if self.user_cache is not None:
-            self.user_cache.add(provider, value)
+        if len(self.user_cache) > 0:
+            for cache in self.user_cache:
+                cache.add(provider, value)
             
         return value
 
@@ -410,7 +411,7 @@ class Mediator:
         self.interleaver = None
         self.child: Mediator = None
         self.history = set()
-        self.user_cache: "Cache" = None
+        self.user_cache: List["Cache"] = list()
         self.iteration = 0
 
         self.args = list()
@@ -517,8 +518,9 @@ class Mediator:
                 try:
                     process = self.handle_skip_event(provider, *data)
                 except SkipException as e:
-                    if self.user_cache is not None:
-                        self.user_cache.add(provider, e.value)
+                    if len(self.user_cache) > 0:
+                        for cache in self.user_cache:
+                            cache.add(provider, e.value)
                     raise e
             elif event == Events.END:
                 process = False
@@ -529,9 +531,10 @@ class Mediator:
             self.handle_end_event()
 
         # TODO maybe move this to the interleaver to cache the pre-iteration provider
-        if self.user_cache is not None and provider is not None:
+        if len(self.user_cache) > 0 and provider is not None:
 
-            self.user_cache.add(provider, self.interleaver.batcher.narrow(self.batch_group, self.interleaver.batcher.current_value))
+            for cache in self.user_cache:
+                cache.add(provider, self.interleaver.batcher.narrow(self.batch_group, self.interleaver.batcher.current_value))
                         
     def handle_end_event(self):
         """
@@ -878,7 +881,7 @@ class Mediator:
             cache: The cache to set
         """
 
-        self.user_cache = cache
+        self.user_cache.append(cache)
 
     ### Serialization ###
 

--- a/src/nnsight/intervention/interleaver.py
+++ b/src/nnsight/intervention/interleaver.py
@@ -388,6 +388,8 @@ class Mediator:
         self.user_cache: "Cache" = None
         self.iteration = 0
 
+        self.args = list()
+
         self._frame = None
 
     def start(self, interleaver: Interleaver):
@@ -403,7 +405,7 @@ class Mediator:
 
         self.thread = Thread(
             target=self.intervention,
-            args=(self, self.info, self.interleaver.tracer.model, self.interleaver.tracer),
+            args=(self, self.info, self.interleaver.tracer.model, self.interleaver.tracer, *self.args),
             daemon=True,
             name=self.name,
         )
@@ -444,11 +446,9 @@ class Mediator:
 
         Args:
             provider: The identifier of the provider
-            value: The value being provided
 
         Returns:
             The original or modified value
-
         """
 
         if self.child is not None:
@@ -785,6 +785,7 @@ class Mediator:
                     stop = self.interleaver.default_all
 
                 mediator.iteration = i
+                mediator.args = list([mediator.iteration])
 
                 self.register(mediator)
 
@@ -796,6 +797,7 @@ class Mediator:
         elif isinstance(iteration, int):
 
             mediator.iteration = iteration
+            mediator.args = list([mediator.iteration])
 
             self.register(mediator)
             

--- a/src/nnsight/intervention/tracing/iterator.py
+++ b/src/nnsight/intervention/tracing/iterator.py
@@ -1,6 +1,7 @@
 from typing import Callable, TYPE_CHECKING, Any, Union
 from .invoker import Invoker
 from ..interleaver import Mediator
+from .util import try_catch
 
 if TYPE_CHECKING:
     from .tracer import InterleavingTracer
@@ -24,6 +25,28 @@ class IteratorTracer(Invoker):
         
         self.iteration = iteration
         
+    def compile(self):
+        """
+        Compile the captured source code as a callable function.
+
+        Wraps the captured code in a function definition that accepts the
+        necessary context parameters for execution.
+
+        Returns:
+            A callable function that executes the captured code block
+        """
+
+        iteration_var_name = self.info.node.items[0].optional_vars.id if self.info.node.items[0].optional_vars is not None else "__nnsight_iteration__"
+
+        # Wrap the captured code in a function definition with appropriate parameters
+        self.info.source = [
+            f"def __nnsight_tracer_{id(self)}__(__nnsight_mediator__, __nnsight_tracing_info__, {self.tracer.model_var_name if self.tracer is not None else '__nnsight_model__'}, {self.tracer.tracer_var_name if self.tracer is not None else '__nnsight_tracer__'}, {iteration_var_name}):\n",
+            *try_catch(
+                self.info.source,
+                exception_source=["__nnsight_mediator__.exception(exception)\n"],
+                else_source=["__nnsight_mediator__.end()\n"],
+            ),
+        ]
         
     def execute(self, fn: Callable):
                 

--- a/src/nnsight/intervention/tracing/tracer.py
+++ b/src/nnsight/intervention/tracing/tracer.py
@@ -65,7 +65,7 @@ class Cache:
         if self.modules is not None:
             self.modules = {m if isinstance(m, str) else m.path for m in self.modules}
 
-        self.cache = {}
+        self.cache = dict().save()
 
     def add(self, provider: str, value: Any):
         """

--- a/src/nnsight/intervention/tracing/tracer.py
+++ b/src/nnsight/intervention/tracing/tracer.py
@@ -172,7 +172,7 @@ class InterleavingTracer(Tracer):
 
         self.batcher = Batcher(**kwargs)
 
-        self.user_cache: Optional[Cache] = None
+        self.user_cache: List[Cache] = list()
 
         super().__init__(*args, backend=backend)
 
@@ -300,18 +300,15 @@ class InterleavingTracer(Tracer):
         """
 
         if self.model._interleaver is None:
-            if self.user_cache is None:
-                self.user_cache = Cache(modules, device, dtype, detach, include_output, include_inputs)
+            self.user_cache.append(Cache(modules, device, dtype, detach, include_output, include_inputs))
 
-            return self.user_cache.cache
-            
+            return self.user_cache[-1].cache
 
-        if self.model._interleaver.current.user_cache is None:
-            self.model._interleaver.current.set_user_cache(
-                Cache(modules, device, dtype, detach, include_output, include_inputs)
-            )
+        self.model._interleaver.current.set_user_cache(
+            Cache(modules, device, dtype, detach, include_output, include_inputs)
+        )
 
-        return self.model._interleaver.current.user_cache.cache
+        return self.model._interleaver.current.user_cache[-1].cache
 
     ### Serialization ###
 

--- a/src/nnsight/intervention/tracing/tracer.py
+++ b/src/nnsight/intervention/tracing/tracer.py
@@ -42,6 +42,62 @@ class Cache:
         def input(self):
             return [*self.inputs[0], *self.inputs[1].values()][0]
 
+    class CacheDict(Dict):
+
+        """
+        A dictionary subclass that provides convenient access to cached module activations.
+
+        This class extends the standard dictionary to provide both dictionary-style access
+        and attribute-style access to cached activations. It supports hierarchical access
+        to nested modules using dot notation and indexing for module lists.
+
+        Examples:
+            Access cached activations using dictionary keys:
+            >>> cache['model.transformer.h.0.attn']
+
+            Access using attribute notation:
+            >>> cache.model.transformer.h[0].attn
+
+            Access module outputs and inputs:
+            >>> cache.model.transformer.h[0].output
+            >>> cache.model.transformer.h[0].inputs
+            >>> cache.model.transformer.h[0].input  # First input argument
+
+        The class maintains an internal path that tracks the current location in the
+        module hierarchy, allowing for intuitive navigation through nested modules.
+        """
+
+        def __init__(self, data: "Union[Cache.CacheDict, Dict[str, Cache.Entry]]", path: Optional[str] = ""):
+            self._path = path
+
+            super().__init__(data)
+
+        def __getitem__(self, key):
+            if isinstance(key, str):
+                return dict.__getitem__(self, key)
+            
+            if isinstance(key, int):
+                path = self._path + "." f"{key}"
+                
+                if any(key.startswith(path) for key in self):
+                    return Cache.CacheDict(self, path)
+                elif any(key.startswith(self._path + ".") and len(key) >= len(self._path) + 1 and key[len(self._path) + 1].isdigit() for key in self):
+                    raise IndexError(f"Index {key} is out of bounds for the list")
+                
+            return dict.__getitem__(self, key)
+        
+        def __getattr__(self, attr: str):
+
+            if attr == "output" or attr == "inputs" or attr == "input":
+                return self[self._path].__getattribute__(attr)
+
+            path = self._path + "." + attr if self._path != "" else attr
+
+            if any(key.startswith(path) for key in self):
+                return Cache.CacheDict(self, path)
+            else:
+                raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{path}'")
+
     def __init__(
         self,
         modules: Optional[List[Union[Envoy, str]]] = None,
@@ -71,7 +127,7 @@ class Cache:
         if self.modules is not None:
             self.modules = {m if isinstance(m, str) else m.path for m in self.modules}
 
-        self.cache = dict().save()
+        self.cache = Cache.CacheDict({}).save()
 
     def add(self, provider: str, value: Any):
         """

--- a/src/nnsight/intervention/tracing/util.py
+++ b/src/nnsight/intervention/tracing/util.py
@@ -241,6 +241,7 @@ def wrap_exception(exception:Exception, info:"Tracer.Info"):
         
     Returns:
         A wrapped exception with enhanced traceback information
+
     """
 
     if isinstance(exception, ExceptionWrapper):

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -457,6 +457,17 @@ def test_out_of_order_skip(gpt2: nnsight.LanguageModel):
             gpt2.transformer.h[1].input[:] = 0
 
 
+@pytest.mark.order
+@pytest.mark.skips
+def test_out_of_order_skip_2(gpt2: nnsight.LanguageModel):
+    with pytest.raises(ValueError):
+        with gpt2.trace("_"):
+
+            inp = gpt2.transformer.h[0].output.save()
+            gpt2.transformer.h[1].skip(inp)
+            gpt2.transformer.h[0].skip(inp)
+
+
 # TODO - FIX THIS?
 # def test_cleanup(gpt2: nnsight.LanguageModel):
 #     with gpt2.trace("_", max_new_tokens=2) as tracer:

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -14,9 +14,13 @@ def gpt2(device: str):
 
 
 @pytest.fixture
+def ET_prompt():
+    return "The Eiffel Tower is located in the city of"
+
+
+@pytest.fixture
 def MSG_prompt():
     return "Madison Square Garden is located in the city of"
-
 
 
 @torch.no_grad()
@@ -432,6 +436,333 @@ def test_input_setting(gpt2: nnsight.LanguageModel, MSG_prompt: str):
     prediction_2 = gpt2.tokenizer.decode(tokens_out_2[0][-1])
 
     assert prediction_1 == prediction_2
+
+
+# TODO - FIX THIS
+def test_cleanup(gpt2: nnsight.LanguageModel):
+    with gpt2.trace("_"):
+        arr = list()
+
+        with gpt2.all():
+            gpt2.lm_head.output
+
+    with pytest.raises(UnboundLocalError):
+        arr
+
+######################### SOURCE #################################
+
+@pytest.mark.source
+def test_source_output(gpt2: nnsight.LanguageModel):
+    with gpt2.trace("_"):
+        out = gpt2.transformer.h[0].attn.source.split_1.output.save()
+
+    assert isinstance(out, tuple)
+
+
+@pytest.mark.source
+def test_source_inputs(gpt2: nnsight.LanguageModel):
+    with gpt2.trace("_"):
+        inp = gpt2.transformer.h[0].attn.source.attention_interface_0.inputs.save()
+
+    assert isinstance(inp, tuple)
+
+
+@pytest.mark.source
+def test_source_safe_intervention(gpt2: nnsight.LanguageModel, MSG_prompt: str):
+
+    input = gpt2.tokenizer(MSG_prompt, return_tensors="pt").to(gpt2.device)
+
+    logits_0 = gpt2(**input)['logits']
+
+    gpt2.transformer.h[0].attn.source
+    with gpt2.trace("_"):
+        gpt2.transformer.h[0].attn.c_attn.output = torch.zeros_like(gpt2.transformer.h[0].attn.c_attn.output)
+        out = gpt2.transformer.h[0].attn.source.split_1.output.save()
+
+    logits_1 = gpt2(**input)['logits']
+
+    assert isinstance(out, tuple)
+    assert torch.all(out[0] == 0) 
+    assert torch.all(logits_0 == logits_1)
+
+
+@pytest.mark.source
+def test_multiple_source(gpt2: nnsight.LanguageModel):
+    with gpt2.trace("_"):
+        out_split_0 = gpt2.transformer.h[0].attn.source.split_1.output.save()
+        out_attention_interface_0 = gpt2.transformer.h[0].attn.source.attention_interface_0.output.save()
+
+        out_split_1 = gpt2.transformer.h[1].attn.source.split_1.output.save()
+        out_attention_interface_1 = gpt2.transformer.h[1].attn.source.attention_interface_0.output.save()
+
+    assert isinstance(out_split_0, tuple)
+    assert isinstance(out_attention_interface_0, tuple)
+    assert isinstance(out_split_1, tuple)
+    assert isinstance(out_attention_interface_1, tuple)
+
+
+@pytest.mark.source
+def test_source_patching(gpt2: nnsight.LanguageModel):
+    with gpt2.trace("_"):
+        out = gpt2.transformer.h[0].attn.source.split_1.output
+        out = (torch.zeros_like(out[0]),) + out[1:]
+
+        gpt2.transformer.h[1].attn.source.split_1.output = out
+
+        out_2 = gpt2.transformer.h[1].attn.source.split_1.output.save()
+
+    assert isinstance(out_2, tuple)
+    assert torch.all(out_2[0] == 0)
+
+
+@pytest.mark.source
+def test_recursive_source(gpt2: nnsight.LanguageModel):
+    
+    with gpt2.trace("_"):
+        out = gpt2.transformer.h[0].attn.source.attention_interface_0.source.torch_nn_functional_scaled_dot_product_attention_0.output.save()
+
+    assert isinstance(out, torch.Tensor)
+
+
+# TODO - FIX THIS
+@pytest.mark.source
+def test_source_imported_function(gpt2: nnsight.LanguageModel):
+    with gpt2.trace("_"):
+        #gpt2.transformer.h[0].attn.source.attention_interface_0.source ## This works!!
+        gpt2.transformer.h[0].attn.source.split_1.source
+        out = gpt2.transformer.h[0].attn.source.split_1.output.save()
+
+    assert isinstance(out, tuple)
+
+
+@pytest.mark.source
+def test_source_operation_not_found(gpt2: nnsight.LanguageModel):
+    with pytest.raises(AttributeError):
+        with gpt2.trace("_"):
+            out = gpt2.transformer.h[0].attn.source.my_func.output.save()
+
+
+######################### SKIP #################################
+
+@pytest.mark.skips
+def test_skip(gpt2: nnsight.LanguageModel):
+    with gpt2.trace("_"):
+
+        inp = gpt2.transformer.h[0].output.save()
+        gpt2.transformer.h[1].skip(inp)
+        out = gpt2.transformer.h[1].output.save()
+
+    assert torch.equal(out[0], inp[0])
+
+
+# TODO - FIX THIS
+@pytest.mark.skips
+def test_input_event_skipped(gpt2: nnsight.LanguageModel):
+    with gpt2.trace("_"):
+
+        gpt2.transformer.h[1].skip(gpt2.transformer.h[0].output)
+        gpt2.transformer.h[1].input[:] = 0
+        
+
+        out = gpt2.transformer.h[5].output.save()
+
+    assert out
+
+
+@pytest.mark.skips
+def test_skip_2(gpt2: nnsight.LanguageModel):
+    with gpt2.trace("_"):
+
+        inp = gpt2.transformer.h[0].output
+        gpt2.transformer.h[1].inputs = ((torch.zeros_like(gpt2.transformer.h[1].input),)) + gpt2.transformer.h[1].inputs[1:]
+        gpt2.transformer.h[1].skip(inp)
+
+        out = gpt2.transformer.h[1].output.save()
+
+    assert not torch.all(out[0] == 0)
+    assert torch.equal(out[0], inp[0])
+
+
+@pytest.mark.skips
+def test_multiple_skip(gpt2: nnsight.LanguageModel):
+    with gpt2.trace("_"):
+
+        inp = gpt2.transformer.h[0].output.save()
+
+        gpt2.transformer.h[1].skip(inp)
+        inp_2 = gpt2.transformer.h[1].output
+        gpt2.transformer.h[2].skip(inp_2)
+        inp_3 = gpt2.transformer.h[2].output
+        gpt2.transformer.h[3].skip(inp_3)
+        
+        out = gpt2.transformer.h[3].output.save()
+    
+    assert torch.equal(out[0], inp_3[0])
+
+
+@pytest.mark.skips
+def test_skip_inner_module(gpt2: nnsight.LanguageModel):
+    with gpt2.trace("Hello World"):
+        inp = gpt2.transformer.h[0].output
+        gpt2.transformer.h[1].skip(inp)
+        hs = gpt2.transformer.h[1].attn.output.save()
+
+    with pytest.raises(UnboundLocalError):
+        hs
+
+
+# TODO - FIX THIS
+@pytest.mark.skips
+def test_skip_module_for_batch(gpt2: nnsight.LanguageModel, ET_prompt: str, MSG_prompt: str):
+    with gpt2.trace() as tracer:
+        with tracer.invoke(ET_prompt):
+            inp = gpt2.transformer.h[0].output.save()
+            gpt2.transformer.h[1].skip(inp)
+            gpt2.transformer.h[2].skip(inp)
+            gpt2.transformer.h[3].skip(inp)
+            gpt2.transformer.h[4].skip(inp)
+
+        with tracer.invoke(ET_prompt):
+
+            out = gpt2.transformer.h[4].output.save()
+
+            logits_2 = gpt2.lm_head.output[0][-1].argmax(dim=-1).save()
+
+
+    assert not torch.equal(out[0], inp[0])
+    assert gpt2.tokenizer.decode(logits_2) == " Paris"
+
+
+###################### ITER #####################
+
+@pytest.mark.iter
+def test_iter(gpt2: nnsight.LanguageModel, MSG_prompt: str):
+    with gpt2.generate(MSG_prompt, max_new_tokens=3):
+        logits_all = list().save()
+
+        with gpt2.all():
+            logits_all.append(gpt2.lm_head.output[0][-1].argmax(dim=-1))
+
+    with gpt2.generate(MSG_prompt, max_new_tokens=3):
+        logits_iter = list().save()
+
+        with gpt2.iter[:]:
+            logits_iter.append(gpt2.lm_head.output[0][-1].argmax(dim=-1))
+
+    assert len(logits_all) == 3
+    assert len(logits_iter) == 3
+    
+    assert gpt2.tokenizer.batch_decode(logits_all) == [" New", " York", " City"]
+    assert gpt2.tokenizer.batch_decode(logits_iter) == [" New", " York", " City"]
+
+
+@pytest.mark.iter
+def test_iter_slice(gpt2: nnsight.LanguageModel, MSG_prompt: str):
+
+    with gpt2.generate(MSG_prompt, max_new_tokens=5) as tracer:
+        logits = list().save()
+
+        with tracer.iter[1:3]:
+            logits.append(gpt2.lm_head.output[0][-1].argmax(dim=-1))
+
+    assert len(logits) == 2
+    assert gpt2.tokenizer.batch_decode(logits) == [" York", " City"]
+
+
+@pytest.mark.iter
+def test_iter_module(gpt2: nnsight.LanguageModel, MSG_prompt: str):
+    with gpt2.trace(MSG_prompt, max_new_tokens=3) as tracer:
+        logits = list()
+
+        with tracer.iter[:]:
+            logits.append(gpt2.lm_head.output[0][-1].argmax(dim=-1))
+
+
+@pytest.mark.iter
+def test_iter_idx(gpt2: nnsight.LanguageModel, MSG_prompt: str):
+    with gpt2.generate(MSG_prompt, max_new_tokens=3) as tracer:
+        hs = list().save()
+
+        with tracer.iter[0]:
+            hs.append(gpt2.transformer.h[0].output[0])
+
+        with tracer.iter[1]:
+            hs.append(gpt2.transformer.h[1].output[0])
+
+        with tracer.iter[2]:
+            hs.append(gpt2.transformer.h[2].output[0])
+
+
+    with gpt2.generate(MSG_prompt, max_new_tokens=3) as tracer:
+        hs_2 = list().save()
+
+        with tracer.iter[:3] as idx:
+            hs_2.append(gpt2.transformer.h[idx].output[0])
+
+    assert all([torch.equal(h, h_2) for h, h_2 in zip(hs, hs_2)])
+
+
+@pytest.mark.iter
+def test_batched_iter(gpt2: nnsight.LanguageModel, MSG_prompt: str):
+    with gpt2.generate(max_new_tokens=5) as tracer:
+
+        with tracer.invoke(MSG_prompt):
+            logits_1 = list().save()
+
+            with tracer.iter[1:3]:
+                logits_1.append(gpt2.lm_head.output[0][-1].argmax(dim=-1))
+
+        with tracer.invoke(MSG_prompt):
+            logits_2 = list().save()
+
+            with tracer.iter[:3]:
+                logits_2.append(gpt2.lm_head.output[0][-1].argmax(dim=-1))
+
+    assert len(logits_1) == 2
+    assert len(logits_2) == 3
+
+    assert gpt2.tokenizer.batch_decode(logits_1) == [" York", " City"]
+    assert gpt2.tokenizer.batch_decode(logits_2) == [" New", " York", " City"]
+
+
+# TODO - FIX THIS
+@pytest.mark.iter
+def test_one_iter(gpt2: nnsight.LanguageModel):
+    with gpt2.generate("_", max_new_tokens=1) as tracer:
+        arr_gen = list().save()
+
+        with tracer.all():
+            arr_gen.append(1)
+
+    with gpt2.trace("_", max_new_tokens=1) as tracer:
+        arr_trace = list().save()
+
+        with tracer.all():
+            arr_trace.append(1)
+
+    print(len(arr_trace))
+
+    assert len(arr_gen) == 1
+    assert len(arr_trace) == 1
+
+
+@pytest.mark.iter
+@pytest.mark.skips
+def test_iter_and_skip(gpt2: nnsight.LanguageModel):
+    with gpt2.generate("_", max_new_tokens=3) as tracer:
+        arr_gen = list().save()
+
+        with tracer.iter[:] as it:
+            if it != 1:
+                arr_gen.append(gpt2.transformer.h[1].output[0])
+            else:
+                gpt2.transformer.h[1].skip((torch.zeros_like(gpt2.transformer.h[0].output[0]),) + gpt2.transformer.h[0].output[1:])
+
+                arr_gen.append(gpt2.transformer.h[1].output[0])
+
+    assert not torch.all(arr_gen[0] == 0)
+    assert torch.all(arr_gen[1] == 0)
+    assert not torch.all(arr_gen[2] == 0)
 
 
 # def test_parameter_protocol(gpt2: nnsight.LanguageModel, MSG_prompt: str):

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -438,6 +438,10 @@ def test_input_setting(gpt2: nnsight.LanguageModel, MSG_prompt: str):
     assert prediction_1 == prediction_2
 
 
+######################### ORDER #################################
+
+
+@torch.no_grad()
 @pytest.mark.order
 def test_out_of_order(gpt2: nnsight.LanguageModel):
     with pytest.raises(ValueError):
@@ -446,6 +450,7 @@ def test_out_of_order(gpt2: nnsight.LanguageModel):
             out_2 = gpt2.transformer.h[1].inputs.save()
 
 
+@torch.no_grad()
 @pytest.mark.order
 @pytest.mark.skips
 def test_out_of_order_skip(gpt2: nnsight.LanguageModel):
@@ -457,6 +462,7 @@ def test_out_of_order_skip(gpt2: nnsight.LanguageModel):
             gpt2.transformer.h[1].input[:] = 0
 
 
+@torch.no_grad()
 @pytest.mark.order
 @pytest.mark.skips
 def test_out_of_order_skip_2(gpt2: nnsight.LanguageModel):
@@ -481,6 +487,7 @@ def test_out_of_order_skip_2(gpt2: nnsight.LanguageModel):
 
 ######################### SOURCE #################################
 
+@torch.no_grad()
 @pytest.mark.source
 def test_source_output(gpt2: nnsight.LanguageModel):
     with gpt2.trace("_"):
@@ -489,6 +496,7 @@ def test_source_output(gpt2: nnsight.LanguageModel):
     assert isinstance(out, tuple)
 
 
+@torch.no_grad()
 @pytest.mark.source
 def test_source_inputs(gpt2: nnsight.LanguageModel):
     with gpt2.trace("_"):
@@ -497,6 +505,7 @@ def test_source_inputs(gpt2: nnsight.LanguageModel):
     assert isinstance(inp, tuple)
 
 
+@torch.no_grad()
 @pytest.mark.source
 def test_source_safe_intervention(gpt2: nnsight.LanguageModel, MSG_prompt: str):
 
@@ -516,6 +525,7 @@ def test_source_safe_intervention(gpt2: nnsight.LanguageModel, MSG_prompt: str):
     assert torch.all(logits_0 == logits_1)
 
 
+@torch.no_grad()
 @pytest.mark.source
 def test_multiple_source(gpt2: nnsight.LanguageModel):
     with gpt2.trace("_"):
@@ -531,6 +541,7 @@ def test_multiple_source(gpt2: nnsight.LanguageModel):
     assert isinstance(out_attention_interface_1, tuple)
 
 
+@torch.no_grad()
 @pytest.mark.source
 def test_source_patching(gpt2: nnsight.LanguageModel):
     with gpt2.trace("_"):
@@ -545,6 +556,7 @@ def test_source_patching(gpt2: nnsight.LanguageModel):
     assert torch.all(out_2[0] == 0)
 
 
+@torch.no_grad()
 @pytest.mark.source
 def test_recursive_source(gpt2: nnsight.LanguageModel):
     
@@ -554,6 +566,7 @@ def test_recursive_source(gpt2: nnsight.LanguageModel):
     assert isinstance(out, torch.Tensor)
 
 
+@torch.no_grad()
 @pytest.mark.source
 def test_source_imported_function(gpt2: nnsight.LanguageModel):
     with gpt2.trace("_"):
@@ -563,6 +576,7 @@ def test_source_imported_function(gpt2: nnsight.LanguageModel):
     assert isinstance(out, tuple)
 
 
+@torch.no_grad()
 @pytest.mark.source
 def test_source_operation_not_found(gpt2: nnsight.LanguageModel):
     with pytest.raises(AttributeError):
@@ -572,6 +586,7 @@ def test_source_operation_not_found(gpt2: nnsight.LanguageModel):
 
 ######################### SKIP #################################
 
+@torch.no_grad()
 @pytest.mark.skips
 def test_skip(gpt2: nnsight.LanguageModel):
     with gpt2.trace("_"):
@@ -583,6 +598,7 @@ def test_skip(gpt2: nnsight.LanguageModel):
     assert torch.equal(out[0], inp[0])
 
 
+@torch.no_grad()
 @pytest.mark.skips
 def test_skip_2(gpt2: nnsight.LanguageModel):
     with gpt2.trace("_"):
@@ -597,6 +613,7 @@ def test_skip_2(gpt2: nnsight.LanguageModel):
     assert torch.equal(out[0], inp[0])
 
 
+@torch.no_grad()
 @pytest.mark.skips
 def test_multiple_skip(gpt2: nnsight.LanguageModel):
     with gpt2.trace("_"):
@@ -614,6 +631,7 @@ def test_multiple_skip(gpt2: nnsight.LanguageModel):
     assert torch.equal(out[0], inp_3[0])
 
 
+@torch.no_grad()
 @pytest.mark.skips
 def test_skip_inner_module(gpt2: nnsight.LanguageModel):
     with gpt2.trace("Hello World"):
@@ -625,6 +643,7 @@ def test_skip_inner_module(gpt2: nnsight.LanguageModel):
         hs
 
 
+@torch.no_grad()
 @pytest.mark.skips
 def test_skip_module_for_batch(gpt2: nnsight.LanguageModel, ET_prompt: str, MSG_prompt: str):
     with gpt2.trace() as tracer:
@@ -648,6 +667,7 @@ def test_skip_module_for_batch(gpt2: nnsight.LanguageModel, ET_prompt: str, MSG_
     assert torch.equal(out_2[0], inp_2[0])
 
 
+@torch.no_grad()
 @pytest.mark.skips
 def test_skip_module_for_batch_error(gpt2: nnsight.LanguageModel, ET_prompt: str, MSG_prompt: str):
 
@@ -664,6 +684,7 @@ def test_skip_module_for_batch_error(gpt2: nnsight.LanguageModel, ET_prompt: str
 
 ###################### ITER #####################
 
+@torch.no_grad()
 @pytest.mark.iter
 def test_iter(gpt2: nnsight.LanguageModel, MSG_prompt: str):
     with gpt2.generate(MSG_prompt, max_new_tokens=3):
@@ -685,6 +706,7 @@ def test_iter(gpt2: nnsight.LanguageModel, MSG_prompt: str):
     assert gpt2.tokenizer.batch_decode(logits_iter) == [" New", " York", " City"]
 
 
+@torch.no_grad()
 @pytest.mark.iter
 def test_iter_slice(gpt2: nnsight.LanguageModel, MSG_prompt: str):
 
@@ -698,6 +720,7 @@ def test_iter_slice(gpt2: nnsight.LanguageModel, MSG_prompt: str):
     assert gpt2.tokenizer.batch_decode(logits) == [" York", " City"]
 
 
+@torch.no_grad()
 @pytest.mark.iter
 def test_iter_module(gpt2: nnsight.LanguageModel, MSG_prompt: str):
     with gpt2.trace(MSG_prompt, max_new_tokens=3) as tracer:
@@ -707,6 +730,7 @@ def test_iter_module(gpt2: nnsight.LanguageModel, MSG_prompt: str):
             logits.append(gpt2.lm_head.output[0][-1].argmax(dim=-1))
 
 
+@torch.no_grad()
 @pytest.mark.iter
 def test_iter_idx(gpt2: nnsight.LanguageModel, MSG_prompt: str):
     with gpt2.generate(MSG_prompt, max_new_tokens=3) as tracer:
@@ -731,6 +755,7 @@ def test_iter_idx(gpt2: nnsight.LanguageModel, MSG_prompt: str):
     assert all([torch.equal(h, h_2) for h, h_2 in zip(hs, hs_2)])
 
 
+@torch.no_grad()
 @pytest.mark.iter
 def test_batched_iter(gpt2: nnsight.LanguageModel, MSG_prompt: str):
     with gpt2.generate(max_new_tokens=5) as tracer:
@@ -754,7 +779,7 @@ def test_batched_iter(gpt2: nnsight.LanguageModel, MSG_prompt: str):
     assert gpt2.tokenizer.batch_decode(logits_2) == [" New", " York", " City"]
 
 
-# TODO - FIX THIS
+@torch.no_grad()
 @pytest.mark.iter
 def test_one_iter(gpt2: nnsight.LanguageModel):
     with gpt2.generate("_", max_new_tokens=1) as tracer:
@@ -766,6 +791,7 @@ def test_one_iter(gpt2: nnsight.LanguageModel):
     assert len(arr_gen) == 1
 
 
+@torch.no_grad()
 @pytest.mark.iter
 @pytest.mark.skips
 def test_iter_and_skip(gpt2: nnsight.LanguageModel):
@@ -783,6 +809,151 @@ def test_iter_and_skip(gpt2: nnsight.LanguageModel):
     assert not torch.all(arr_gen[0] == 0)
     assert torch.all(arr_gen[1] == 0)
     assert not torch.all(arr_gen[2] == 0)
+
+
+######################### CACHE #################################
+
+@torch.no_grad()
+@pytest.mark.cache
+def test_cache(gpt2: nnsight.LanguageModel, MSG_prompt: str):
+    with gpt2.trace(MSG_prompt) as tracer:
+        cache = tracer.cache().save()
+
+    assert torch.equal(cache['model.transformer.h.0'].output[0], cache['model.transformer.h.1'].inputs[0][0])
+
+
+@torch.no_grad()
+@pytest.mark.cache
+def test_cache_generation(gpt2: nnsight.LanguageModel, MSG_prompt: str):
+    with gpt2.generate(MSG_prompt, max_new_tokens=3) as tracer:
+        cache = tracer.cache().save()
+
+    assert len(cache['model.transformer.h.0.attn.c_attn']) == 3
+
+
+@torch.no_grad()
+@pytest.mark.cache
+def test_cache_with_intervention(gpt2: nnsight.LanguageModel, MSG_prompt: str):
+    with gpt2.trace(MSG_prompt) as tracer:
+        cache = tracer.cache().save() # the cache needs to be called first
+        gpt2.transformer.h[0].attn.c_attn.output = torch.zeros_like(gpt2.transformer.h[0].attn.c_attn.output)
+
+    assert torch.all(cache['model.transformer.h.0.attn.c_attn'].output == 0)
+
+
+@torch.no_grad()
+@pytest.mark.cache
+def test_cache_all_invokers_outside(gpt2: nnsight.LanguageModel, MSG_prompt: str, ET_prompt: str):
+    with gpt2.trace() as tracer:
+        cache = tracer.cache().save()
+        with tracer.invoke(MSG_prompt):
+            attn_out = gpt2.transformer.h[0].attn.c_attn.output.cpu().save()
+
+        with tracer.invoke(ET_prompt):
+            attn_out_2 = gpt2.transformer.h[0].attn.c_attn.output.cpu().save()
+
+    assert torch.equal(cache['model.transformer.h.0.attn.c_attn'].output[0], attn_out[0])
+    assert torch.equal(cache['model.transformer.h.0.attn.c_attn'].output[1], attn_out_2[0])
+
+
+@torch.no_grad()
+@pytest.mark.cache
+def test_cache_all_invokers(gpt2: nnsight.LanguageModel, MSG_prompt: str, ET_prompt: str):
+    with gpt2.trace() as tracer:
+        cache = tracer.cache().save()
+        with tracer.invoke(MSG_prompt):
+            cache_MSG = tracer.cache().save()
+            attn_out = gpt2.transformer.h[0].attn.c_attn.output.cpu().save()
+
+        with tracer.invoke(ET_prompt):
+            cache_ET = tracer.cache().save()
+            attn_out_2 = gpt2.transformer.h[0].attn.c_attn.output.cpu().save()
+
+    assert not torch.equal(attn_out, attn_out_2)
+    assert torch.equal(cache['model.transformer.h.0.attn.c_attn'].output[0], cache_MSG['model.transformer.h.0.attn.c_attn'].output[0])
+    assert torch.equal(cache['model.transformer.h.0.attn.c_attn'].output[1], cache_ET['model.transformer.h.0.attn.c_attn'].output[0])
+    assert torch.equal(cache_MSG['model.transformer.h.0.attn.c_attn'].output, attn_out)
+    assert torch.equal(cache_ET['model.transformer.h.0.attn.c_attn'].output, attn_out_2)
+
+
+@torch.no_grad()
+@pytest.mark.cache
+def test_cache_single_invoker(gpt2: nnsight.LanguageModel, MSG_prompt: str, ET_prompt: str):
+    with gpt2.trace() as tracer:
+
+        with tracer.invoke(MSG_prompt):
+            pass
+
+        with tracer.invoke(ET_prompt):
+            cache = tracer.cache().save()
+            attn_out = gpt2.transformer.h[0].attn.c_attn.output.cpu().save()
+
+    assert torch.equal(cache['model.transformer.h.0.attn.c_attn'].output[0], attn_out[0])
+
+
+@torch.no_grad()
+@pytest.mark.cache
+def test_cache_after_some_point(gpt2: nnsight.LanguageModel, MSG_prompt: str):
+    with gpt2.trace(MSG_prompt) as tracer:
+        gpt2.transformer.h[1].attn.c_attn.output = torch.zeros_like(gpt2.transformer.h[1].attn.c_attn.output)
+        cache = tracer.cache().save()
+
+    assert 'model.transformer.h.0' not in cache
+    assert cache['model.transformer'].inputs is None
+    assert cache['model.transformer.h.1.attn.c_attn'].inputs is None
+    assert torch.equal(cache['model.transformer.h.2'].output[0], cache['model.transformer.h.3'].inputs[0][0])
+
+
+@torch.no_grad()
+@pytest.mark.cache
+def test_cache_skip(gpt2: nnsight.LanguageModel, MSG_prompt: str):
+    with gpt2.trace(MSG_prompt) as tracer:
+        cache = tracer.cache().save()
+        out = gpt2.transformer.h[0].output.save()
+        gpt2.transformer.h[1].skip(gpt2.transformer.h[0].output)
+
+    assert torch.equal(cache['model.transformer.h.1'].output[0], out[0].cpu())
+
+
+@torch.no_grad()
+@pytest.mark.cache
+def test_cache_some_modules(gpt2: nnsight.LanguageModel, MSG_prompt: str):
+    with gpt2.trace(MSG_prompt) as tracer:
+        cache = tracer.cache(modules=['model.transformer.h.0', 'model.transformer.h.1', 'model.transformer.h.2']).save()
+
+    assert len(cache.keys()) == 3
+    assert torch.equal(cache['model.transformer.h.0'].output[0], cache['model.transformer.h.1'].inputs[0][0])
+
+
+@torch.no_grad()
+@pytest.mark.cache
+def test_cache_some_modules_2(gpt2: nnsight.LanguageModel, MSG_prompt: str):
+    with gpt2.trace(MSG_prompt) as tracer:
+        cache = tracer.cache(modules=[module for module in gpt2.transformer.h]).save()
+
+    assert len(cache.keys()) == 12
+    assert torch.equal(cache['model.transformer.h.0'].output[0], cache['model.transformer.h.1'].inputs[0][0])
+
+
+@torch.no_grad()
+@pytest.mark.cache
+def test_cache_some_modules_generation(gpt2: nnsight.LanguageModel, MSG_prompt: str):
+    with gpt2.generate(MSG_prompt, max_new_tokens=2) as tracer:
+        cache = tracer.cache(modules=['model.transformer.h.0', 'model.transformer.h.1', 'model.transformer.h.2']).save()
+
+    assert len(cache.keys()) == 3
+    assert len(cache['model.transformer.h.0']) == 2
+
+
+# # TODO - test this
+# @torch.no_grad()
+# @pytest.mark.cache
+# def test_cache_with_renaming(gpt2: nnsight.LanguageModel, MSG_prompt: str):
+#     with gpt2.generate(MSG_prompt, max_new_tokens=2) as tracer:
+#         cache = tracer.cache(modules=['model.transformer.h.0', 'model.transformer.h.1', 'model.transformer.h.2']).save()
+
+
+######################### PARAMETER #################################
 
 
 # def test_parameter_protocol(gpt2: nnsight.LanguageModel, MSG_prompt: str):

--- a/tests/test_vllm.py
+++ b/tests/test_vllm.py
@@ -3,17 +3,18 @@ import nnsight
 import torch
 from typing import TYPE_CHECKING
 
-pytest.skip("Skipping VLLM tests", allow_module_level=True)
+try:
+    from nnsight.modeling.vllm import VLLM
+except:
+    pytest.skip("Skipping VLLM tests", allow_module_level=True)
 
-from nnsight.tracing.backends import Backend
-from nnsight.tracing.protocols import StopProtocol
+pytest.skip("Skipping VLLM tests", allow_module_level=True)
 
 if TYPE_CHECKING:
     from nnsight.tracing.graph import Graph
 
-# try:
-#     from nnsight.modeling.vllm import VLLM
-# except:
+from nnsight.tracing.backends import Backend
+from nnsight.tracing.protocols import StopProtocol
 
 class AssertSavedLenBackend(Backend):
     

--- a/tests/test_vllm.py
+++ b/tests/test_vllm.py
@@ -3,17 +3,17 @@ import nnsight
 import torch
 from typing import TYPE_CHECKING
 
+pytest.skip("Skipping VLLM tests", allow_module_level=True)
+
 from nnsight.tracing.backends import Backend
 from nnsight.tracing.protocols import StopProtocol
 
 if TYPE_CHECKING:
     from nnsight.tracing.graph import Graph
 
-try:
-    from nnsight.modeling.vllm import VLLM
-except:
-    pytest.skip("Skipping VLLM tests", allow_module_level=True)
-
+# try:
+#     from nnsight.modeling.vllm import VLLM
+# except:
 
 class AssertSavedLenBackend(Backend):
     


### PR DESCRIPTION
Saved activations in the cache object can now be accessed with their module path from the original model.

```py
with model.trace("_") as tracer:
    cache = tracer.cache()

assert torch.equal(cache.model.transformer.h[0].mlp.output, cache["model.transformer.h.0.mlp"].output)
```