### PR TITLE
Update dict_learning.ipynb

### DIFF
--- a/docs/source/notebooks/tutorials/dict_learning.ipynb
+++ b/docs/source/notebooks/tutorials/dict_learning.ipynb
@@ -98,7 +98,7 @@
         "    !pip install -U nnsight\n",
         "    !git clone https://github.com/saprmarks/dictionary_learning\n",
         "    %cd dictionary_learning\n",
-        "    !pip install -r requirements.txt\n",
+        "    !pip install .\n",
         "clear_output()"
       ]
     },


### PR DESCRIPTION
Fixed a broken dependency caused by updates in saprmarks/dictionary_learning.

saprmarks switched from requirements.txt to pyproject.toml for dependency management. Without this change, the current notebook would fail to install circuitsvis.