### PR TITLE
Cache access w/ Alias paths

### DIFF
--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -1124,6 +1124,9 @@ def test_cache_alias(MSG_prompt: str):
 
     assert torch.equal(cache.model.transformer.h[0].output[0], cache.model.model.first_layer.output[0])
     assert torch.equal(cache.model.transformer.h[1].output[0], cache.model.model.h["second_layer"].output[0])
+
+    assert torch.equal(cache['model.model.first_layer'].output[0], cache.model.model.first_layer.output[0])
+    assert torch.equal(cache['model.model.h.second_layer'].output[0], cache.model.model.h["second_layer"].output[0])
     
 
 ######################### RENAME #################################


### PR DESCRIPTION
Improvements:

- Leading '.' is in path to rename is ignored. (e.g. `rename={".transformer", "model"}`)
- To get cache keys (paths of modules cached) with alias naming, use `cache.keys(alias=True)`