### PR TITLE
Pass through Lora Request Kwargs

### DIFF
--- a/src/nnsight/intervention/interleaver.py
+++ b/src/nnsight/intervention/interleaver.py
@@ -405,6 +405,7 @@ class Mediator:
         name: Optional[str] = None,
         batch_group: Optional[int] = 0,
         stop: Optional[int] = None,
+        custom_data: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
         Initialize a Mediator with an intervention function.
@@ -414,11 +415,13 @@ class Mediator:
             info: Information about the tracing context
             name: Optional name for the mediator
             stop: Optional number of times to execute this mediator
+            custom_data: Optional dictionary to store custom metadata
         """
         self.intervention = intervention
         self.name = name if name else f"Mediator{id(self)}"
         self.info = info
         self.batch_group = batch_group
+        self.custom_data = custom_data or {}
         self.event_queue = Queue()
         self.response_queue = Queue()
         

--- a/src/nnsight/intervention/tracing/invoker.py
+++ b/src/nnsight/intervention/tracing/invoker.py
@@ -69,10 +69,16 @@ class Invoker(Tracer):
             fn: The compiled intervention function
         """
         
-        inputs, batch_group = self.tracer.batcher.batch(self.tracer.model, *self.args, **self.kwargs)
+        # Extract request_id from kwargs before batching
+        custom_data = {}
+        filtered_kwargs = dict(self.kwargs)
+        if 'request_id' in filtered_kwargs:
+            custom_data['request_id'] = filtered_kwargs.pop('request_id')
+
+        inputs, batch_group = self.tracer.batcher.batch(self.tracer.model, *self.args, **filtered_kwargs)
 
         self.inputs = inputs
 
-        mediator = Mediator(fn, self.info, batch_group=batch_group)
+        mediator = Mediator(fn, self.info, batch_group=batch_group, custom_data=custom_data)
 
         self.tracer.mediators.append(mediator)

--- a/src/nnsight/modeling/vllm/vllm.py
+++ b/src/nnsight/modeling/vllm/vllm.py
@@ -207,6 +207,8 @@ class VLLM(RemoteableMixin):
         
         default_param = NNsightSamplingParams.from_optional()
 
+        # Extract LoRA request if present
+        lora_request = kwargs.pop('lora_request', None)
         kwargs.pop('hook', None)
         kwargs.pop('processed', None)
 
@@ -224,7 +226,7 @@ class VLLM(RemoteableMixin):
             else:
                 mediator.all_stop = max_max_tokens
         
-        output = self.vllm_entrypoint.generate(prompts, sampling_params=params)
+        output = self.vllm_entrypoint.generate(prompts, sampling_params=params, lora_request=lora_request)
         
         with self._interleaver:
             self.generator(output, hook=True)


### PR DESCRIPTION
Added support for passing through LORA Requests into vllm.trace

```python
# Test with LoRA adapter
with vllm.trace(test_prompts, temperature=0.0, max_tokens=500, lora_request=lora_request) as tracer:
    lora_results = vllm.generator.output.save()
```