### PR TITLE
Fix: normalize indentation before compile

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "accelerate",
     "toml",
     "ipython",
+    "autopep8",
     ]
 
 [project.optional-dependencies]

--- a/src/nnsight/intervention/tracing/tracer.py
+++ b/src/nnsight/intervention/tracing/tracer.py
@@ -4,6 +4,7 @@ import re
 from dataclasses import dataclass
 from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set,
                     Tuple, Union)
+from autopep8 import fix_code
 
 import torch
 from torch._subclasses.fake_tensor import FakeCopyMode, FakeTensorMode
@@ -344,7 +345,7 @@ class InterleavingTracer(Tracer):
         self.info.source = [
             f"def __nnsight_tracer_{id(self)}__(__nnsight_tracing_info__,{self.tracer_var_name}):\n",
             f"    {self.tracer_var_name}.pull()\n",
-            *self.info.source,
+            *["    " + line for line in fix_code("".join(self.info.source)).splitlines(keepends=True)],
             f"    {self.tracer_var_name}.get_frame()\n",
         ]
         


### PR DESCRIPTION
Currently, if indentation within trace context is != 4, there is an error due to the way the code is concatenated and compiled (indentation error). It may be that several users (myself included), use, for example, 2 spaces for formatting. The system is currently incompatible with any indentation scheme that is not 4 spaces. This fix would normalize the code block using `autopep8`, ensuring that the execution is indentation-agnostic.