### PR TITLE
Do Not Merge As Is (specifies RC0): Batch decode now matches decode and encode API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 description = "Package for interpreting and manipulating the internals of deep learning models."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = { text = "MIT License" }
 keywords = ["deep learning", "neural networks", "interpretability", "pytorch", "transformers"]
 
@@ -20,8 +20,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -31,8 +29,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "transformers",
-    "astor", 
+    "transformers==5.0.0rc1",
+    "astor",
     "cloudpickle",
     "python-socketio[client]",
     "pydantic>=2.9.0",

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -812,8 +812,8 @@ def test_iter(gpt2: nnsight.LanguageModel, MSG_prompt: str):
     assert len(logits_all) == 3
     assert len(logits_iter) == 3
     
-    assert gpt2.tokenizer.batch_decode(logits_all) == [" New", " York", " City"]
-    assert gpt2.tokenizer.batch_decode(logits_iter) == [" New", " York", " City"]
+    assert gpt2.tokenizer.batch_decode(logits_all) == [" New York City"]
+    assert gpt2.tokenizer.batch_decode(logits_iter) == [" New York City"]
 
 
 @torch.no_grad()
@@ -827,7 +827,7 @@ def test_iter_slice(gpt2: nnsight.LanguageModel, MSG_prompt: str):
             logits.append(gpt2.lm_head.output[0][-1].argmax(dim=-1))
 
     assert len(logits) == 2
-    assert gpt2.tokenizer.batch_decode(logits) == [" York", " City"]
+    assert gpt2.tokenizer.batch_decode(logits) == [" York City"]
 
 
 @torch.no_grad()
@@ -885,8 +885,8 @@ def test_batched_iter(gpt2: nnsight.LanguageModel, MSG_prompt: str):
     assert len(logits_1) == 2
     assert len(logits_2) == 3
 
-    assert gpt2.tokenizer.batch_decode(logits_1) == [" York", " City"]
-    assert gpt2.tokenizer.batch_decode(logits_2) == [" New", " York", " City"]
+    assert gpt2.tokenizer.batch_decode(logits_1) == [" York City"]
+    assert gpt2.tokenizer.batch_decode(logits_2) == [" New York City"]
 
 
 @torch.no_grad()


### PR DESCRIPTION
As you can see, the decoder API has changed in Transformers V5, while this doesn't break *our behavior* it means our batch decoder behavior tests did fail, and users will need to know about this breaking change - via the new Transformers decode API.

From their docs:
-------

<img width="794" height="739" alt="image" src="https://github.com/user-attachments/assets/dd138f0b-c11c-4955-833a-d97150cd07b5" />