### PR TITLE
Delete note on iterative .source access in NNsight.md

### DIFF
--- a/NNsight.md
+++ b/NNsight.md
@@ -884,8 +884,6 @@ You can trace into nested function calls:
 model.transformer.h[0].attn.source.attention_interface_0.source.some_inner_op.output
 ```
 
-**Note:** Don't use `.source` on a submodule from within another `.source`. Access the submodule directly instead.
-
 ---
 
 ### 4.4 Method Delegation and Tracing


### PR DESCRIPTION
Removed note saying that using .source recursively is not allowed.