### PR TITLE
fix(typing): correct _prepare_input type annotations in LanguageModel

### DIFF
--- a/src/nnsight/modeling/language.py
+++ b/src/nnsight/modeling/language.py
@@ -207,18 +207,16 @@ class LanguageModel(TransformersModel):
 
     def _prepare_input(
         self,
-        *inputs: Tuple[
-            Union[
-                str,
-                List[str],
-                List[List[str]],
-                List[int],
-                List[List[int]],
-                torch.Tensor,
-                List[torch.Tensor],
-                Dict[str, Any],
-                BatchEncoding,
-            ]
+        *inputs: Union[
+            str,
+            List[str],
+            List[List[str]],
+            List[int],
+            List[List[int]],
+            torch.Tensor,
+            List[torch.Tensor],
+            Dict[str, Any],
+            BatchEncoding,
         ],
         input_ids: Union[
             List[int], List[List[int]], torch.Tensor, List[torch.Tensor]
@@ -226,7 +224,7 @@ class LanguageModel(TransformersModel):
         labels: Any = None,
         attention_mask: Any = None,
         **kwargs,
-    ) -> Tuple[BatchEncoding, int]:
+    ) -> Tuple[Tuple[()], Dict[str, Any]]:
         
         if input_ids is not None:
 


### PR DESCRIPTION
## Summary
- Remove erroneous `Tuple` wrapper around `*inputs` parameter (each positional arg should be typed as `Union[...]`, not `Tuple[Union[...]]`)
- Fix return type annotation to match actual return value: `Tuple[Tuple[()], Dict[str, Any]]` instead of `Tuple[BatchEncoding, int]`

## Test plan
- Type checking should pass without errors on this method

🤖 Generated with [Claude Code](https://claude.com/claude-code)