### PR TITLE
Fix #608: Add validation for empty tokenized input in LanguageModel.trace()

### DIFF
--- a/src/nnsight/modeling/language.py
+++ b/src/nnsight/modeling/language.py
@@ -300,6 +300,16 @@ class LanguageModel(TransformersModel):
         if attention_mask is not None:
             inputs["attention_mask"] = attention_mask
 
+        tokenized_input_ids = inputs.get("input_ids", None)
+        if (
+            isinstance(tokenized_input_ids, torch.Tensor)
+            and tokenized_input_ids.shape[-1] == 0
+        ):
+            raise ValueError(
+                "Input produced zero tokens after tokenization. "
+                "Pass a non-empty prompt or non-empty `input_ids`."
+            )
+
         return (
             tuple(),
             {**inputs, "labels": labels, **remaining_kwargs},

--- a/tests/test_0516_features.py
+++ b/tests/test_0516_features.py
@@ -195,3 +195,9 @@ class TestExceptionHandling:
             with gpt2.trace("Hello world"):
                 # 'nonexistent' attribute doesn't exist
                 output = gpt2.transformer.nonexistent.output.save()
+
+    def test_empty_prompt_error_message(self, gpt2: nnsight.LanguageModel):
+        """Test that empty prompts raise an actionable error."""
+        with pytest.raises(ValueError, match="zero tokens"):
+            with gpt2.trace(""):
+                hidden = gpt2.transformer.h[0].output[0].save()


### PR DESCRIPTION
Closes #608

Add an early validation in `LanguageModel._prepare_input` to catch cases where tokenization produces zero tokens (e.g. trace("")) and raise a clear ValueError.

Also add a regression test:
- tests/test_0516_features.py::TestExceptionHandling::test_empty_prompt_error_message