### PR TITLE
Fix get_non_nnsight_frame failing on macOS by checking module name in…

### DIFF
--- a/src/nnsight/intervention/tracing/util.py
+++ b/src/nnsight/intervention/tracing/util.py
@@ -330,11 +330,9 @@ def get_non_nnsight_frame() -> FrameType:
     while frame:
         frame = frame.f_back
         if frame:
-            # Match if filename contains 'nnsight/tests' or 'nnsight\tests'
-            # OR if it does NOT contain '/nnsight/' or '\nnsight\'
-
-            norm = frame.f_code.co_filename.replace("\\", "/")
-            if "/nnsight/tests" in norm or "/nnsight/" not in norm:
+            module = frame.f_globals.get("__name__", "")
+            is_nnsight = module == "nnsight" or module.startswith("nnsight.")
+            if not is_nnsight or module.startswith("nnsight.tests"):
                 break
 
     return frame


### PR DESCRIPTION
…stead of file path

The previous implementation used filename substring matching ("/nnsight/" in path) to identify nnsight-internal frames, which could fail when users had "nnsight" in their directory path or when OS-specific path resolution differed (e.g. macOS symlinks).

Now checks frame.f_globals["__name__"] against the nnsight package namespace, which is set by the Python import system and is path/OS independent.

Fixes #604