### PR TITLE
Fix CacheDict RecursionError during unpickling (#501)

### DIFF
--- a/src/nnsight/intervention/tracing/tracer.py
+++ b/src/nnsight/intervention/tracing/tracer.py
@@ -160,6 +160,13 @@ class Cache:
             return dict.__getitem__(self, key)
 
         def __getattr__(self, attr: str):
+            # Guard against access during unpickling: pickle uses __new__
+            # (skipping __init__) then restores state, so _path may not
+            # exist yet when __getattr__ is called.  Without this guard
+            # torch.load() triggers infinite recursion (issue #501).
+            if attr == "_path":
+                raise AttributeError(attr)
+
             path = self._path + "." + attr if self._path != "" else attr
 
             if any(key.startswith(path) for key in self):


### PR DESCRIPTION
## Summary
- Guard `CacheDict.__getattr__` against access during unpickling, fixing the `RecursionError` reported in #501

## Root Cause

When NDIF returns remote execution results, `_decompress_and_load()` deserializes them via `torch.load()`. Pickle reconstructs `CacheDict` using `__new__` (skipping `__init__`), then restores the dict state. During this process, `__getattr__` is called before `_path` is initialized. Since `__getattr__` accesses `self._path` on its first line, this triggers another `__getattr__` call → infinite recursion.

## Fix

Add a guard at the top of `__getattr__`:

```python
if attr == "_path":
    raise AttributeError(attr)
```

This lets pickle fall back to normal attribute resolution via `__dict__`, which works correctly once `__init__` has run.

## Verification

Isolated reproduction confirms the fix:

```python
import pickle, io

# Simulated CacheDict (dict subclass with __getattr__ accessing self._path)
class CacheDictBroken(dict):
    def __init__(self, data, path=''):
        self._path = path
        super().__init__(data)
    def __getattr__(self, attr):
        path = self._path + '.' + attr  # RecursionError here during unpickle
        raise AttributeError(attr)

cd = CacheDictBroken({'k': 'v'}, path='test')
buf = io.BytesIO()
pickle.dump(cd, buf)
buf.seek(0)
pickle.load(buf)  # RecursionError!

# With guard: succeeds
```

## Test plan
- [x] Isolated pickle round-trip confirms fix resolves RecursionError
- [x] Downstream project (lmprobe) verified remote extraction works with this fix on nnsight 0.6.0 and 0.6.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)