### PR TITLE
Fix RecursionError in Envoy overloaded mount handling for modules with child named output

### DIFF
--- a/src/nnsight/intervention/envoy.py
+++ b/src/nnsight/intervention/envoy.py
@@ -866,7 +866,7 @@ class Envoy(Batchable):
                 {},
             )
 
-            self.__class__ = new_cls
+            object.__setattr__(self, "__class__", new_cls)
 
         # Get the normal proxy mount point
         mount = getattr(Envoy, mount_point)

--- a/tests/test_multiple_wrappers.py
+++ b/tests/test_multiple_wrappers.py
@@ -326,3 +326,15 @@ class TestMultipleWrapperEdgeCases:
 
         # Gradients should be the same
         assert torch.allclose(grad1, grad2)
+
+    def test_bert_wrapper_construction_with_output_modules(self):
+        from transformers import BertConfig, BertForMaskedLM
+
+        with pytest.warns(UserWarning, match="pre-defined a `output` attribute"):
+            wrapper = NNsight(BertForMaskedLM(BertConfig()))
+
+        assert (
+            wrapper.bert.encoder.layer[0].output.path
+            == "model.bert.encoder.layer.0.output"
+        )
+        assert hasattr(type(wrapper.bert.encoder.layer[0]), "nns_output")


### PR DESCRIPTION
### Summary

This fixes a constructor-time `RecursionError` when wrapping models that contain child module names colliding with `Envoy` mount points such as `output`.

### Linked issue

The issue is detailed in #627 

### Root cause

`Envoy._handle_overloaded_mount()` dynamically creates a Preserved subclass and currently reassigns the instance class with:
```python
self.__class__ = new_cls
```

However, `Envoy.__setattr__` is overloaded and may forward attribute assignments to the wrapped torch module. In this path, the class reassignment does not behave like a normal Python instance-level `__class__` update and can corrupt the wrapped module state.

That eventually causes recursive attribute access during envoy mounting / error formatting, resulting in a `RecursionError`.

### Fix

Use raw object-level assignment for the class update inside `_handle_overloaded_mount`, so the reassignment is applied to the Envoy instance itself and does not go through `Envoy.__setattr__`.

This preserves the existing overloaded-mount behavior while avoiding the recursive failure.

### Commits

This PR first reproduces the bug in a minimal test in 4860de946afc57b8872aa63f2134b28dd3fca5f6, then fixes it in 11458e460c899024cfb38eb7c3745dd5613b5649 with a one-line change.

### Contributing

I have read the `contributing.md` file and confirm that the tests pass.

This has been mainly driven by GPT-5.4, but I cross-checked every step.