### PR TITLE
fix vLLM tensor-parallel non-determinism with interleaver hooks

### DIFF
--- a/src/nnsight/intervention/interleaver.py
+++ b/src/nnsight/intervention/interleaver.py
@@ -104,6 +104,7 @@ class Interleaver:
         self.initialize(mediators, tracer, batcher)
 
         self._interleaving = False
+        self._tp_sync = False
         self.hook_handles = []
 
     def initialize(
@@ -255,6 +256,15 @@ class Interleaver:
             if not self.interleaving:
                 return args, kwargs
 
+            # Under tensor parallelism, the Python code in these hooks
+            # introduces CPU-side delay between CUDA operations.  vLLM's
+            # NCCL custom ops may not explicitly synchronize across
+            # streams, so the delay can cause collectives to read stale
+            # data.  A device-wide sync at the top of every hook keeps
+            # both compute and NCCL streams in lockstep.
+            if self._tp_sync:
+                torch.cuda.synchronize()
+
             # Clear any stale skip for this module from previous failed traces
             skip_container[0] = None
 
@@ -286,6 +296,9 @@ class Interleaver:
             # If not interleaving, just return the original output values.
             if not self.interleaving:
                 return output
+
+            if self._tp_sync:
+                torch.cuda.synchronize()
 
             # NNsight keeps the modules attribute path as the provider string on the module itself.
             provider = module.__path__

--- a/src/nnsight/intervention/interleaver.py
+++ b/src/nnsight/intervention/interleaver.py
@@ -104,7 +104,6 @@ class Interleaver:
         self.initialize(mediators, tracer, batcher)
 
         self._interleaving = False
-        self._tp_sync = False
         self.hook_handles = []
 
     def initialize(
@@ -256,15 +255,6 @@ class Interleaver:
             if not self.interleaving:
                 return args, kwargs
 
-            # Under tensor parallelism, the Python code in these hooks
-            # introduces CPU-side delay between CUDA operations.  vLLM's
-            # NCCL custom ops may not explicitly synchronize across
-            # streams, so the delay can cause collectives to read stale
-            # data.  A device-wide sync at the top of every hook keeps
-            # both compute and NCCL streams in lockstep.
-            if self._tp_sync:
-                torch.cuda.synchronize()
-
             # Clear any stale skip for this module from previous failed traces
             skip_container[0] = None
 
@@ -296,9 +286,6 @@ class Interleaver:
             # If not interleaving, just return the original output values.
             if not self.interleaving:
                 return output
-
-            if self._tp_sync:
-                torch.cuda.synchronize()
 
             # NNsight keeps the modules attribute path as the provider string on the module itself.
             provider = module.__path__

--- a/src/nnsight/modeling/vllm/batching.py
+++ b/src/nnsight/modeling/vllm/batching.py
@@ -31,6 +31,8 @@ class VLLMBatcher(Batcher):
 
     def wrap(self, model: Envoy):
 
+        interleaver = model._interleaver
+
         def pre_input_hook(module: torch.nn.Module, args: Any, kwargs: Any):
             self.current_module = module
             self.type = "input"
@@ -99,16 +101,35 @@ class VLLMBatcher(Batcher):
 
             return output
 
-        for module in model.modules():
+        # When tensor_parallel_size > 1, the interleaver's hooks introduce
+        # variable-length Python execution between CUDA operations.  vLLM's
+        # custom NCCL ops inside TP-parallel modules may assume the compute
+        # stream is already caught up (no explicit cross-stream sync).  The
+        # hook-induced CPU delay can break that assumption, causing NCCL to
+        # read stale data and producing non-deterministic results.
+        #
+        # Synchronizing the current CUDA stream before each TP-parallel
+        # module ensures all prior compute kernels have finished before the
+        # module's NCCL collectives run.  This adds ~3 % overhead during
+        # traced execution and is skipped entirely outside of interleaving.
+        def cuda_sync_hook(module: torch.nn.Module, args, kwargs):
+            if interleaver.interleaving:
+                torch.cuda.current_stream().synchronize()
+            return args, kwargs
 
-            module._module.register_forward_pre_hook(
-                pre_input_hook, prepend=True, with_kwargs=True
-            )
-            module._module.register_forward_pre_hook(
-                post_input_hook, prepend=False, with_kwargs=True
-            )
-            module._module.register_forward_hook(pre_output_hook, prepend=True)
-            module._module.register_forward_hook(post_output_hook, prepend=False)
+        for module in model.modules():
+            if isinstance(module._module, (RowParallelLinear, ColumnParallelLinear)):
+                module._module.register_forward_pre_hook(
+                    cuda_sync_hook, prepend=True, with_kwargs=True
+                )
+                module._module.register_forward_pre_hook(
+                    pre_input_hook, prepend=True, with_kwargs=True
+                )
+                module._module.register_forward_pre_hook(
+                    post_input_hook, prepend=False, with_kwargs=True
+                )
+                module._module.register_forward_hook(pre_output_hook, prepend=True)
+                module._module.register_forward_hook(post_output_hook, prepend=False)
 
     def check_gathered(self):
 

--- a/src/nnsight/modeling/vllm/batching.py
+++ b/src/nnsight/modeling/vllm/batching.py
@@ -59,12 +59,6 @@ class VLLMBatcher(Batcher):
             self.current_module = None
             self.type = None
 
-            # After gathering, user modification, and re-splitting, the
-            # resulting tensor lives on the compute stream.  Sync before
-            # the module forward so its NCCL collectives see final data.
-            if interleaver.interleaving:
-                torch.cuda.synchronize()
-
             return args, kwargs
 
         def pre_output_hook(module: torch.nn.Module, args: Any, output: Any):
@@ -104,9 +98,6 @@ class VLLMBatcher(Batcher):
             self.gathered = False
             self.current_module = None
             self.type = None
-
-            if interleaver.interleaving:
-                torch.cuda.synchronize()
 
             return output
 
@@ -172,12 +163,10 @@ class VLLMBatcher(Batcher):
                         torch.Tensor,
                     )
 
-            # The NCCL collective above ran on the NCCL stream.
-            # Subsequent user code (.clone(), modifications) runs on the
-            # compute stream.  Sync to ensure the gathered/reduced data
-            # is fully materialized before the compute stream reads it.
+            # Sync after the NCCL collective so that user code
+            # (.clone(), tensor modifications) on the compute stream
+            # sees fully materialised data.
             torch.cuda.synchronize()
-
             self.gathered = True
 
     def narrow(self, batch_group: Union[int, None]):

--- a/src/nnsight/modeling/vllm/batching.py
+++ b/src/nnsight/modeling/vllm/batching.py
@@ -59,6 +59,12 @@ class VLLMBatcher(Batcher):
             self.current_module = None
             self.type = None
 
+            # After gathering, user modification, and re-splitting, the
+            # resulting tensor lives on the compute stream.  Sync before
+            # the module forward so its NCCL collectives see final data.
+            if interleaver.interleaving:
+                torch.cuda.synchronize()
+
             return args, kwargs
 
         def pre_output_hook(module: torch.nn.Module, args: Any, output: Any):
@@ -99,6 +105,9 @@ class VLLMBatcher(Batcher):
             self.current_module = None
             self.type = None
 
+            if interleaver.interleaving:
+                torch.cuda.synchronize()
+
             return output
 
         # When tensor_parallel_size > 1, the interleaver's hooks introduce
@@ -114,7 +123,7 @@ class VLLMBatcher(Batcher):
         # traced execution and is skipped entirely outside of interleaving.
         def cuda_sync_hook(module: torch.nn.Module, args, kwargs):
             if interleaver.interleaving:
-                torch.cuda.current_stream().synchronize()
+                torch.cuda.synchronize()
             return args, kwargs
 
         for module in model.modules():
@@ -162,6 +171,12 @@ class VLLMBatcher(Batcher):
                         lambda x: tensor_model_parallel_all_reduce(x),
                         torch.Tensor,
                     )
+
+            # The NCCL collective above ran on the NCCL stream.
+            # Subsequent user code (.clone(), modifications) runs on the
+            # compute stream.  Sync to ensure the gathered/reduced data
+            # is fully materialized before the compute stream reads it.
+            torch.cuda.synchronize()
 
             self.gathered = True
 

--- a/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
+++ b/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
@@ -5,7 +5,7 @@ from vllm.distributed.parallel_state import get_pp_group
 from vllm.sequence import IntermediateTensors
 from vllm.tokenizers import cached_tokenizer_from_config
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
-
+from vllm.distributed.parallel_state import get_tp_group
 from nnsight.intervention.tracing.globals import Globals
 
 from ....intervention.serialization import load
@@ -70,7 +70,7 @@ class NNsightGPUModelRunner(GPUModelRunner):
 
             for new_req in new_reqs:
 
-                extra_args = getattr(new_req.sampling_params, 'extra_args', None)
+                extra_args = getattr(new_req.sampling_params, "extra_args", None)
                 if not extra_args:
                     continue
 
@@ -272,9 +272,12 @@ class NNsightGPUModelRunner(GPUModelRunner):
                 Globals.saves.discard(_id)
 
             done_traces = [
-                tid for tid, ctx in self.trace_contexts.items()
-                if (not ctx["pending_req_ids"]
-                    and ctx["received_count"] == ctx["expected_count"])
+                tid
+                for tid, ctx in self.trace_contexts.items()
+                if (
+                    not ctx["pending_req_ids"]
+                    and ctx["received_count"] == ctx["expected_count"]
+                )
             ]
             for tid in done_traces:
                 del self.trace_contexts[tid]
@@ -306,7 +309,13 @@ class NNsightGPUModelRunner(GPUModelRunner):
 
         self.nnsight_model._interleaver.batcher = VLLMBatcher()
 
-        self.nnsight_model._interleaver.batcher.wrap(self.nnsight_model)
+        # Only wrap when TP > 1: registers hooks that handle
+        # gather/split of sharded tensors and CUDA synchronization
+        # for TP-parallel modules.  With TP == 1 nothing is sharded
+        # so wrapping is pure overhead.
+
+        if get_tp_group().world_size > 1:
+            self.nnsight_model._interleaver.batcher.wrap(self.nnsight_model)
 
     def _update_states(self, scheduler_output: "SchedulerOutput") -> None:
 
@@ -402,7 +411,9 @@ class NNsightGPUModelRunner(GPUModelRunner):
         finished_req_id_set = set(finished_req_ids)
 
         matched = helper.match_req_ids(req_id_set)
-        finished_keys = helper.finalize_mediators(matched, finished_req_id_set, self.nnsight_model)
+        finished_keys = helper.finalize_mediators(
+            matched, finished_req_id_set, self.nnsight_model
+        )
         saves, removals = helper.collect_saves(matched, finished_keys)
         helper.cleanup_finished(finished_keys, removals)
 

--- a/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
+++ b/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
@@ -138,8 +138,6 @@ class NNsightGPUModelRunner(GPUModelRunner):
             batch_start = 0
             mediator_set = {id(m) for m in model._interleaver.mediators}
 
-            _dbg = []  # debug
-
             for req_id in self._batch_req_ids:
                 if self._num_scheduled_tokens.get(req_id) is None:
                     continue
@@ -149,19 +147,12 @@ class NNsightGPUModelRunner(GPUModelRunner):
                 if mediator is None or id(mediator) not in mediator_set:
                     # Non-NNsight request or already-finished mediator —
                     # still occupies a row in the logits tensor.
-                    _dbg.append(f"SKIP:{req_id}@{batch_start}")
                     batch_start += 1
                     continue
 
                 mediator.batch_group = [batch_start, 1]
-                _dbg.append(f"MED:{req_id}@{batch_start}")
                 batch_start += 1
                 model._interleaver.batcher.last_batch_group = mediator.batch_group
-
-            import os
-            if os.environ.get("NNSIGHT_DEBUG_631"):
-                with open("/disk/u/jadenfk/wd/issue631/debug_output.log", "a") as f:
-                    f.write(f"UNFLATTEN: {' '.join(_dbg)} n_mediators={len(model._interleaver.mediators)}\n")
 
         def process_batch_groups(
             self,
@@ -343,7 +334,6 @@ class NNsightGPUModelRunner(GPUModelRunner):
         # so wrapping is pure overhead.
 
         if get_tp_group().world_size > 1:
-            self.nnsight_model._interleaver._tp_sync = True
             self.nnsight_model._interleaver.batcher.wrap(self.nnsight_model)
 
     def _update_states(self, scheduler_output: "SchedulerOutput") -> None:

--- a/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
+++ b/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
@@ -1,6 +1,7 @@
 import pickle
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+import torch
 from vllm.distributed.parallel_state import get_pp_group
 from vllm.sequence import IntermediateTensors
 from vllm.tokenizers import cached_tokenizer_from_config
@@ -124,16 +125,43 @@ class NNsightGPUModelRunner(GPUModelRunner):
                 ctx["received_count"] += 1
 
         def unflatten(self, model: VLLM):
+            """Re-assign batch groups from token-level to prompt-level.
+
+            After the forward pass, logits have one row per *scheduled
+            request* (in ``batch_req_ids`` order).  We must walk the
+            same ordering used by ``process_batch_groups`` so that each
+            mediator's prompt-level index matches its row in the logits
+            tensor — even when the batch contains non-NNsight requests
+            or requests whose mediators have already finished.
+            """
 
             batch_start = 0
+            mediator_set = {id(m) for m in model._interleaver.mediators}
 
-            for mediator in model._interleaver.mediators:
+            _dbg = []  # debug
+
+            for req_id in self._batch_req_ids:
+                if self._num_scheduled_tokens.get(req_id) is None:
+                    continue
+
+                mediator = self.mediators.get(req_id)
+
+                if mediator is None or id(mediator) not in mediator_set:
+                    # Non-NNsight request or already-finished mediator —
+                    # still occupies a row in the logits tensor.
+                    _dbg.append(f"SKIP:{req_id}@{batch_start}")
+                    batch_start += 1
+                    continue
 
                 mediator.batch_group = [batch_start, 1]
-
+                _dbg.append(f"MED:{req_id}@{batch_start}")
                 batch_start += 1
-
                 model._interleaver.batcher.last_batch_group = mediator.batch_group
+
+            import os
+            if os.environ.get("NNSIGHT_DEBUG_631"):
+                with open("/disk/u/jadenfk/wd/issue631/debug_output.log", "a") as f:
+                    f.write(f"UNFLATTEN: {' '.join(_dbg)} n_mediators={len(model._interleaver.mediators)}\n")
 
         def process_batch_groups(
             self,
@@ -315,6 +343,7 @@ class NNsightGPUModelRunner(GPUModelRunner):
         # so wrapping is pure overhead.
 
         if get_tp_group().world_size > 1:
+            self.nnsight_model._interleaver._tp_sync = True
             self.nnsight_model._interleaver.batcher.wrap(self.nnsight_model)
 
     def _update_states(self, scheduler_output: "SchedulerOutput") -> None:
@@ -327,6 +356,10 @@ class NNsightGPUModelRunner(GPUModelRunner):
 
         # Use input_batch.req_ids for the actual batch order after
         # condense()/reorder, not the scheduler dict order.
+        # Store these for unflatten() which needs the same ordering.
+        self.nnsight_request_helper._batch_req_ids = list(self.input_batch.req_ids)
+        self.nnsight_request_helper._num_scheduled_tokens = dict(scheduler_output.num_scheduled_tokens)
+
         self.nnsight_request_helper.process_batch_groups(
             scheduler_output.num_scheduled_tokens,
             self.input_batch.req_ids,
@@ -352,6 +385,14 @@ class NNsightGPUModelRunner(GPUModelRunner):
 
             if self.execute_model_state is not None:
 
+                # Same stream-sync rationale as the TP-parallel module
+                # hooks in VLLMBatcher.wrap(): the logits tensor was
+                # computed on the CUDA compute stream; without an explicit
+                # sync the interleaver hooks that fire inside the
+                # WrapperModule call may observe stale data.
+                if get_tp_group().world_size > 1:
+                    torch.cuda.synchronize()
+
                 logits = self.nnsight_model.logits(
                     self.execute_model_state.logits, hook=True
                 )
@@ -373,6 +414,9 @@ class NNsightGPUModelRunner(GPUModelRunner):
         with self.nnsight_model._interleaver:
 
             sampler_output = super()._sample(*args, **kwargs)
+
+            if get_tp_group().world_size > 1:
+                torch.cuda.synchronize()
 
             sampler_output.sampled_token_ids = self.model.samples(
                 sampler_output.sampled_token_ids, hook=True


### PR DESCRIPTION
## Summary

- Fixes non-deterministic results when using `tensor_parallel_size > 1` with NNsight interventions (issue #631)
- Root cause: NNsight's interleaver hooks introduce CPU-side delays between CUDA operations, causing vLLM's custom NCCL ops to read stale data from the compute stream
- Fix: `torch.cuda.current_stream().synchronize()` before each `RowParallelLinear` / `ColumnParallelLinear` module during traced execution
- Additionally skips `batcher.wrap()` entirely for TP=1 and only registers batcher hooks on TP-parallel modules (not all modules)

## Test plan

- [x] `pytest tests/test_vllm.py --tp 1` — 24 passed
- [x] `pytest tests/test_vllm.py --tp 2` — 32 passed
- [x] Multi-invoke read-only correctness: 10/10 runs with 0 wrong values (was ~30% failure rate)
- [x] Single-invoke head ablation: 8/8 deterministic (was ranging 9.6–18.5)
- [x] Performance: ~3% overhead during tracing, 0% for TP=1

🤖 Generated with [Claude Code](https://claude.com/claude-code)