### PR TITLE
Preserve original line numbers in deserialized function tracebacks

### DIFF
--- a/src/nnsight/intervention/serialization.py
+++ b/src/nnsight/intervention/serialization.py
@@ -37,6 +37,7 @@ import dataclasses
 import inspect
 import io
 import linecache
+import os
 import pickle
 import textwrap
 import tokenize
@@ -74,7 +75,7 @@ def _register_source_with_linecache(filename: Optional[str], source: str) -> Non
     if not filename:
         return
 
-    if linecache.getlines(filename):
+    if os.path.isfile(filename):
         return
 
     lines = source.splitlines(keepends=True)

--- a/src/nnsight/intervention/serialization.py
+++ b/src/nnsight/intervention/serialization.py
@@ -42,7 +42,6 @@ import pickle
 import textwrap
 import tokenize
 import types
-import uuid
 from pathlib import Path
 from typing import Any, BinaryIO, Optional, Union
 
@@ -71,8 +70,16 @@ _DATACLASS_GENERATED_METHODS = frozenset(
 DEFAULT_PROTOCOL = 4
 
 
-def _register_source_with_linecache(filename: Optional[str], source: str) -> None:
-    """Register reconstructed source so inspect can recover it by filename."""
+def _register_source_with_linecache(
+    filename: Optional[str], source: str, firstlineno: int = 1
+) -> None:
+    """Register reconstructed source so inspect can recover it by filename.
+
+    Places the source lines at the correct offset (``firstlineno``) so that
+    ``inspect.getsourcelines`` finds the function at the right line number.
+    When multiple functions from the same file are deserialized, their source
+    lines are merged into a single linecache entry at their respective offsets.
+    """
     if not filename:
         return
 
@@ -83,7 +90,24 @@ def _register_source_with_linecache(filename: Optional[str], source: str) -> Non
     if lines and not lines[-1].endswith("\n"):
         lines[-1] += "\n"
 
-    linecache.cache[filename] = (len(source), None, lines, filename)
+    end_line = firstlineno - 1 + len(lines)
+
+    if filename in linecache.cache:
+        # Merge: place lines at correct offset in existing entry
+        existing = list(linecache.cache[filename][2])
+        while len(existing) < end_line:
+            existing.append("\n")
+        for i, line in enumerate(lines):
+            existing[firstlineno - 1 + i] = line
+        linecache.cache[filename] = (
+            sum(len(l) for l in existing), None, existing, filename
+        )
+    else:
+        # New entry: pad with blank lines to preserve original line numbers
+        padded = ["\n"] * (firstlineno - 1) + lines
+        linecache.cache[filename] = (
+            sum(len(l) for l in padded), None, padded, filename
+        )
 
 
 def _extract_lambda_source(source: str, code: types.CodeType) -> str:
@@ -442,6 +466,7 @@ def make_function(
     base_globals: dict,
     closure_values: Optional[list],
     closure_names: Optional[list],
+    firstlineno: int = 1,
 ) -> types.FunctionType:
     """Reconstruct a function from its serialized source code and metadata.
 
@@ -471,6 +496,8 @@ def make_function(
         closure_values: List of closure variable values (passed immediately, not
             deferred, because closures need factory pattern to bind properly).
         closure_names: List of closure variable names (co_freevars).
+        firstlineno: The original co_firstlineno of the function. Used to
+            preserve correct line numbers in tracebacks and linecache.
 
     Returns:
         A newly constructed function object. Note: the globals are minimal
@@ -481,15 +508,10 @@ def make_function(
     """
     # Remove any leading indentation (e.g., if function was defined inside a class)
     source = textwrap.dedent(source)
-    linecache_source = source
 
     # Set up the global namespace for the reconstructed function.
     # This is a minimal globals dict - full globals are added by _source_function_setstate.
     func_globals = {"__builtins__": __builtins__, **base_globals}
-
-    if filename is not None and not filename.startswith("<"):
-
-        filename = f"{uuid.uuid4().hex[:8]} {filename}"
 
     if closure_values and closure_names:
         # CLOSURE HANDLING: Functions with closures require special treatment.
@@ -520,8 +542,6 @@ def make_function(
             indented_source = textwrap.indent(source, "    ")
             factory_source += indented_source + "\n"
             factory_source += f"    return {name}\n"
-
-        linecache_source = factory_source
 
         # Compile and execute the factory, then call it with closure values
         try:
@@ -577,10 +597,15 @@ def make_function(
     func.__doc__ = doc
     func.__qualname__ = qualname
 
+    # Restore original co_firstlineno so tracebacks and inspect show correct
+    # line numbers relative to the original source file.
+    if firstlineno > 1:
+        func.__code__ = func.__code__.replace(co_firstlineno=firstlineno)
+
     # Attach original source for re-serialization (inspect.getsource won't work
     # because line numbers don't match the original file)
     func.__source__ = source
-    _register_source_with_linecache(filename, linecache_source)
+    _register_source_with_linecache(filename, source, firstlineno)
 
     return func
 
@@ -783,6 +808,7 @@ class CustomCloudPickler(cloudpickle.Pickler):
         kwdefaults = slotstate["__kwdefaults__"]
         annotations = slotstate["__annotations__"]
         filename = func.__code__.co_filename
+        firstlineno = func.__code__.co_firstlineno
         qualname = slotstate["__qualname__"]
         module_name = slotstate["__module__"]
         doc = slotstate["__doc__"]
@@ -852,6 +878,7 @@ class CustomCloudPickler(cloudpickle.Pickler):
             base_globals,
             closure_values,
             closure_names,
+            firstlineno,
         )
 
         # Return 6-tuple: (func, args, state, listitems, dictitems, state_setter)

--- a/src/nnsight/intervention/serialization.py
+++ b/src/nnsight/intervention/serialization.py
@@ -42,6 +42,7 @@ import pickle
 import textwrap
 import tokenize
 import types
+import uuid
 from pathlib import Path
 from typing import Any, BinaryIO, Optional, Union
 
@@ -485,6 +486,10 @@ def make_function(
     # Set up the global namespace for the reconstructed function.
     # This is a minimal globals dict - full globals are added by _source_function_setstate.
     func_globals = {"__builtins__": __builtins__, **base_globals}
+
+    if filename is not None and not filename.startswith("<"):
+
+        filename = f"{uuid.uuid4().hex[:8]} {filename}"
 
     if closure_values and closure_names:
         # CLOSURE HANDLING: Functions with closures require special treatment.

--- a/src/nnsight/intervention/serialization.py
+++ b/src/nnsight/intervention/serialization.py
@@ -36,6 +36,7 @@ Examples:
 import dataclasses
 import inspect
 import io
+import linecache
 import pickle
 import textwrap
 import tokenize
@@ -66,6 +67,21 @@ _DATACLASS_GENERATED_METHODS = frozenset(
 
 # Default pickle protocol - protocol 4 is available in Python 3.4+ and supports large objects
 DEFAULT_PROTOCOL = 4
+
+
+def _register_source_with_linecache(filename: Optional[str], source: str) -> None:
+    """Register reconstructed source so inspect can recover it by filename."""
+    if not filename:
+        return
+
+    if linecache.getlines(filename):
+        return
+
+    lines = source.splitlines(keepends=True)
+    if lines and not lines[-1].endswith("\n"):
+        lines[-1] += "\n"
+
+    linecache.cache[filename] = (len(source), None, lines, filename)
 
 
 def _extract_lambda_source(source: str, code: types.CodeType) -> str:
@@ -463,6 +479,7 @@ def make_function(
     """
     # Remove any leading indentation (e.g., if function was defined inside a class)
     source = textwrap.dedent(source)
+    linecache_source = source
 
     # Set up the global namespace for the reconstructed function.
     # This is a minimal globals dict - full globals are added by _source_function_setstate.
@@ -497,6 +514,8 @@ def make_function(
             indented_source = textwrap.indent(source, "    ")
             factory_source += indented_source + "\n"
             factory_source += f"    return {name}\n"
+
+        linecache_source = factory_source
 
         # Compile and execute the factory, then call it with closure values
         try:
@@ -555,6 +574,7 @@ def make_function(
     # Attach original source for re-serialization (inspect.getsource won't work
     # because line numbers don't match the original file)
     func.__source__ = source
+    _register_source_with_linecache(filename, linecache_source)
 
     return func
 

--- a/tests/test_serialization_edge_cases.py
+++ b/tests/test_serialization_edge_cases.py
@@ -9,12 +9,45 @@ Run with: pytest tests/test_serialization_edge_cases.py -v
 """
 
 import sys
+import linecache
+import textwrap
 import pytest
 import torch
 
 sys.path.insert(0, "tests")
 
 from nnsight.intervention.serialization import dumps, loads
+
+
+def test_deserialized_helper_trace_uses_registered_linecache(tiny_model, tmp_path):
+    """Nested traces should work after helper functions are deserialized."""
+    filename = str(tmp_path / "missing_remote_helper.py")
+    source = textwrap.dedent(
+        """\
+        def helper(model, prompt):
+            with model.trace(prompt):
+                pass
+        """
+    )
+
+    expected_lines = source.splitlines(keepends=True)
+    namespace = {}
+    linecache.cache[filename] = (
+        len(source),
+        None,
+        expected_lines,
+        filename,
+    )
+    exec(compile(source, filename, "exec"), namespace)
+    helper = namespace["helper"]
+
+    data = dumps(helper)
+    linecache.cache.pop(filename, None)
+
+    restored = loads(data)
+    restored(tiny_model, "Hello")
+
+    assert linecache.getlines(filename) == expected_lines
 
 
 # =============================================================================

--- a/tests/test_serialization_edge_cases.py
+++ b/tests/test_serialization_edge_cases.py
@@ -55,8 +55,13 @@ def test_deserialized_helper_trace_uses_registered_linecache(tiny_model, tmp_pat
     result = restored(tiny_model, "Hello")
     assert result is not None
 
-    # linecache must now contain the registered source.
+    # linecache must now contain the registered source under the original
+    # filename (no UUID prefix).
     assert filename in linecache.cache
+
+    # co_firstlineno must match the original so tracebacks are correct.
+    assert restored.__code__.co_firstlineno == helper.__code__.co_firstlineno
+    assert restored.__code__.co_filename == filename
 
 
 def test_deserialized_closure_helper_trace(tiny_model, tmp_path):
@@ -87,6 +92,69 @@ def test_deserialized_closure_helper_trace(tiny_model, tmp_path):
     result = restored(tiny_model, "Hello")
     assert result is not None
     assert filename in linecache.cache
+
+    # co_firstlineno must match the original inner function.
+    assert restored.__code__.co_firstlineno == helper.__code__.co_firstlineno
+    assert restored.__code__.co_filename == filename
+
+
+def test_two_functions_same_file_no_collision(tiny_model, tmp_path):
+    """Two functions from the same file must not clobber each other in linecache.
+
+    This is the key scenario that motivated replacing the UUID approach: when
+    two different functions share the same co_filename, their source lines are
+    merged into a single linecache entry at the correct offsets.
+    """
+    filename = str(tmp_path / "shared_helpers.py")
+    # Two functions at different line offsets in the same "file".
+    # Lines 1-4: helper_a, Lines 6-9: helper_b (blank line 5 separates them).
+    full_source = textwrap.dedent(
+        """\
+        def helper_a(model, prompt):
+            with model.trace(prompt):
+                out = model.output.save()
+            return out
+
+        def helper_b(model, prompt):
+            with model.trace(prompt):
+                out = model.output.save()
+            return out
+        """
+    )
+
+    lines = full_source.splitlines(keepends=True)
+    namespace = {}
+    linecache.cache[filename] = (len(full_source), None, lines, filename)
+    exec(compile(full_source, filename, "exec"), namespace)
+    helper_a = namespace["helper_a"]
+    helper_b = namespace["helper_b"]
+
+    # Sanity: they have different firstlineno in the original file.
+    assert helper_a.__code__.co_firstlineno != helper_b.__code__.co_firstlineno
+
+    data_a = dumps(helper_a)
+    data_b = dumps(helper_b)
+
+    # Clear linecache to simulate remote worker.
+    linecache.cache.pop(filename, None)
+
+    restored_a = loads(data_a)
+    restored_b = loads(data_b)
+
+    # Both must be callable with correct trace extraction.
+    result_a = restored_a(tiny_model, "Hello")
+    result_b = restored_b(tiny_model, "World")
+    assert result_a is not None
+    assert result_b is not None
+
+    # Both share the same linecache entry (original filename, no UUID).
+    assert filename in linecache.cache
+    assert restored_a.__code__.co_filename == filename
+    assert restored_b.__code__.co_filename == filename
+
+    # Line numbers are preserved.
+    assert restored_a.__code__.co_firstlineno == helper_a.__code__.co_firstlineno
+    assert restored_b.__code__.co_firstlineno == helper_b.__code__.co_firstlineno
 
 
 # =============================================================================

--- a/tests/test_serialization_edge_cases.py
+++ b/tests/test_serialization_edge_cases.py
@@ -20,34 +20,73 @@ from nnsight.intervention.serialization import dumps, loads
 
 
 def test_deserialized_helper_trace_uses_registered_linecache(tiny_model, tmp_path):
-    """Nested traces should work after helper functions are deserialized."""
+    """Nested traces should work after helper functions are deserialized.
+
+    Simulates the remote session flow: a helper containing model.trace() is
+    serialized locally, then deserialized on a worker where the original file
+    doesn't exist.  inspect.getsourcelines() must still succeed.
+    """
     filename = str(tmp_path / "missing_remote_helper.py")
     source = textwrap.dedent(
         """\
         def helper(model, prompt):
             with model.trace(prompt):
-                pass
+                out = model.output.save()
+            return out
         """
     )
 
-    expected_lines = source.splitlines(keepends=True)
+    # Compile against a fake filename and pre-populate linecache so dumps()
+    # can serialise the function (the file doesn't really exist on disk).
+    lines = source.splitlines(keepends=True)
     namespace = {}
-    linecache.cache[filename] = (
-        len(source),
-        None,
-        expected_lines,
-        filename,
-    )
+    linecache.cache[filename] = (len(source), None, lines, filename)
     exec(compile(source, filename, "exec"), namespace)
     helper = namespace["helper"]
+
+    data = dumps(helper)
+    # Clear linecache to simulate a remote worker where the file is absent.
+    linecache.cache.pop(filename, None)
+
+    restored = loads(data)
+
+    # The deserialized helper must be callable and the nested trace must
+    # successfully extract source (no OSError).
+    result = restored(tiny_model, "Hello")
+    assert result is not None
+
+    # linecache must now contain the registered source.
+    assert filename in linecache.cache
+
+
+def test_deserialized_closure_helper_trace(tiny_model, tmp_path):
+    """Same as above but for a closure, which takes the factory_source path."""
+    filename = str(tmp_path / "missing_remote_closure.py")
+    # outer() returns a closure that captures `layer_idx`.
+    source = textwrap.dedent(
+        """\
+        def outer(layer_idx):
+            def helper(model, prompt):
+                with model.trace(prompt):
+                    out = model.output.save()
+                return out
+            return helper
+        """
+    )
+
+    lines = source.splitlines(keepends=True)
+    namespace = {}
+    linecache.cache[filename] = (len(source), None, lines, filename)
+    exec(compile(source, filename, "exec"), namespace)
+    helper = namespace["outer"](0)  # creates the closure
 
     data = dumps(helper)
     linecache.cache.pop(filename, None)
 
     restored = loads(data)
-    restored(tiny_model, "Hello")
-
-    assert linecache.getlines(filename) == expected_lines
+    result = restored(tiny_model, "Hello")
+    assert result is not None
+    assert filename in linecache.cache
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Replace UUID-prefixed filename approach with line-offset-aware linecache registration for deserialized functions
- Functions are registered under their original `co_filename` at the correct `co_firstlineno` offset, so stack traces show the real filename and correct line numbers
- Multiple functions from the same file are merged into a single linecache entry at their respective offsets, avoiding the collision that motivated the UUID approach

## Problem
PR #626 registered deserialized function source in linecache to fix `inspect.getsourcelines()` on remote workers. However, two functions from the same file would overwrite each other in linecache (keyed by filename). The UUID workaround (`{uuid} {filename}`) fixed collisions but introduced ugly filenames and wrong line numbers in stack traces.

## Approach
1. Serialize `co_firstlineno` alongside the function source
2. On deserialization, restore `co_firstlineno` via `code.replace()` so the code object has the correct original line number
3. Register source in linecache at the correct line offset, merging with existing entries for the same file

## Test plan
- [x] `pytest tests/test_serialization_edge_cases.py --device cpu` — 31/31 passed
- [x] `pytest tests/test_tiny.py --device cpu` — 18/18 passed
- [x] New `test_two_functions_same_file_no_collision` verifies two functions from the same file coexist correctly
- [x] Updated existing tests to assert `co_firstlineno` and `co_filename` preservation

🤖 Generated with [Claude Code](https://claude.com/claude-code)