### PR TITLE
fix #631 vLLM TP non-determinism: propagate CUDA stream to worker threads

### DIFF
--- a/src/nnsight/intervention/interleaver.py
+++ b/src/nnsight/intervention/interleaver.py
@@ -674,10 +674,29 @@ class Mediator:
             len(self.interleaver.mediators) > 1 and CONFIG.APP.CROSS_INVOKER
         )
 
+        # Capture the current CUDA stream so the worker thread uses it.
+        # Worker threads default to the NULL stream (stream 0), but
+        # vLLM (and other frameworks) run on a non-default stream.
+        # PyTorch creates non-default streams with cudaStreamNonBlocking,
+        # which disables implicit synchronization with the NULL stream.
+        # Without propagating the stream, worker-thread CUDA ops (clone,
+        # fill) race with main-thread ops on the compute stream.
+        if torch.cuda.is_available() and torch.cuda.current_device() >= 0:
+            _caller_stream = torch.cuda.current_stream()
+        else:
+            _caller_stream = None
+
+        _intervention = self.intervention
+        _args = (self, self.info, *self.args)
+
+        def _worker_target():
+            if _caller_stream is not None:
+                torch.cuda.set_stream(_caller_stream)
+            _intervention(*_args)
+
         # Start the worker thread.
         self.worker = Thread(
-            target=self.intervention,
-            args=(self, self.info, *self.args),
+            target=_worker_target,
             daemon=True,
             name=self.name,
         )

--- a/src/nnsight/intervention/interleaver.py
+++ b/src/nnsight/intervention/interleaver.py
@@ -681,7 +681,7 @@ class Mediator:
         # which disables implicit synchronization with the NULL stream.
         # Without propagating the stream, worker-thread CUDA ops (clone,
         # fill) race with main-thread ops on the compute stream.
-        if torch.cuda.is_available() and torch.cuda.current_device() >= 0:
+        if torch.cuda.is_available():
             _caller_stream = torch.cuda.current_stream()
         else:
             _caller_stream = None

--- a/src/nnsight/modeling/vllm/batching.py
+++ b/src/nnsight/modeling/vllm/batching.py
@@ -31,8 +31,6 @@ class VLLMBatcher(Batcher):
 
     def wrap(self, model: Envoy):
 
-        interleaver = model._interleaver
-
         def pre_input_hook(module: torch.nn.Module, args: Any, kwargs: Any):
             self.current_module = module
             self.type = "input"
@@ -101,27 +99,8 @@ class VLLMBatcher(Batcher):
 
             return output
 
-        # When tensor_parallel_size > 1, the interleaver's hooks introduce
-        # variable-length Python execution between CUDA operations.  vLLM's
-        # custom NCCL ops inside TP-parallel modules may assume the compute
-        # stream is already caught up (no explicit cross-stream sync).  The
-        # hook-induced CPU delay can break that assumption, causing NCCL to
-        # read stale data and producing non-deterministic results.
-        #
-        # Synchronizing the current CUDA stream before each TP-parallel
-        # module ensures all prior compute kernels have finished before the
-        # module's NCCL collectives run.  This adds ~3 % overhead during
-        # traced execution and is skipped entirely outside of interleaving.
-        def cuda_sync_hook(module: torch.nn.Module, args, kwargs):
-            if interleaver.interleaving:
-                torch.cuda.synchronize()
-            return args, kwargs
-
         for module in model.modules():
             if isinstance(module._module, (RowParallelLinear, ColumnParallelLinear)):
-                module._module.register_forward_pre_hook(
-                    cuda_sync_hook, prepend=True, with_kwargs=True
-                )
                 module._module.register_forward_pre_hook(
                     pre_input_hook, prepend=True, with_kwargs=True
                 )
@@ -163,10 +142,6 @@ class VLLMBatcher(Batcher):
                         torch.Tensor,
                     )
 
-            # Sync after the NCCL collective so that user code
-            # (.clone(), tensor modifications) on the compute stream
-            # sees fully materialised data.
-            torch.cuda.synchronize()
             self.gathered = True
 
     def narrow(self, batch_group: Union[int, None]):

--- a/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
+++ b/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
@@ -1,7 +1,6 @@
 import pickle
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-import torch
 from vllm.distributed.parallel_state import get_pp_group
 from vllm.sequence import IntermediateTensors
 from vllm.tokenizers import cached_tokenizer_from_config
@@ -375,14 +374,6 @@ class NNsightGPUModelRunner(GPUModelRunner):
 
             if self.execute_model_state is not None:
 
-                # Same stream-sync rationale as the TP-parallel module
-                # hooks in VLLMBatcher.wrap(): the logits tensor was
-                # computed on the CUDA compute stream; without an explicit
-                # sync the interleaver hooks that fire inside the
-                # WrapperModule call may observe stale data.
-                if get_tp_group().world_size > 1:
-                    torch.cuda.synchronize()
-
                 logits = self.nnsight_model.logits(
                     self.execute_model_state.logits, hook=True
                 )
@@ -404,9 +395,6 @@ class NNsightGPUModelRunner(GPUModelRunner):
         with self.nnsight_model._interleaver:
 
             sampler_output = super()._sample(*args, **kwargs)
-
-            if get_tp_group().world_size > 1:
-                torch.cuda.synchronize()
 
             sampler_output.sampled_token_ids = self.model.samples(
                 sampler_output.sampled_token_ids, hook=True

--- a/tests/repro_631.py
+++ b/tests/repro_631.py
@@ -1,0 +1,153 @@
+"""
+Minimal reproduction for issue #631: Inconsistent intervention results between
+tensor_parallel_size=1 and tensor_parallel_size=2.
+
+Adapted from cwdghh's script to use Qwen2.5-0.5B-Instruct (fits on packed GPUs).
+
+Usage:
+    python tests/repro_631.py --tp 2 --runs 5
+    python tests/repro_631.py --tp 1 2 --runs 5   # run both and compare
+"""
+
+import argparse
+import statistics
+import torch
+from nnsight.modeling.vllm import VLLM
+
+
+MODEL_PATH   = "Qwen/Qwen2.5-0.5B-Instruct"
+PROMPT       = "After John and Mary went to the store, Mary gave a bottle of milk to"
+OUTPUT_TOKEN = " John"
+# Qwen2.5-0.5B: 14 heads, head_dim=64, hidden=896, 24 layers
+TARGET_LAYER = 20
+NUM_HEADS    = 14
+START_INDEX  = 0
+HEAD_DIM     = 64
+
+
+@torch.inference_mode()
+def run_single_tp(tp: int, runs: int) -> dict:
+    print(f"\n{'='*60}")
+    print(f"  Loading model  tensor_parallel_size={tp}")
+    print(f"{'='*60}")
+
+    vllm = VLLM(
+        MODEL_PATH,
+        tensor_parallel_size=tp,
+        dispatch=True,
+        dtype=torch.float16,
+        gpu_memory_utilization=0.05,
+    )
+
+    token_id = vllm.tokenizer.encode(OUTPUT_TOKEN, add_special_tokens=False)[0]
+    results  = {"tp": tp, "baseline": [], "heads": {h: [] for h in range(START_INDEX, NUM_HEADS)}}
+
+    for run_idx in range(runs):
+        print(f"\n[TP={tp}] Run {run_idx + 1}/{runs}")
+
+        with torch.no_grad():
+            with vllm.trace(temperature=0.0, max_tokens=1) as tracer:
+                with tracer.invoke(PROMPT):
+                    baseline_logit = vllm.logits.output[-1, token_id].item().save()
+
+        bl = float(baseline_logit)
+        results["baseline"].append(bl)
+        print(f"  Baseline logit: {bl:.6f}")
+
+        with torch.no_grad():
+            with vllm.trace(temperature=0.0, max_tokens=1) as tracer:
+                saved = dict().save()
+                for head in range(START_INDEX, NUM_HEADS):
+                    with tracer.invoke(PROMPT):
+                        head_in = (
+                            vllm.model.layers[TARGET_LAYER]
+                            .self_attn.o_proj.input.clone()
+                        )
+                        s, e = head * HEAD_DIM, (head + 1) * HEAD_DIM
+                        head_in[:, s:e] = 0
+                        vllm.model.layers[TARGET_LAYER].self_attn.o_proj.input = head_in
+                        saved[head] = vllm.logits.output[-1, token_id].item().save()
+
+        for head, sv in saved.items():
+            v = float(sv)
+            results["heads"][head].append(v)
+            diff = bl - v
+            print(f"  head={head:2d}  logit={v:.6f}  diff={diff:+.6f}")
+
+    del vllm
+    torch.cuda.empty_cache()
+
+    return results
+
+
+def stats(values):
+    mean = statistics.mean(values)
+    std  = statistics.pstdev(values)
+    return mean, std
+
+
+def print_results(all_results):
+    if len(all_results) >= 2:
+        tp_list = sorted(all_results.keys())
+        res1, res2 = all_results[tp_list[0]], all_results[tp_list[1]]
+        tp1, tp2 = res1["tp"], res2["tp"]
+
+        bl1_mean, bl1_std = stats(res1["baseline"])
+        bl2_mean, bl2_std = stats(res2["baseline"])
+
+        print(f"\n{'─'*80}")
+        print(f"  Baseline logit  (token='{OUTPUT_TOKEN}')")
+        print(f"  TP={tp1}: mean={bl1_mean:.6f}  std={bl1_std:.6f}")
+        print(f"  TP={tp2}: mean={bl2_mean:.6f}  std={bl2_std:.6f}  delta={bl2_mean - bl1_mean:+.6f}")
+        print(f"{'─'*80}")
+
+        print(f"\n  Intervention logits  (layer={TARGET_LAYER}, one head zeroed per row)")
+        print(f"  {'Head':>4}  {'TP='+str(tp1)+' mean':>12}  {'std':>10}  {'TP='+str(tp2)+' mean':>12}  {'std':>10}  {'Δ mean':>10}  {'Unstable?':>10}")
+
+        unstable_heads = []
+        for head in range(START_INDEX, NUM_HEADS):
+            m1, s1 = stats(res1["heads"][head])
+            m2, s2 = stats(res2["heads"][head])
+            flag = "***" if s2 > 1e-4 else ""
+            if s2 > 1e-4:
+                unstable_heads.append(head)
+            print(f"  {head:>4}  {m1:>12.6f}  {s1:>10.6f}  {m2:>12.6f}  {s2:>10.6f}  {m2-m1:>+10.6f}  {flag:>10}")
+
+        print(f"\n  TP={tp2} unstable heads (std > 1e-4): {unstable_heads if unstable_heads else 'none'}")
+        max_delta = max(abs(stats(res2["heads"][h])[0] - stats(res1["heads"][h])[0])
+                        for h in range(START_INDEX, NUM_HEADS))
+        print(f"  Max |mean(TP={tp2}) - mean(TP={tp1})| across heads: {max_delta:.6f}")
+    else:
+        tp = list(all_results.keys())[0]
+        res = all_results[tp]
+        bl_mean, bl_std = stats(res["baseline"])
+        print(f"\nBaseline: mean={bl_mean:.6f}  std={bl_std:.6f}")
+
+        unstable_heads = []
+        for head in range(START_INDEX, NUM_HEADS):
+            m, s = stats(res["heads"][head])
+            flag = "***" if s > 1e-4 else ""
+            if s > 1e-4:
+                unstable_heads.append(head)
+            print(f"  head={head:>2}  mean={m:.6f}  std={s:.6f}  {flag}")
+
+        print(f"\n  Unstable heads (std > 1e-4): {unstable_heads if unstable_heads else 'none'}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="TP inconsistency reproducer (issue #631)")
+    parser.add_argument("--tp", type=int, nargs="+", default=[2],
+                        help="tensor_parallel_size values to test")
+    parser.add_argument("--runs", type=int, default=5,
+                        help="Number of repeat runs")
+    args = parser.parse_args()
+
+    all_results = {}
+    for tp in args.tp:
+        all_results[tp] = run_single_tp(tp, runs=args.runs)
+
+    print_results(all_results)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tp_stream_fix.py
+++ b/tests/test_tp_stream_fix.py
@@ -1,0 +1,100 @@
+"""
+Tests for the CUDA stream propagation fix (issue #631).
+
+Verifies that propagating the caller's CUDA stream to mediator worker
+threads produces deterministic and correct intervention results under
+tensor parallelism.
+
+For thorough multi-run determinism testing, see tests/repro_631.py.
+
+Usage:
+    pytest tests/test_tp_stream_fix.py --tp 2 -v
+"""
+
+import pytest
+import torch
+
+try:
+    from nnsight.modeling.vllm import VLLM
+except Exception as e:
+    pytest.skip(f"Skipping VLLM tests: \n{e}", allow_module_level=True)
+
+
+MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
+PROMPT = "The Eiffel Tower is in the city of"
+TARGET_TOKEN = " Paris"
+
+
+@pytest.fixture(scope="module")
+def tp(request):
+    tp = request.config.getoption("--tp")
+    if tp > torch.cuda.device_count() or tp < 1:
+        pytest.exit("--tp can't be higher than the number of available GPUs.")
+    return tp
+
+
+@pytest.fixture(scope="module")
+def model(tp: int):
+    return VLLM(
+        MODEL,
+        tensor_parallel_size=tp,
+        gpu_memory_utilization=0.1,
+        dispatch=True,
+        dtype=torch.float16,
+    )
+
+
+@pytest.fixture(scope="module")
+def token_id(model):
+    ids = model.tokenizer.encode(TARGET_TOKEN, add_special_tokens=False)
+    assert len(ids) == 1
+    return ids[0]
+
+
+class TestTPStreamFix:
+    """Tests for issue #631: TP>1 intervention determinism via stream propagation."""
+
+    @torch.no_grad()
+    def test_worker_stream_not_null(self, tp, model):
+        """Under TP>1, worker thread should use vLLM's non-default stream."""
+        if tp < 2:
+            pytest.skip("Stream mismatch only occurs with TP>1")
+
+        import nnsight
+
+        with model.trace(temperature=0.0, max_tokens=1) as tracer:
+            with tracer.invoke(PROMPT):
+                worker_ptr = nnsight.save(torch.cuda.current_stream().cuda_stream)
+
+        assert worker_ptr != 0, (
+            f"Worker thread is on the NULL stream ({worker_ptr:#x}). "
+            f"Stream propagation fix is not working."
+        )
+
+    @torch.no_grad()
+    def test_head_ablation_determinism(self, tp, model, token_id):
+        """Head ablation on o_proj.input should produce identical results across 2 runs."""
+        if tp < 2:
+            pytest.skip("This test targets TP>1 intervention determinism")
+
+        head_dim = model.model.config.hidden_size // model.model.config.num_attention_heads
+        num_heads = model.model.config.num_attention_heads
+        layer = model.model.config.num_hidden_layers - 4
+        heads = list(range(num_heads))
+
+        runs = []
+        for _ in range(2):
+            with model.trace(temperature=0.0, max_tokens=1) as tracer:
+                logits_list = list().save()
+                for h in heads:
+                    with tracer.invoke(PROMPT):
+                        head_in = model.model.layers[layer].self_attn.o_proj.input.clone()
+                        head_in[:, h * head_dim:(h + 1) * head_dim] = 0
+                        model.model.layers[layer].self_attn.o_proj.input = head_in
+                        logits_list.append(model.logits.output[-1, token_id].item().save())
+            runs.append(logits_list[:])
+
+        for i, h in enumerate(heads):
+            assert runs[0][i] == runs[1][i], (
+                f"Head {h}: run 0 = {runs[0][i]}, run 1 = {runs[1][i]}"
+            )


### PR DESCRIPTION
Root cause: NNsight's mediator worker threads defaulted to the CUDA NULL stream (stream 0), while vLLM's forward pass ran on a non-default stream. PyTorch creates streams with cudaStreamNonBlocking, which disables implicit synchronization between them. Worker-thread CUDA ops (clone, fill) raced with main-thread ops on the compute stream, producing non-deterministic and silently incorrect intervention results under tensor_parallel_size > 1.

Fix: capture the caller's CUDA stream in Mediator.start() and set it in the worker thread before the intervention code runs. This puts all CUDA operations on the same stream, where ordering is guaranteed.

This replaces all 4 torch.cuda.synchronize() workarounds that were added in earlier commits (cuda_sync_hook on TP modules, check_gathered sync, logits sync, samples sync). Same-stream ordering makes them unnecessary, and removing them eliminates expensive CPU-GPU stalls.

Validated with Qwen2.5-0.5B-Instruct TP=2: 14 heads × 5 runs = 0 unstable heads. TP=1 vs TP=2 value comparison shows max diff of 1 ULP (0.015625 in fp16), consistent with normal TP numerical differences.

Fixes #631