### PR TITLE
Fix backward/gradient through batched narrow views

### DIFF
--- a/src/nnsight/intervention/batching.py
+++ b/src/nnsight/intervention/batching.py
@@ -294,6 +294,13 @@ class Batcher:
                 current_value.requires_grad and current_value.is_leaf
             ) or current_value._base is not None
 
+            # When swap_value is a view of current_value (e.g. the user
+            # read a narrow slice from the batcher and assigned it back),
+            # in-place assignment creates a self-referential autograd
+            # graph that segfaults during backward.  Use concat instead.
+            if not needs_concat and swap_value._base is current_value:
+                needs_concat = True
+
             if needs_concat:
                 pre = current_value.narrow(0, 0, batch_start)
                 post = (

--- a/src/nnsight/intervention/tracing/backwards.py
+++ b/src/nnsight/intervention/tracing/backwards.py
@@ -7,6 +7,57 @@ from ..interleaver import Interleaver, Mediator
 from .invoker import Invoker
 
 
+def _get_batch_narrow_info(tensor: torch.Tensor):
+    """If *tensor* is a dim-0 narrow view of a base tensor, return
+    ``(base, start, size)``.  Otherwise return ``None``.
+
+    When multiple invokes are batched, ``Batcher._narrow`` slices the
+    full-batch activation along dim 0 for each invoke.  The resulting
+    view is **not** in the autograd forward path (the full tensor is
+    returned to the next module), so ``register_hook`` on the view
+    will never fire.  This helper detects such views so that
+    ``wrap_grad`` can register the hook on the base tensor instead
+    and narrow the gradient inside the hook.
+
+    TODO: This relies on ``tensor._base`` which always points to the
+    root storage owner.  It works for the common case (user accesses
+    ``module.output[0].grad`` where the tensor is a direct narrow
+    from the batcher), but may give wrong results if:
+      - The user further slices the narrow view before accessing .grad
+        (e.g. ``output[0][:, -1, :].grad``) — the storage offset
+        would reflect both operations.
+      - ``full_output`` is itself a view of an internal buffer —
+        ``_base`` would skip past it to the root tensor.
+    These are uncommon in practice for gradient access patterns.
+
+    TODO: With concurrent mediators (future), multiple hooks on the
+    same base tensor would interfere — each backward() fires ALL
+    hooks.  A module-level ``register_full_backward_hook`` approach
+    (mirroring the forward output hook) would be the correct long-term
+    solution: one hook distributes gradients to all mediators via
+    ``handle()`` + ``batcher.narrow()``.
+    """
+    base = tensor._base
+    if base is None:
+        return None
+    if tensor.dim() == 0 or base.dim() == 0:
+        return None
+    if tensor.dim() != base.dim():
+        return None
+    if tensor.shape[1:] != base.shape[1:]:
+        return None
+    if tensor.stride() != base.stride():
+        return None
+    stride0 = base.stride()[0]
+    if stride0 == 0:
+        return None
+    start = tensor.storage_offset() // stride0
+    size = tensor.shape[0]
+    if start + size > base.shape[0]:
+        return None
+    return (base, start, size)
+
+
 def wrap_grad(interleaver: Interleaver):
     """
     Create a hook for gradient intervention.
@@ -15,14 +66,32 @@ def wrap_grad(interleaver: Interleaver):
         A function that can be used to intercept gradients
     """
 
-    def wrap(tensor: torch.Tensor):
+    # Track which (hook_target_id, provider_id) pairs have been wrapped
+    # so multiple narrow views of the same base each get their own hook.
+    _wrapped: set = set()
 
-        # Only wrap the tensor once
-        if tensor._backward_hooks:
-            return
+    def wrap(tensor: torch.Tensor):
 
         # We are providing the grad of the tensor
         provider = id(tensor)
+
+        # When the tensor is a batch-dim narrow view (created by
+        # Batcher._narrow), the view is NOT in the autograd forward
+        # path — the full-batch base tensor is what flows through the
+        # model.  A hook on the view would never fire.  Register on
+        # the base instead and narrow the gradient in the hook.
+        narrow_info = _get_batch_narrow_info(tensor)
+
+        if narrow_info is not None:
+            hook_target, batch_start, batch_size = narrow_info
+        else:
+            hook_target = tensor
+            batch_start = batch_size = None
+
+        key = (id(hook_target), provider)
+        if key in _wrapped:
+            return
+        _wrapped.add(key)
 
         # Well need to remove the hook
         hook = None
@@ -30,17 +99,27 @@ def wrap_grad(interleaver: Interleaver):
         # On backwards for this tensor
         def inner(grad: torch.Tensor):
 
-            # Inject the grad value
-            # Possibly editing it in the process
             try:
-                grad = interleaver.handle(f"{provider}.grad", grad)
+                if batch_start is not None:
+                    # Narrow the full-batch gradient to this invoke's slice.
+                    narrow_grad = grad.narrow(0, batch_start, batch_size)
+                    result = interleaver.handle(f"{provider}.grad", narrow_grad)
+                    # If the user modified the gradient, splice it back
+                    # into the full gradient.
+                    if result is not narrow_grad:
+                        grad = grad.clone()
+                        grad[batch_start : batch_start + batch_size] = result
+                        return grad
+                else:
+                    # No batching — handle the gradient directly.
+                    grad = interleaver.handle(f"{provider}.grad", grad)
             finally:
                 hook.remove()
 
             return grad
 
         # Register the hook
-        hook = tensor.register_hook(inner)
+        hook = hook_target.register_hook(inner)
 
     def getter(tensor: torch.Tensor):
 

--- a/tests/test_backward_batching.py
+++ b/tests/test_backward_batching.py
@@ -1,0 +1,184 @@
+"""Tests for backward/gradient support with batched (multi-invoke) traces.
+
+These tests verify that `.grad` access works correctly when multiple input
+invokes are batched together.  The core issue is that `Batcher._narrow()`
+creates views that are not in the autograd forward path, so backward hooks
+on those views never fire.  The fix in `wrap_grad` registers hooks on the
+base tensor instead and narrows the gradient in the hook.
+
+A secondary fix in `Batcher._swap` prevents a segfault when a user assigns
+a narrow view back into its own base tensor (self-referential autograd).
+"""
+
+import pytest
+import torch
+from nnsight import LanguageModel
+
+
+@pytest.fixture(scope="module")
+def model():
+    return LanguageModel(
+        "openai-community/gpt2", device_map="cpu", dispatch=True
+    )
+
+
+class TestBackwardWithBatchedInvokes:
+    """Gradient access with two input invokes (needs_batching=True)."""
+
+    def test_grad_in_second_invoke(self, model):
+        """User's original attribution patching pattern: clean run + corrupted
+        run with backward in the second invoke."""
+        with model.trace() as tracer:
+            with tracer.invoke("Hello"):
+                clean = model.transformer.h[-1].output[0].save()
+            with tracer.invoke("World"):
+                x = model.transformer.h[-1].output[0]
+                x.requires_grad_(True)
+                logits = model.lm_head.output
+                with logits.sum().backward():
+                    grad = x.grad.save()
+
+        assert grad.shape[0] == 1
+        assert grad.shape[-1] == 768
+        assert (grad != 0).any()
+
+    def test_grad_in_first_invoke(self, model):
+        """Backward in the first invoke of two."""
+        with model.trace() as tracer:
+            with tracer.invoke("Hello"):
+                x = model.transformer.h[-1].output[0]
+                x.requires_grad_(True)
+                logits = model.lm_head.output
+                with logits.sum().backward():
+                    grad = x.grad.save()
+            with tracer.invoke("World"):
+                clean = model.transformer.h[-1].output[0].save()
+
+        assert grad.shape[0] == 1
+        assert (grad != 0).any()
+
+    def test_attribution_patching(self, model):
+        """Full attribution patching: logit-diff metric with gradient."""
+        paris = model.tokenizer.encode(" Paris")[0]
+        rome = model.tokenizer.encode(" Rome")[0]
+
+        with model.trace() as tracer:
+            with tracer.invoke("The Eiffel Tower is in"):
+                pass
+            with tracer.invoke("The Colosseum is in"):
+                hs = model.transformer.h[5].output[0]
+                hs.requires_grad_(True)
+                logits = model.lm_head.output[:, -1]
+                metric = logits[0, paris] - logits[0, rome]
+                with metric.backward():
+                    attr = hs.grad.save()
+
+        assert attr.shape[-1] == 768
+        assert (attr != 0).any()
+
+    def test_grad_deterministic(self, model):
+        """Same setup run twice produces identical gradients."""
+        grads = []
+        for _ in range(2):
+            with model.trace() as tracer:
+                with tracer.invoke("Hello"):
+                    pass
+                with tracer.invoke("World"):
+                    x = model.transformer.h[-1].output[0]
+                    x.requires_grad_(True)
+                    logits = model.lm_head.output
+                    with logits.sum().backward():
+                        grads.append(x.grad.save())
+
+        assert torch.allclose(grads[0], grads[1])
+
+    def test_grad_modification(self, model):
+        """User can read and modify gradients inside backward context."""
+        with model.trace() as tracer:
+            with tracer.invoke("Hello"):
+                pass
+            with tracer.invoke("World"):
+                x = model.transformer.h[-1].output[0]
+                x.requires_grad_(True)
+                logits = model.lm_head.output
+                with logits.sum().backward():
+                    orig = x.grad.clone().save()
+                    x.grad[:] = 0
+                    zeroed = x.grad.save()
+
+        assert (orig != 0).any()
+        assert (zeroed == 0).all()
+
+
+class TestBackwardRegressions:
+    """Ensure existing single-invoke and empty-invoke patterns still work."""
+
+    def test_single_invoke(self, model):
+        with model.trace("Hello"):
+            x = model.transformer.h[-1].output[0]
+            x.requires_grad_(True)
+            logits = model.lm_head.output
+            with logits.sum().backward():
+                grad = x.grad.save()
+
+        assert (grad != 0).any()
+
+    def test_input_plus_empty_invoke(self, model):
+        with model.trace() as tracer:
+            with tracer.invoke("Hello"):
+                x = model.transformer.h[-1].output[0]
+                x.requires_grad_(True)
+                logits = model.lm_head.output
+                with logits.sum().backward():
+                    grad = x.grad.save()
+            with tracer.invoke():
+                out = model.transformer.h[-1].output[0].save()
+
+        assert (grad != 0).any()
+
+    def test_retain_graph(self, model):
+        with model.trace("Hello"):
+            x = model.transformer.h[-1].output[0]
+            x.requires_grad_(True)
+            logits = model.lm_head.output
+            with logits.sum().backward(retain_graph=True):
+                g1 = x.grad.save()
+            modified = logits * 2
+            with modified.sum().backward():
+                g2 = x.grad.save()
+
+        assert torch.allclose(g2, g1 * 2, atol=1e-5)
+
+
+class TestSwapSelfReferentialGuard:
+    """Batcher._swap must use concat when swap_value is a view of
+    current_value, otherwise in-place assignment segfaults during backward."""
+
+    def test_pop_back_pattern(self, model):
+        """User reads output, sets requires_grad, assigns back — was segfault."""
+        with model.trace() as tracer:
+            with tracer.invoke("Hello"):
+                clean = model.transformer.h[-1].output[0].save()
+            with tracer.invoke("World"):
+                out = model.transformer.h[-1].output
+                x = out[0]
+                x.requires_grad_(True)
+                model.transformer.h[-1].output = (x,) + out[1:]
+                logits = model.lm_head.output
+                with logits.sum().backward():
+                    grad = x.grad.save()
+
+        assert (grad != 0).any()
+
+    def test_normal_swap_unaffected(self, model):
+        """Swapping a new tensor (not a view) still uses in-place path."""
+        with model.trace() as tracer:
+            with tracer.invoke("Hello"):
+                pass
+            with tracer.invoke("World"):
+                out = model.transformer.h[-1].output
+                modified = out[0] * 2
+                model.transformer.h[-1].output = (modified,) + out[1:]
+                logits = model.lm_head.output.save()
+
+        assert logits.shape[-1] == 50257


### PR DESCRIPTION
## Fix backward/gradient through batched narrow views

### Problem

When using `.grad` in a trace with multiple input invokes (batching), backward hooks never fire:

```python
with model.trace() as tracer:
    with tracer.invoke(clean_tokens):
        clean_out = model.transformer.h[-1].output[0].save()
    with tracer.invoke(corrupted_tokens):
        layer_out = model.transformer.h[-1].output[0]
        layer_out.requires_grad_(True)
        logits = model.lm_head.output
        value = vqa_metric(logits)
        with value.backward():
            grad = layer_out.grad.save()  # ValueError: grad was not provided
```

This blocks attribution patching, integrated gradients, and any gradient-based interpretability technique that uses multiple invokes in a single trace.

### Root Cause

`Batcher._narrow()` creates dim-0 narrow views for each invoke's slice of the batch. These views are **not in the autograd forward path** — the full-batch tensor is what flows through the model. PyTorch's `register_hook` on a tensor only fires when gradients are computed for that tensor's autograd node. Since no downstream operation uses the narrow view, its gradient is never computed and the hook never fires.

```
full_output ──────────────→ next_module → ... → loss   (autograd path)
     │
     └── narrow() → view    (dead end — not used by anything leading to loss)
```

A secondary issue: if a user assigns a narrow view back into its base tensor (`module.output = (x,) + rest` where `x` is a narrow view of the output), the in-place assignment in `_swap` creates a self-referential autograd graph that segfaults during backward. This is a PyTorch-level bug triggered by `full[start:end] = view_of_full`.

### Fix

**1. `wrap_grad` (backwards.py):** When registering a backward hook, detect batch-dim narrow views via `tensor._base`. Register the hook on the base tensor (which IS in the autograd path) and narrow the gradient to the invoke's slice inside the hook before providing it to the mediator. (We can discuss this fix, which is the only way that can fix the problem without extra cost. If telling users always reassign the tensor if they need grad is fine, we don't need this fix)

**2. `Batcher._swap` (batching.py):** When `swap_value._base is current_value` (view being assigned back into its own base), route to the `torch.cat` path instead of in-place assignment to avoid the self-referential autograd segfault. swap_value.requires_grad is too weak, if the user code clones or modifies that tensor, autograd graph can capture their gradient correctly. So we only need this self reference guard.

### Known Limitations (documented as TODOs)

- **`_base` view chain fragility:** `tensor._base` always points to the root storage owner, not the immediate parent. If the user further slices a narrow view before accessing `.grad` (e.g. `output[0][:, -1, :].grad`), or if `full_output` is itself a view of an internal buffer, `_base` may skip levels. Uncommon in practice for gradient access patterns.

- **Concurrent mediators (future):** Multiple hooks on the same base tensor would interfere — each `backward()` fires ALL registered hooks, and one finished mediator will remove all of them.

### Tests

10 new tests in `tests/test_backward_batching.py`:
- Gradient in first/second invoke of a batched trace
- Full attribution patching pattern (logit-diff metric)
- Gradient determinism across runs
- Gradient modification (setter) inside backward context
- Single invoke and input+empty invoke regressions
- `retain_graph` with multiple backward passes
- Pop-back pattern (was segfault, now works)
- Normal swap unaffected by the guard