### PR TITLE
Vllm serve combined

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1577,6 +1577,38 @@ with model.scan("Hello"):
 print(dim)  # 768
 ```
 
+### 12. Don't `.save()` Elements Inside a List Comprehension
+
+`.save()` marks an object's `id()` in `Globals.saves`. After the trace, `push` walks the caller's frame locals and only injects variables whose `id()` is in that set. When you `.save()` individual tensors inside a list comprehension, each tensor's id is saved but the tensors aren't bound to any variable name — they're anonymous elements of a list that itself isn't saved. So `push` finds nothing to inject.
+
+```python
+# WRONG — each element is saved but none have names in the frame
+with model.trace("Hello"):
+    results = [model.transformer.h[i].output[0].save() for i in range(12)]
+# NameError: name 'results' is not defined
+
+# WRONG — same problem with a loop appending to a plain list
+with model.trace("Hello"):
+    results = []
+    for i in range(12):
+        results.append(model.transformer.h[i].output[0].save())
+# NameError: name 'results' is not defined
+
+# CORRECT — .save() the list itself, append unsaved elements
+with model.trace("Hello"):
+    results = list().save()
+    for i in range(12):
+        results.append(model.transformer.h[i].output[0])
+# results is a list of 12 tensors
+
+# CORRECT — .save() the comprehension result (the list)
+with model.trace("Hello"):
+    results = [model.transformer.h[i].output[0] for i in range(12)].save()
+# results is a list of 12 tensors
+```
+
+**Rule of thumb:** `.save()` must be called on the object that is assigned to a named variable in your code. If you want a list of tensors, save the list — not the individual tensors inside it.
+
 ---
 
 ## Understanding Exceptions in NNsight

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,11 +58,18 @@ diffusers = [
 
 vllm = [
     "vllm==0.15.1",
-    "triton==3.5.0",
 ]
 
+serve = [
+    "nnsight[vllm]",
+    "fastapi>=0.100",
+    "uvicorn[standard]>=0.24",
+]
 
-all = ["nnsight[test,diffusers,vllm]"]
+all = ["nnsight[test,diffusers,vllm,serve]"]
+
+[project.scripts]
+nnsight-serve = "nnsight.modeling.vllm.serve.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/ndif-team/nnsight"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,12 +57,8 @@ diffusers = [
 
 
 vllm = [
-<<<<<<< vllm-serve-combined
-    "vllm==0.15.1",
-=======
     "vllm",
     "triton",
->>>>>>> dev
 ]
 
 serve = [

--- a/src/nnsight/intervention/backends/local_serve.py
+++ b/src/nnsight/intervention/backends/local_serve.py
@@ -1,0 +1,94 @@
+"""Client backend for nnsight-vllm-serve.
+
+Sends compiled traces to a local nnsight-serve instance and retrieves saves.
+
+Design choices:
+- Reuses RequestModel serialization (same format as NDIF remote backend).
+- Synchronous HTTP: POSTs to /v1/nnsight/generate and blocks until done.
+  No WebSocket or polling — the server processes the request and returns
+  the result in the same HTTP response.
+- Response uses torch.save format (handles tensors correctly, avoids
+  arbitrary pickle deserialization by using weights_only where possible).
+- The client does NOT need a GPU or dispatched model. Only the meta model
+  is needed for envoy proxies (so user code like model.layers[5].output
+  resolves correctly during tracing).
+"""
+
+from __future__ import annotations
+
+import io
+from typing import TYPE_CHECKING, Any, Optional
+
+import httpx
+import torch
+
+from ..tracing.util import wrap_exception
+from ...schema.request import RequestModel
+from .base import Backend
+
+if TYPE_CHECKING:
+    from ..tracing.tracer import Tracer
+
+
+class LocalServeBackend(Backend):
+    """Backend that sends compiled traces to a local nnsight-serve instance."""
+
+    CONNECT_TIMEOUT: float = 10.0
+    READ_TIMEOUT: float = 600.0  # 10 min for large models.
+
+    def __init__(self, model: Any, host: str):
+        self.model = model
+        self.host = host.rstrip("/")
+
+    def __call__(self, tracer: Optional["Tracer"] = None):
+        if tracer is not None:
+            self._compile_and_send(tracer)
+
+    def _compile_and_send(self, tracer: "Tracer"):
+        """Compile traced code, serialize as RequestModel, POST to server."""
+        # Compile trace → intervention function (same as RemoteBackend.request).
+        interventions = Backend.__call__(self, tracer)
+
+        try:
+            compress = False
+            data = RequestModel(
+                interventions=interventions, tracer=tracer
+            ).serialize(compress)
+
+            headers = {
+                "Content-Type": "application/octet-stream",
+                "nnsight-compress": str(compress),
+            }
+
+            timeout = httpx.Timeout(self.CONNECT_TIMEOUT, read=self.READ_TIMEOUT)
+
+            with httpx.Client(timeout=timeout) as client:
+                response = client.post(
+                    f"{self.host}/v1/nnsight/generate",
+                    content=data,
+                    headers=headers,
+                )
+
+            if response.status_code != 200:
+                try:
+                    detail = response.json().get("detail", response.reason_phrase)
+                except Exception:
+                    detail = response.reason_phrase
+                raise ConnectionError(
+                    f"nnsight-serve returned {response.status_code}: {detail}"
+                )
+
+            # Deserialize response (torch.save format).
+            result = torch.load(
+                io.BytesIO(response.content),
+                map_location="cpu",
+                weights_only=False,
+            )
+            saves = result.get("saves", {})
+
+            # Push saves to the tracer's original frame
+            # (same as RemoteBackend.blocking_request line 875).
+            tracer.push(saves)
+
+        except Exception as e:
+            raise wrap_exception(e, tracer.info) from None

--- a/src/nnsight/intervention/backends/local_serve.py
+++ b/src/nnsight/intervention/backends/local_serve.py
@@ -4,20 +4,24 @@ Sends compiled traces to a local nnsight-serve instance and retrieves saves.
 
 Design choices:
 - Reuses RequestModel serialization (same format as NDIF remote backend).
-- Synchronous HTTP: POSTs to /v1/nnsight/generate and blocks until done.
-  No WebSocket or polling — the server processes the request and returns
-  the result in the same HTTP response.
-- Response uses torch.save format (handles tensors correctly, avoids
-  arbitrary pickle deserialization by using weights_only where possible).
+- Synchronous HTTP by default: POSTs to /v1/nnsight/generate and blocks
+  until done, then pushes saves into the caller's frame (same as local execution).
+- Non-blocking mode (blocking=False): fires the HTTP request in a background
+  thread and returns immediately. The tracer is returned from the ``with``
+  block with a ``.collect(timeout=None)`` method. Calling ``.result()``
+  blocks until the response arrives and returns a dict of saved values.
+  Frame injection is NOT possible in non-blocking mode because the caller's
+  frame has moved on by the time the response arrives.
+- Response uses torch.save format (handles tensors correctly).
 - The client does NOT need a GPU or dispatched model. Only the meta model
-  is needed for envoy proxies (so user code like model.layers[5].output
-  resolves correctly during tracing).
+  is needed for envoy proxies.
 """
 
 from __future__ import annotations
 
 import io
-from typing import TYPE_CHECKING, Any, Optional
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import httpx
 import torch
@@ -29,66 +33,101 @@ from .base import Backend
 if TYPE_CHECKING:
     from ..tracing.tracer import Tracer
 
+# Shared thread pool for non-blocking requests.
+# Threads are cheap here — the work is IO-bound (HTTP round-trip).
+_pool = ThreadPoolExecutor(max_workers=16)
+
 
 class LocalServeBackend(Backend):
-    """Backend that sends compiled traces to a local nnsight-serve instance."""
+    """Backend that sends compiled traces to a local nnsight-serve instance.
+
+    Args:
+        model: The NNsight model wrapper (meta model for envoy proxies).
+        host: URL of the nnsight-serve instance.
+        blocking: If True (default), block until the server responds and
+            push saves into the caller's frame (identical to local execution).
+            If False, fire the request in a background thread. The tracer
+            gets a ``.collect(timeout=None)`` method that blocks and returns
+            the saves dict.
+
+    Usage (blocking, default)::
+
+        with model.trace("prompt", serve=url):
+            out = model.logits.output.save()
+        print(out)  # tensor, available immediately
+
+    Usage (non-blocking)::
+
+        with model.trace("prompt1", serve=url, blocking=False) as t1:
+            out1 = model.logits.output.save()
+        with model.trace("prompt2", serve=url, blocking=False) as t2:
+            out2 = model.logits.output.save()
+
+        # Both in-flight concurrently inside vLLM's engine.
+        saves1 = t1.collect()  # blocks, returns {"out1": tensor}
+        saves2 = t2.collect()  # blocks, returns {"out2": tensor}
+        out1, out2 = saves1["out1"], saves2["out2"]
+    """
 
     CONNECT_TIMEOUT: float = 10.0
     READ_TIMEOUT: float = 600.0  # 10 min for large models.
 
-    def __init__(self, model: Any, host: str):
+    def __init__(self, model: Any, host: str, blocking: bool = True):
         self.model = model
         self.host = host.rstrip("/")
+        self.blocking = blocking
 
     def __call__(self, tracer: Optional["Tracer"] = None):
-        if tracer is not None:
-            self._compile_and_send(tracer)
+        if tracer is None:
+            return
 
-    def _compile_and_send(self, tracer: "Tracer"):
-        """Compile traced code, serialize as RequestModel, POST to server."""
-        # Compile trace → intervention function (same as RemoteBackend.request).
+        # Compile trace → intervention function.
         interventions = Backend.__call__(self, tracer)
 
+        # Serialize eagerly — the tracer state is ephemeral.
         try:
             compress = False
             data = RequestModel(
                 interventions=interventions, tracer=tracer
             ).serialize(compress)
-
-            headers = {
-                "Content-Type": "application/octet-stream",
-                "nnsight-compress": str(compress),
-            }
-
-            timeout = httpx.Timeout(self.CONNECT_TIMEOUT, read=self.READ_TIMEOUT)
-
-            with httpx.Client(timeout=timeout) as client:
-                response = client.post(
-                    f"{self.host}/v1/nnsight/generate",
-                    content=data,
-                    headers=headers,
-                )
-
-            if response.status_code != 200:
-                try:
-                    detail = response.json().get("detail", response.reason_phrase)
-                except Exception:
-                    detail = response.reason_phrase
-                raise ConnectionError(
-                    f"nnsight-serve returned {response.status_code}: {detail}"
-                )
-
-            # Deserialize response (torch.save format).
-            result = torch.load(
-                io.BytesIO(response.content),
-                map_location="cpu",
-                weights_only=False,
-            )
-            saves = result.get("saves", {})
-
-            # Push saves to the tracer's original frame
-            # (same as RemoteBackend.blocking_request line 875).
-            tracer.push(saves)
-
         except Exception as e:
             raise wrap_exception(e, tracer.info) from None
+
+        if self.blocking:
+            saves = self._send(data, compress)
+            tracer.push(saves)
+        else:
+            future = _pool.submit(self._send, data, compress)
+            tracer._serve_future = future
+
+    def _send(self, data: bytes, compress: bool) -> Dict[str, Any]:
+        """Send serialized request, return saves dict."""
+        headers = {
+            "Content-Type": "application/octet-stream",
+            "nnsight-compress": str(compress),
+        }
+
+        timeout = httpx.Timeout(self.CONNECT_TIMEOUT, read=self.READ_TIMEOUT)
+
+        with httpx.Client(timeout=timeout) as client:
+            response = client.post(
+                f"{self.host}/v1/nnsight/generate",
+                content=data,
+                headers=headers,
+            )
+
+        if response.status_code != 200:
+            try:
+                detail = response.json().get("detail", response.reason_phrase)
+            except Exception:
+                detail = response.reason_phrase
+            raise ConnectionError(
+                f"nnsight-serve returned {response.status_code}: {detail}"
+            )
+
+        result = torch.load(
+            io.BytesIO(response.content),
+            map_location="cpu",
+            weights_only=False,
+        )
+        return result.get("saves", {})

--- a/src/nnsight/intervention/backends/local_serve.py
+++ b/src/nnsight/intervention/backends/local_serve.py
@@ -8,7 +8,7 @@ Design choices:
   until done, then pushes saves into the caller's frame (same as local execution).
 - Non-blocking mode (blocking=False): fires the HTTP request in a background
   thread and returns immediately. The tracer is returned from the ``with``
-  block with a ``.collect(timeout=None)`` method. Calling ``.result()``
+  block with a ``.collect(timeout=None)`` method. Calling ``.collect()``
   blocks until the response arrives and returns a dict of saved values.
   Frame injection is NOT possible in non-blocking mode because the caller's
   frame has moved on by the time the response arrives.
@@ -20,7 +20,7 @@ Design choices:
 from __future__ import annotations
 
 import io
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import httpx
@@ -72,10 +72,14 @@ class LocalServeBackend(Backend):
     CONNECT_TIMEOUT: float = 10.0
     READ_TIMEOUT: float = 600.0  # 10 min for large models.
 
-    def __init__(self, model: Any, host: str, blocking: bool = True):
+    def __init__(self, model: Any, host: str, blocking: bool = True, api_key: str = None):
         self.model = model
         self.host = host.rstrip("/")
         self.blocking = blocking
+        self.api_key = api_key
+        self._client = httpx.Client(
+            timeout=httpx.Timeout(self.CONNECT_TIMEOUT, read=self.READ_TIMEOUT),
+        )
 
     def __call__(self, tracer: Optional["Tracer"] = None):
         if tracer is None:
@@ -106,15 +110,14 @@ class LocalServeBackend(Backend):
             "Content-Type": "application/octet-stream",
             "nnsight-compress": str(compress),
         }
+        if self.api_key:
+            headers["ndif-api-key"] = self.api_key
 
-        timeout = httpx.Timeout(self.CONNECT_TIMEOUT, read=self.READ_TIMEOUT)
-
-        with httpx.Client(timeout=timeout) as client:
-            response = client.post(
-                f"{self.host}/v1/nnsight/generate",
-                content=data,
-                headers=headers,
-            )
+        response = self._client.post(
+            f"{self.host}/v1/nnsight/generate",
+            content=data,
+            headers=headers,
+        )
 
         if response.status_code != 200:
             try:

--- a/src/nnsight/intervention/batching.py
+++ b/src/nnsight/intervention/batching.py
@@ -294,6 +294,13 @@ class Batcher:
                 current_value.requires_grad and current_value.is_leaf
             ) or current_value._base is not None
 
+            # When swap_value is a view of current_value (e.g. the user
+            # read a narrow slice from the batcher and assigned it back),
+            # in-place assignment creates a self-referential autograd
+            # graph that segfaults during backward.  Use concat instead.
+            if not needs_concat and swap_value._base is current_value:
+                needs_concat = True
+
             if needs_concat:
                 pre = current_value.narrow(0, 0, batch_start)
                 post = (

--- a/src/nnsight/intervention/interleaver.py
+++ b/src/nnsight/intervention/interleaver.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextvars
 import inspect
 import types
 import warnings
@@ -702,9 +703,13 @@ class Mediator:
                 torch.cuda.set_stream(_caller_stream)
             _intervention(*_args)
 
-        # Start the worker thread.
+        # Start the worker thread. Copy the current context so the
+        # worker inherits Globals.stack / Globals.saves from the caller.
+        ctx = contextvars.copy_context()
+
         self.worker = Thread(
-            target=_worker_target,
+            target=ctx.run,
+            args=(_worker_target,),
             daemon=True,
             name=self.name,
         )

--- a/src/nnsight/intervention/interleaver.py
+++ b/src/nnsight/intervention/interleaver.py
@@ -105,6 +105,7 @@ class Interleaver:
 
         self._interleaving = False
         self.hook_handles = []
+        self._defer_exceptions = False
 
     def initialize(
         self,
@@ -394,6 +395,12 @@ class Interleaver:
         if exc_type is not None and issubclass(exc_type, EarlyStopException):
             return True
 
+        # In defer mode (vLLM), don't raise here — exceptions are stored
+        # per-mediator and will be raised on the client side.
+        # Raising from __exit__ would kill the vLLM engine process.
+        if self._defer_exceptions:
+            return
+
     def check_dangling_mediators(self):
 
         # If any mediators are still waiting for their values for their events, they probably called an Envoy out of order
@@ -632,6 +639,7 @@ class Mediator:
         self.cross_invoker = None
 
         self.original_globals = {}
+        self._deferred_exception = None
 
         self._prev = None
 
@@ -874,6 +882,13 @@ class Mediator:
 
             # because of the defered execution of NNsight, we need to rebuild where the execption was in the original user code instead of this execption.
             exception = wrap_exception(exception, self.info)
+
+            # In vLLM mode, defer the exception instead of re-raising inside
+            # the forward pass.  The mediator is already cancelled (above),
+            # so subsequent hooks will skip it.  Other mediators keep running.
+            if self.interleaver._defer_exceptions:
+                self._deferred_exception = exception
+                return False
 
             raise exception
 
@@ -1128,4 +1143,5 @@ class Mediator:
         self.iteration = 0
         self.args = list()
         self.original_globals = {}
+        self._deferred_exception = None
         self.cross_invoker = None

--- a/src/nnsight/intervention/tracing/backwards.py
+++ b/src/nnsight/intervention/tracing/backwards.py
@@ -7,6 +7,57 @@ from ..interleaver import Interleaver, Mediator
 from .invoker import Invoker
 
 
+def _get_batch_narrow_info(tensor: torch.Tensor):
+    """If *tensor* is a dim-0 narrow view of a base tensor, return
+    ``(base, start, size)``.  Otherwise return ``None``.
+
+    When multiple invokes are batched, ``Batcher._narrow`` slices the
+    full-batch activation along dim 0 for each invoke.  The resulting
+    view is **not** in the autograd forward path (the full tensor is
+    returned to the next module), so ``register_hook`` on the view
+    will never fire.  This helper detects such views so that
+    ``wrap_grad`` can register the hook on the base tensor instead
+    and narrow the gradient inside the hook.
+
+    TODO: This relies on ``tensor._base`` which always points to the
+    root storage owner.  It works for the common case (user accesses
+    ``module.output[0].grad`` where the tensor is a direct narrow
+    from the batcher), but may give wrong results if:
+      - The user further slices the narrow view before accessing .grad
+        (e.g. ``output[0][:, -1, :].grad``) — the storage offset
+        would reflect both operations.
+      - ``full_output`` is itself a view of an internal buffer —
+        ``_base`` would skip past it to the root tensor.
+    These are uncommon in practice for gradient access patterns.
+
+    TODO: With concurrent mediators (future), multiple hooks on the
+    same base tensor would interfere — each backward() fires ALL
+    hooks.  A module-level ``register_full_backward_hook`` approach
+    (mirroring the forward output hook) would be the correct long-term
+    solution: one hook distributes gradients to all mediators via
+    ``handle()`` + ``batcher.narrow()``.
+    """
+    base = tensor._base
+    if base is None:
+        return None
+    if tensor.dim() == 0 or base.dim() == 0:
+        return None
+    if tensor.dim() != base.dim():
+        return None
+    if tensor.shape[1:] != base.shape[1:]:
+        return None
+    if tensor.stride() != base.stride():
+        return None
+    stride0 = base.stride()[0]
+    if stride0 == 0:
+        return None
+    start = tensor.storage_offset() // stride0
+    size = tensor.shape[0]
+    if start + size > base.shape[0]:
+        return None
+    return (base, start, size)
+
+
 def wrap_grad(interleaver: Interleaver):
     """
     Create a hook for gradient intervention.
@@ -15,14 +66,32 @@ def wrap_grad(interleaver: Interleaver):
         A function that can be used to intercept gradients
     """
 
-    def wrap(tensor: torch.Tensor):
+    # Track which (hook_target_id, provider_id) pairs have been wrapped
+    # so multiple narrow views of the same base each get their own hook.
+    _wrapped: set = set()
 
-        # Only wrap the tensor once
-        if tensor._backward_hooks:
-            return
+    def wrap(tensor: torch.Tensor):
 
         # We are providing the grad of the tensor
         provider = id(tensor)
+
+        # When the tensor is a batch-dim narrow view (created by
+        # Batcher._narrow), the view is NOT in the autograd forward
+        # path — the full-batch base tensor is what flows through the
+        # model.  A hook on the view would never fire.  Register on
+        # the base instead and narrow the gradient in the hook.
+        narrow_info = _get_batch_narrow_info(tensor)
+
+        if narrow_info is not None:
+            hook_target, batch_start, batch_size = narrow_info
+        else:
+            hook_target = tensor
+            batch_start = batch_size = None
+
+        key = (id(hook_target), provider)
+        if key in _wrapped:
+            return
+        _wrapped.add(key)
 
         # Well need to remove the hook
         hook = None
@@ -30,17 +99,27 @@ def wrap_grad(interleaver: Interleaver):
         # On backwards for this tensor
         def inner(grad: torch.Tensor):
 
-            # Inject the grad value
-            # Possibly editing it in the process
             try:
-                grad = interleaver.handle(f"{provider}.grad", grad)
+                if batch_start is not None:
+                    # Narrow the full-batch gradient to this invoke's slice.
+                    narrow_grad = grad.narrow(0, batch_start, batch_size)
+                    result = interleaver.handle(f"{provider}.grad", narrow_grad)
+                    # If the user modified the gradient, splice it back
+                    # into the full gradient.
+                    if result is not narrow_grad:
+                        grad = grad.clone()
+                        grad[batch_start : batch_start + batch_size] = result
+                        return grad
+                else:
+                    # No batching — handle the gradient directly.
+                    grad = interleaver.handle(f"{provider}.grad", grad)
             finally:
                 hook.remove()
 
             return grad
 
         # Register the hook
-        hook = tensor.register_hook(inner)
+        hook = hook_target.register_hook(inner)
 
     def getter(tensor: torch.Tensor):
 

--- a/src/nnsight/intervention/tracing/globals.py
+++ b/src/nnsight/intervention/tracing/globals.py
@@ -1,9 +1,22 @@
+import contextvars
 from typing import Any, Callable, Tuple, Union
 
 import torch
 from typing_extensions import Self
 from ..._c.py_mount import mount
 from ... import CONFIG
+
+# Per-context state: each async task / thread gets its own stack and saves.
+_stack_var: contextvars.ContextVar[int] = contextvars.ContextVar("nnsight_stack", default=0)
+_saves_var: contextvars.ContextVar[set] = contextvars.ContextVar("nnsight_saves", default=None)
+
+
+def _get_saves() -> set:
+    s = _saves_var.get()
+    if s is None:
+        s = set()
+        _saves_var.set(s)
+    return s
 
 
 def save(object: Any):
@@ -15,7 +28,7 @@ def save(object: Any):
     if isinstance(object, torch.Tensor) and object.is_inference():
         object = object.clone()
 
-    Globals.saves.add(id(object))
+    _get_saves().add(id(object))
 
     return object
 
@@ -34,7 +47,7 @@ class Object(torch.Tensor):
         >>> print(attn_0)
         """
 
-        if Globals.stack == 0:
+        if _stack_var.get() == 0:
             raise RuntimeError(
                 ".save() called outside of a trace context. "
                 "Use .save() only inside a `with model.trace(...)` block."
@@ -93,14 +106,30 @@ class TracingCache:
         self.code_cache.clear()
 
 
-class Globals:
+class _GlobalsMeta(type):
+    """Metaclass that routes Globals.stack and Globals.saves to contextvars."""
 
-    stack = 0
+    @property
+    def stack(cls) -> int:
+        return _stack_var.get()
 
-    saves = set()
+    @stack.setter
+    def stack(cls, value: int):
+        _stack_var.set(value)
 
+    @property
+    def saves(cls) -> set:
+        return _get_saves()
+
+    @saves.setter
+    def saves(cls, value: set):
+        _saves_var.set(value)
+
+
+class Globals(metaclass=_GlobalsMeta):
+
+    # cache and _mounted are process-wide (shared across all tasks).
     cache = TracingCache()
-
     _mounted = False
 
     @staticmethod
@@ -109,14 +138,18 @@ class Globals:
         if CONFIG.APP.PYMOUNT and not Globals._mounted:
             mount(Object.save, "save")
             Globals._mounted = True
-        Globals.stack += 1
+        cur = _stack_var.get()
+        if cur == 0:
+            # New trace context — start with a fresh saves set.
+            _saves_var.set(set())
+        _stack_var.set(cur + 1)
 
     @staticmethod
     def exit():
-        Globals.stack -= 1
+        _stack_var.set(_stack_var.get() - 1)
 
     @staticmethod
     def clear():
-        Globals.saves.clear()
+        _get_saves().clear()
         Globals.cache.clear()
-        Globals.stack = 0
+        _stack_var.set(0)

--- a/src/nnsight/intervention/tracing/globals.py
+++ b/src/nnsight/intervention/tracing/globals.py
@@ -8,6 +8,13 @@ from ... import CONFIG
 
 def save(object: Any):
 
+    # Clone inference-mode tensors on save to protect against downstream
+    # in-place mutations by fused kernels (e.g. vLLM's fused_add_rms_norm).
+    # The clone is a separate allocation so fused ops mutate the original,
+    # not the user's saved reference.
+    if isinstance(object, torch.Tensor) and object.is_inference():
+        object = object.clone()
+
     Globals.saves.add(id(object))
 
     return object
@@ -33,9 +40,7 @@ class Object(torch.Tensor):
                 "Use .save() only inside a `with model.trace(...)` block."
             )
 
-        save(self)
-
-        return self
+        return save(self)
 
     def __getattr__(self, name: str) -> Self:
 

--- a/src/nnsight/intervention/tracing/tracer.py
+++ b/src/nnsight/intervention/tracing/tracer.py
@@ -406,8 +406,19 @@ class InterleavingTracer(Tracer):
 
         return self._frame
 
-    def _setup_interleaver(self, fn: Callable):
-        """Run compiled user code, collect batched args, and initialize the interleaver.
+    def _setup_interleaver(self, fn: Callable, init_interleaver: bool = True):
+        """Run compiled user code, collect batched args, and (optionally) initialize the interleaver.
+
+        ``init_interleaver=False`` is for server paths (HTTP handlers) that
+        share ``model._interleaver`` with a background execution thread.
+        ``Interleaver.initialize`` resets ``self.current = None`` and replaces
+        ``self.mediators``/``self.batcher``. On a background thread, this races
+        with ``Mediator.start()`` — which relies on ``current = self`` staying
+        stable between ``worker.start()`` and the worker's first ``.output``
+        access. Callers that pass ``init_interleaver=False`` must read
+        mediators from ``self.mediators`` (the tracer's own list, always
+        populated here by ``fn(info, tracer)``) rather than
+        ``model._interleaver.mediators``.
 
         Returns:
             (args, kwargs): The batched positional and keyword arguments.
@@ -420,8 +431,9 @@ class InterleavingTracer(Tracer):
         self.batcher.batched_args = tuple()
         self.batcher.batched_kwargs = {}
 
-        interleaver = self.model._interleaver
-        interleaver.initialize(self.mediators, self, batcher=self.batcher)
+        if init_interleaver:
+            interleaver = self.model._interleaver
+            interleaver.initialize(self.mediators, self, batcher=self.batcher)
 
         return args, kwargs
 

--- a/src/nnsight/intervention/tracing/tracer.py
+++ b/src/nnsight/intervention/tracing/tracer.py
@@ -406,19 +406,10 @@ class InterleavingTracer(Tracer):
 
         return self._frame
 
-    def _setup_interleaver(self, fn: Callable, init_interleaver: bool = True):
-        """Run compiled user code, collect batched args, and (optionally) initialize the interleaver.
+    def _run_user_fn(self, fn: Callable):
+        """Run compiled user code and collect the batched arguments.
 
-        ``init_interleaver=False`` is for server paths (HTTP handlers) that
-        share ``model._interleaver`` with a background execution thread.
-        ``Interleaver.initialize`` resets ``self.current = None`` and replaces
-        ``self.mediators``/``self.batcher``. On a background thread, this races
-        with ``Mediator.start()`` — which relies on ``current = self`` staying
-        stable between ``worker.start()`` and the worker's first ``.output``
-        access. Callers that pass ``init_interleaver=False`` must read
-        mediators from ``self.mediators`` (the tracer's own list, always
-        populated here by ``fn(info, tracer)``) rather than
-        ``model._interleaver.mediators``.
+        Populates ``self.mediators`` as a side effect of ``fn(info, self)``.
 
         Returns:
             (args, kwargs): The batched positional and keyword arguments.
@@ -431,11 +422,22 @@ class InterleavingTracer(Tracer):
         self.batcher.batched_args = tuple()
         self.batcher.batched_kwargs = {}
 
-        if init_interleaver:
-            interleaver = self.model._interleaver
-            interleaver.initialize(self.mediators, self, batcher=self.batcher)
-
         return args, kwargs
+
+    def _init_shared_interleaver(self):
+        """Bind this tracer's mediators onto ``model._interleaver``.
+
+        Skip this from server-side paths (HTTP handlers, async vLLM backends)
+        where another thread / process already owns ``model._interleaver``.
+        ``Interleaver.initialize`` resets ``current = None`` and replaces
+        ``mediators``/``batcher``; on a background thread that races with
+        ``Mediator.start()`` (which relies on ``current = self`` staying
+        stable between ``worker.start()`` and the worker's first ``.output``
+        access). Callers that skip this must read mediators from
+        ``self.mediators`` rather than ``model._interleaver.mediators``.
+        """
+        interleaver = self.model._interleaver
+        interleaver.initialize(self.mediators, self, batcher=self.batcher)
 
     def execute(self, fn: Callable):
         """
@@ -443,7 +445,8 @@ class InterleavingTracer(Tracer):
         then creates an Interleaver to manage the interventions during model execution.
         """
 
-        args, kwargs = self._setup_interleaver(fn)
+        args, kwargs = self._run_user_fn(fn)
+        self._init_shared_interleaver()
 
         try:
             self.model.interleave(self.fn, *args, **kwargs)
@@ -471,36 +474,6 @@ class InterleavingTracer(Tracer):
         """
         # TODO make sure not already executing
         return Invoker(self, *args, **kwargs)
-
-    def collect(self, timeout: float = None) -> Dict:
-        """Block until a non-blocking serve request completes and return saves.
-
-        Only valid after ``model.trace(..., serve=url, blocking=False)``.
-
-        Args:
-            timeout: Maximum seconds to wait. ``None`` means wait forever.
-
-        Returns:
-            Dict mapping saved variable names to their values.
-
-        Raises:
-            AttributeError: If the tracer was not used with ``blocking=False``.
-            Exception: Any exception from the server or network.
-
-        Example::
-
-            with model.trace("prompt", serve=url, blocking=False) as t:
-                out = model.logits.output.save()
-            saves = t.collect()
-            out = saves["out"]
-        """
-        future = getattr(self, "_serve_future", None)
-        if future is None:
-            raise AttributeError(
-                "Tracer has no pending serve request. "
-                "Did you use blocking=False?"
-            )
-        return future.result(timeout=timeout)
 
     def stop(self):
         """

--- a/src/nnsight/intervention/tracing/tracer.py
+++ b/src/nnsight/intervention/tracing/tracer.py
@@ -460,6 +460,36 @@ class InterleavingTracer(Tracer):
         # TODO make sure not already executing
         return Invoker(self, *args, **kwargs)
 
+    def collect(self, timeout: float = None) -> Dict:
+        """Block until a non-blocking serve request completes and return saves.
+
+        Only valid after ``model.trace(..., serve=url, blocking=False)``.
+
+        Args:
+            timeout: Maximum seconds to wait. ``None`` means wait forever.
+
+        Returns:
+            Dict mapping saved variable names to their values.
+
+        Raises:
+            AttributeError: If the tracer was not used with ``blocking=False``.
+            Exception: Any exception from the server or network.
+
+        Example::
+
+            with model.trace("prompt", serve=url, blocking=False) as t:
+                out = model.logits.output.save()
+            saves = t.collect()
+            out = saves["out"]
+        """
+        future = getattr(self, "_serve_future", None)
+        if future is None:
+            raise AttributeError(
+                "Tracer has no pending serve request. "
+                "Did you use blocking=False?"
+            )
+        return future.result(timeout=timeout)
+
     def stop(self):
         """
         Raise an EarlyStopException to stop the execution of the model.

--- a/src/nnsight/modeling/mixins/remoteable.py
+++ b/src/nnsight/modeling/mixins/remoteable.py
@@ -66,10 +66,10 @@ class RemoteableMixin(MetaMixin):
             backend = RemoteBackend(
                 self.to_model_key(), host=backend, blocking=blocking
             )
+        kwargs.setdefault("tracer_cls", RemoteInterleavingTracer)
         return super().trace(
             *inputs,
             backend=backend,
-            tracer_cls=RemoteInterleavingTracer,
             **kwargs,
         )
 
@@ -102,10 +102,10 @@ class RemoteableMixin(MetaMixin):
             backend = RemoteBackend(
                 self.to_model_key(), host=backend, blocking=blocking
             )
+        kwargs.setdefault("tracer_cls", RemoteTracer)
         return super().session(
             *inputs,
             backend=backend,
-            tracer_cls=RemoteTracer,
             **kwargs,
         )
 

--- a/src/nnsight/modeling/vllm/async_backend.py
+++ b/src/nnsight/modeling/vllm/async_backend.py
@@ -104,6 +104,12 @@ class AsyncVLLMBackend(Backend):
             )
             saves_bytes = next((r for r in results if r is not None), None)
             if saves_bytes:
-                saves = pickle.loads(saves_bytes)
-                output.saves = saves
+                # Worker returns ``{base_id: {var_name: value}}``.  Pull
+                # out this request's own sub-dict — the outer layer
+                # exists to keep concurrent separate-trace requests
+                # from colliding at shared variable names.
+                saves_by_req = pickle.loads(saves_bytes)
+                per_req = saves_by_req.get(output.request_id)
+                if per_req:
+                    output.saves = per_req
             yield output

--- a/src/nnsight/modeling/vllm/async_backend.py
+++ b/src/nnsight/modeling/vllm/async_backend.py
@@ -17,7 +17,7 @@ class AsyncVLLMBackend(Backend):
 
     Usage pattern:
     - ``__call__(tracer)``: Called from ``__exit__``. Compiles the traced
-      code, sets up mediators via ``_setup_interleaver()``, serializes them
+      code, sets up mediators via ``_run_user_fn()``, serializes them
       into sampling params, and stores the prepared data on this backend.
     - ``__call__()``: Called by user via ``tracer.backend()``. Returns an
       async generator that streams ``RequestOutput`` objects from ``AsyncLLM``.
@@ -33,21 +33,21 @@ class AsyncVLLMBackend(Backend):
     def _compile_and_execute(self, tracer):
         """Compile traced code, set up mediators, and serialize them.
 
-        Uses ``tracer._setup_interleaver()`` directly instead of going
-        through ``tracer.execute()`` / ``model.interleave()``, since the
-        async path only needs to serialize mediators — not run the model.
+        Uses ``tracer._run_user_fn()`` directly instead of going through
+        ``tracer.execute()`` / ``model.interleave()``, since the async path
+        only needs to serialize mediators — not run the model.
         """
         fn = Backend.__call__(self, tracer)
 
         try:
             Globals.enter()
 
-            # init_interleaver=False: vLLM async workers mutate
-            # ``model._interleaver`` on another thread. Calling
-            # ``Interleaver.initialize`` here would reset
+            # We deliberately do NOT call ``_init_shared_interleaver()``:
+            # vLLM async workers mutate ``model._interleaver`` on another
+            # thread. Calling ``Interleaver.initialize`` here would reset
             # ``interleaver.current`` to ``None`` and race with a concurrent
             # ``Mediator.start()`` on the worker thread.
-            args, kwargs = tracer._setup_interleaver(fn, init_interleaver=False)
+            args, kwargs = tracer._run_user_fn(fn)
 
             if not self.model.dispatched:
                 self.model.dispatch()

--- a/src/nnsight/modeling/vllm/async_backend.py
+++ b/src/nnsight/modeling/vllm/async_backend.py
@@ -42,15 +42,20 @@ class AsyncVLLMBackend(Backend):
         try:
             Globals.enter()
 
-            # Set up mediators and collect batched args (shared with sync path).
-            args, kwargs = tracer._setup_interleaver(fn)
+            # init_interleaver=False: vLLM async workers mutate
+            # ``model._interleaver`` on another thread. Calling
+            # ``Interleaver.initialize`` here would reset
+            # ``interleaver.current`` to ``None`` and race with a concurrent
+            # ``Mediator.start()`` on the worker thread.
+            args, kwargs = tracer._setup_interleaver(fn, init_interleaver=False)
 
             if not self.model.dispatched:
                 self.model.dispatch()
 
-            # Serialize mediators into sampling params.
+            # Serialize mediators into sampling params. Pass tracer.mediators
+            # explicitly because we skipped initialize() above.
             prompts, params, lora_requests = self.model._serialize_mediators(
-                *args, **kwargs
+                *args, mediators=tracer.mediators, **kwargs
             )
             self._prompts = prompts
             self._params = params

--- a/src/nnsight/modeling/vllm/engines/engine.py
+++ b/src/nnsight/modeling/vllm/engines/engine.py
@@ -24,9 +24,18 @@ class NNsightLLMEngine(LLMEngine):
             # results is a list (one per worker). Rank-0 returns pickled bytes, others None.
             saves_bytes = next((r for r in results if r is not None), None)
             if saves_bytes:
-                saves = pickle.loads(saves_bytes)
+                # Worker returns ``{base_id: {var_name: value}}`` so the
+                # step attaches each request's OWN saves sub-dict to its
+                # OWN RequestOutput.  The previous ``ro.saves = saves``
+                # (same dict bound to every finished output) entangled
+                # concurrent separate traces whose user code used
+                # overlapping variable names — one winner clobbered the
+                # rest.  See Bug A in PP_DESIGN notes.
+                saves_by_req = pickle.loads(saves_bytes)
                 for ro in request_outputs:
                     if ro.finished:
-                        ro.saves = saves
+                        per_req = saves_by_req.get(ro.request_id)
+                        if per_req:
+                            ro.saves = per_req
 
         return request_outputs

--- a/src/nnsight/modeling/vllm/intervention-gaps/REPORT.md
+++ b/src/nnsight/modeling/vllm/intervention-gaps/REPORT.md
@@ -1,0 +1,267 @@
+# vLLM ↔ HuggingFace Intervention Gap Report
+
+**Date:** 2026-03-24
+**Model:** Qwen/Qwen2-0.5B
+**vLLM version:** 0.15.1
+**nnsight branch:** worktree-vllm_debug
+**Hardware:** 8× NVIDIA A100 (vLLM on GPU 0, HF on GPU 1)
+
+## Summary
+
+**13 gaps documented.** Gap 1.1 is mitigated by general inference-mode cloning. All others are documented differences or hard blocks.
+
+| Gap | Description | Status |
+|-----|-------------|--------|
+| 1.1 | In-place mutation corrupts `.save()` | **FIXED** — clone-on-save for inference tensors |
+| 1.2 | Decoder layer output: `(mlp, res)` vs `(combined,)` | DOCUMENTED |
+| 1.3 | Decoder layer `.input` returns int64 positions | DOCUMENTED |
+| 1.4 | LayerNorm output: tuple vs tensor | DOCUMENTED |
+| 1.5 | LayerNorm input semantics differ | DOCUMENTED |
+| 2.1 | MLP submodule layout (merged gate\_up\_proj) | DOCUMENTED |
+| 2.2 | Attention submodule layout (merged qkv\_proj) | DOCUMENTED |
+| 2.3 | RowParallelLinear returns tuple | DOCUMENTED |
+| 3.1 | Flat batch dimension [total\_tokens, hidden] | DOCUMENTED |
+| 3.2 | PagedAttention: no attention weights | HARD BLOCK |
+| 4.1 | Gradients blocked by inference\_mode | HARD BLOCK |
+| 4.2 | Source tracing into fused kernels | HARD BLOCK |
+| 4.3 | Module skip breaks fused norm | DOCUMENTED |
+
+The gap descriptions below document the **architectural differences** between vLLM and HuggingFace backends. Users must account for these when writing vLLM interventions.
+
+---
+
+## Group 1: Activation Semantics
+
+### Gap 1.1 — In-place mutation corrupts `.save()` — **FIXED**
+
+**Root cause:** vLLM's `fused_add_rms_norm` mutates tensors in-place after nnsight hooks fire. `.save()` stores a reference, so the saved value silently becomes the post-mutation value.
+
+**Evidence:**
+- `layer.output[0]` ref vs clone: diff = **64.62**
+- `layer.output[1]` ref vs clone: diff = **1013.81**
+- `mlp.output` and `self_attn.output`: unaffected (not mutated downstream)
+
+**Fix:** `.save()` automatically clones inference-mode tensors (`tensor.is_inference()`). The clone is a separate allocation, so downstream fused-kernel mutations affect the original tensor flowing through the model, not the user's saved reference. This is architecture-agnostic — it fires on any inference-mode tensor, not just vLLM.
+
+**Impact:** Transparent to users. `.save()` returns a safe copy on vLLM; no behavior change on HF (tensors are not inference-mode).
+
+---
+
+### Gap 1.2 — Decoder layer output semantics differ
+
+**Root cause:** vLLM maintains a dual residual stream. Decoder layers return `(hidden_states, residual)` as separate tuple elements. HF returns `(hidden_states + residual,)` combined.
+
+**Evidence:**
+- vLLM: output is 2-tuple; `output[0] == mlp.output` (cosine = 1.0)
+- HF: output is 1-tuple; `output[0] != mlp.output` (cosine = 0.45) because it includes the residual
+
+**Impact:** Users must combine streams manually: `combined = layer.output[0] + layer.output[1]`. Logit lens, steering vectors, activation patching all need to account for the dual-stream format.
+
+---
+
+### Gap 1.3 — Decoder layer input semantics differ
+
+**Root cause:** vLLM decoder signature is `forward(positions, hidden_states, residual, ...)`. The first positional arg (`.input`) is int64 position IDs, not float hidden states.
+
+**Evidence:**
+- vLLM `.input` dtype: `torch.int64`, values: `[0, 1, 2, 3, 4]`
+- HF `.input` dtype: `torch.float32`, shape: `[1, 5, 896]`
+
+**Impact:** `.input` returns position IDs, not hidden states. Use `.inputs` to access the full `(args, kwargs)` and extract `args[1]` (hidden\_states) and `args[2]` (residual) directly.
+
+---
+
+### Gap 1.4 — LayerNorm output: tensor vs tuple
+
+**Root cause:** vLLM's fused `fused_add_rms_norm` returns `(normalized, new_residual)` tuple. HF returns a single tensor.
+
+**Evidence:**
+- vLLM `input_layernorm.output`: is tuple = True
+- HF `input_layernorm.output`: is tensor = True
+
+**Impact:** Use `norm.output[0]` to get the normalized tensor. Logit lens code must extract from tuple: `normed = model.model.norm.output[0]`.
+
+---
+
+### Gap 1.5 — LayerNorm input semantics differ
+
+**Root cause:** vLLM uses `fused_add_rms_norm(x, residual)` (2 args). HF uses `RMSNorm(hidden)` (1 arg).
+
+**Evidence:**
+- vLLM `input_layernorm`: num_args = 2
+- HF `input_layernorm`: num_args = 1
+
+**Impact:** Reading/modifying layernorm inputs gets incomplete value (raw output without residual component).
+
+---
+
+## Group 2: Module Architecture
+
+### Gap 2.1 — MLP submodule layout (merged gate\_up\_proj)
+
+**Root cause:** vLLM uses a single `MergedColumnParallelLinear` (`gate_up_proj`) instead of separate `gate_proj` and `up_proj`.
+
+**Evidence:**
+- vLLM: `gate_proj=False`, `up_proj=False`, `gate_up_proj=True`
+- HF: `gate_proj=True`, `up_proj=True`, `gate_up_proj=False`
+
+**Impact:** Cannot analyze/ablate gate vs up projections separately. SAE training on individual projections impossible.
+
+---
+
+### Gap 2.2 — Attention submodule layout (merged qkv\_proj)
+
+**Root cause:** vLLM uses a single `QKVParallelLinear` (`qkv_proj`) instead of separate `q_proj`, `k_proj`, `v_proj`.
+
+**Evidence:**
+- vLLM: `q_proj=False`, `k_proj=False`, `v_proj=False`, `qkv_proj=True`
+- HF: `q_proj=True`, `k_proj=True`, `v_proj=True`, `qkv_proj=False`
+
+**Impact:** Attention head analysis, key/value editing, Q/K/V-specific interventions all require manual tensor splitting.
+
+---
+
+### Gap 2.3 — RowParallelLinear returns tuple
+
+**Root cause:** vLLM's `RowParallelLinear` returns `(output, output_bias)` 2-tuple. HF `Linear` returns a single tensor.
+
+**Evidence:**
+- vLLM: `down_proj` tuple = True, `o_proj` tuple = True
+- HF: `down_proj` tuple = False, `o_proj` tuple = False
+
+**Impact:** Use `down_proj.output[0]` to get the tensor. `down_proj.output * 2` fails without unpacking.
+
+---
+
+## Group 3: Data Layout & Accessibility
+
+### Gap 3.1 — Flat batch dimension [total\_tokens, hidden]
+
+**Root cause:** vLLM uses continuous batching with a flat 2D layout `[total_tokens, hidden]`. HF natively uses padded 3D `[batch, seq, hidden]`.
+
+**Evidence:**
+- vLLM: ndim = 2, shape = `[7, 896]` — tokens from all sequences packed flat
+- HF: ndim = 2, shape = `[7, 896]` — nnsight's batcher narrows the batch dimension even for single-input traces (implicit invoke)
+
+**Clarification:** Inside nnsight traces, both backends produce 2D tensors because nnsight creates an implicit invoke that narrows the batch dimension. The gap manifests in two ways: (1) **Doc examples use 3D indexing** like `[:, -1, :]` which assumes a `[batch, seq, hidden]` layout — these fail on vLLM because the native format is flat `[total_tokens, hidden]` with no sequence dimension; (2) **Multi-sequence batching** in vLLM packs all tokens contiguously with no padding, so token boundary tracking requires out-of-band knowledge of sequence lengths. Use `[-1, :]` for last-token selection on both backends inside traces.
+
+**Impact:** Positional indexing like `[:, -1, :]` (last token) or `[:, pos, :]` breaks. Token targeting requires knowing token boundaries in the flat layout.
+
+---
+
+### Gap 3.2 — PagedAttention: no attention weights
+
+**Root cause:** vLLM's PagedAttention computes attention entirely in C/CUDA. No Python-level attention weight tensor exists.
+
+**Evidence:**
+- vLLM attn output: single tensor, shape `[7, 896]`
+- HF attn output: tuple, length 2 (hidden\_states + attention\_weights)
+
+**Impact:** Attention visualization, head pruning, induction head detection, attention knockout all impossible. Fundamental architectural limitation.
+
+---
+
+## Group 4: Advanced Features
+
+### Gap 4.1 — Gradients blocked by inference\_mode
+
+**Root cause:** vLLM wraps all execution in `torch.inference_mode()`, disabling gradient tracking globally.
+
+**Evidence:**
+- vLLM: `requires_grad_()` FAILED (RuntimeError from inference\_mode), `backward()` FAILED
+- HF: `requires_grad_()` OK, `backward()` FAILED (unrelated nnsight interleaver issue — grad not captured for this model/layer combination; the key asymmetry is that `requires_grad_()` itself succeeds on HF, proving no inference\_mode barrier)
+
+**Impact:** Integrated gradients, GradCAM, saliency maps, gradient-based attribution, probe training all impossible.
+
+---
+
+### Gap 4.2 — Source tracing into fused kernels
+
+**Root cause:** vLLM's fused modules (`input_layernorm`, `act_fn`, PagedAttention) have trivial Python wrappers that delegate to C/CUDA. `.source` reveals only the delegate call.
+
+**Evidence:**
+- vLLM `input_layernorm`: 1 op (175 chars) — single delegate
+- HF `input_layernorm`: 6 ops — full Python-visible computation
+- vLLM `act_fn`: 1 op vs HF: 2 ops
+
+**Impact:** Fine-grained intervention inside fused modules impossible. Intervention granularity capped at module level.
+
+---
+
+### Gap 4.3 — Module skip breaks fused norm
+
+**Root cause:** vLLM decoder layers return `(hidden_states, residual)` tuple. Skipping with a single tensor fails because the next layer's `fused_add_rms_norm` expects the `(x, residual)` pair.
+
+**Evidence:**
+- vLLM `skip(single_tensor)`: FAILED (EngineDeadError — unrecoverable engine crash)
+- vLLM `skip(tuple)`: FAILED (EngineDeadError — engine already dead from first attempt)
+- HF `skip(single_tensor)`: FAILED (shape mismatch — HF layers also expect tuple input)
+- HF `skip(tuple)`: OK
+
+**Note:** `skip(single_tensor)` fails on both backends, but for different reasons: HF raises a shape error (recoverable), while vLLM crashes the engine (unrecoverable — all subsequent traces fail with `EngineDeadError`, requiring process restart). The deferred exception mechanism prevents engine death but the skip still fails.
+
+**Impact:** Skip values must match vLLM's expected format `(hidden_states, residual)`. Use `layer.skip((zeros, value))` for layer ablation.
+
+---
+
+## Architectural Root Causes
+
+All 13 gaps stem from four architectural decisions in vLLM:
+
+1. **Fused CUDA kernels** — `fused_add_rms_norm`, `SiluAndMul`, PagedAttention mutate tensors in-place, return tuples, and hide internals from Python hooks. (Gaps 1.1, 1.4, 1.5, 3.2, 4.2, 4.3)
+
+2. **Dual residual stream** — Hidden states and residual are kept as separate tensors throughout the forward pass, unlike HF which combines them. (Gaps 1.2, 1.3)
+
+3. **Merged linear layers** — `ColumnParallelLinear` (gate\_up\_proj, qkv\_proj) and `RowParallelLinear` (returning tuples) for tensor parallelism. (Gaps 2.1, 2.2, 2.3)
+
+4. **Continuous batching + inference\_mode** — Flat `[total_tokens, hidden]` layout and `torch.inference_mode()` wrapper for performance. (Gaps 3.1, 4.1)
+
+---
+
+## Fixability Assessment
+
+| Category | Status | Notes |
+|----------|--------|-------|
+| **Gap 1.1** (mutation) | **Fixed** | `.save()` auto-clones inference-mode tensors |
+| **Gap 1.2** (dual residual output) | Documented | Users combine streams manually |
+| **Gap 1.3** (input positions) | Documented | Use `.inputs` to access hidden states at `args[1]` |
+| **Gap 1.4** (norm tuple) | Documented | Use `.output[0]` to get normalized tensor |
+| **Gap 1.5** (norm input) | Documented | vLLM passes 2 args, HF passes 1 |
+| **Gaps 2.1–2.2** (merged modules) | Not fixable | Fundamental vLLM architecture; use `.chunk()` / `.split()` |
+| **Gap 2.3** (RowParallel tuple) | Documented | Use `.output[0]` to get tensor |
+| **Gap 3.1** (flat layout) | Documented | Use `[-1, :]` not `[:, -1, :]` |
+| **Gap 3.2** (no attn weights) | Not fixable | PagedAttention is a fused CUDA kernel |
+| **Gap 4.1** (no gradients) | Not fixable | `inference_mode` is set by vLLM engine |
+| **Gap 4.2** (fused source) | Not fixable | Computation happens in C/CUDA |
+| **Gap 4.3** (skip breaks) | Documented | Skip value must match `(hidden, residual)` format |
+
+---
+
+## Intervention Patterns
+
+vLLM exposes raw internal semantics. Users must account for the differences documented above.
+
+### vLLM-specific patterns
+
+| Operation | Pattern | Notes |
+|-----------|---------|-------|
+| **Save** | `layer.output[0].save()` | `.save()` auto-clones inference tensors (Gap 1.1) |
+| **Combined hidden** | `layer.output[0] + layer.output[1]` | Must combine dual streams manually (Gap 1.2) |
+| **Steer** | `layer.output[0][-1, :] += v` | 2D indexing (Gap 3.1) |
+| **Ablate** | `layer.output[0][:] = 0` | Only zeroes one stream; zero both for full ablation |
+| **Skip** | `layer.skip((zeros, value))` | Must provide `(hidden, residual)` tuple (Gap 4.3) |
+| **LayerNorm** | `norm.output[0]` | Extract from tuple (Gap 1.4) |
+| **down/o proj** | `proj.output[0]` | Extract from tuple (Gap 2.3) |
+| **Layer input** | `layer.inputs[0][1]` | `args[1]` is hidden\_states (Gap 1.3) |
+
+### Key differences from HF
+
+1. **2D layout** `[tokens, hidden]` not 3D `[batch, seq, hidden]` — index with `[-1, :]` not `[:, -1, :]` (Gap 3.1)
+2. **Logits** — use `model.logits.output` instead of `model.lm_head.output`
+3. **Generation** — use `model.trace(max_tokens=N)` instead of `model.generate(max_new_tokens=N)`
+4. **Merged projections** — `gate_up_proj` (Gap 2.1), `qkv_proj` (Gap 2.2) require `.chunk()` / `.split()`
+5. **Baseline logit gap** — vLLM and HF use different kernels (fused vs separate), producing slightly different numerical results. Compare intervention *effects* (delta from baseline), not absolute values.
+
+### vLLM's dual residual stream
+
+vLLM decoder layers return `(mlp_output, residual)` as separate tensors. The next layer's `fused_add_rms_norm` computes `RMSNorm(stream0 + stream1)`, so only the sum matters. To get the equivalent of HF's combined hidden state, add both streams: `combined = layer.output[0] + layer.output[1]`.

--- a/src/nnsight/modeling/vllm/intervention-gaps/VLLM_GUIDE.md
+++ b/src/nnsight/modeling/vllm/intervention-gaps/VLLM_GUIDE.md
@@ -1,0 +1,564 @@
+# NNsight vLLM Intervention Guide
+
+This guide mirrors the [main nnsight documentation](../../../../CLAUDE.md) (written for HuggingFace Transformers) and documents how each pattern translates to the vLLM backend — what works identically, what differs, and what is blocked.
+
+For each feature, the structure is:
+1. **HF pattern** — what users expect (from the main docs)
+2. **vLLM gap** — how vLLM's internals differ
+3. **Status** — works as-is, requires different syntax, or hard-blocked
+
+---
+
+## Hard Blocks
+
+These features are **fundamentally impossible** on vLLM due to C/CUDA-level architecture. Use the HF backend if your workflow requires them.
+
+| Feature | Why blocked | Impact |
+|---------|------------|--------|
+| **Gradients / backward** | `torch.inference_mode()` globally disables gradients. `requires_grad_(True)` raises `RuntimeError`. | Integrated gradients, saliency maps, GradCAM, all gradient-based attribution. |
+| **Attention weights** | PagedAttention computes attention in C/CUDA. No Python-level weight tensor exists. | Attention visualization, head pruning, induction head detection. |
+| **Source tracing (fused modules)** | Fused kernels have trivial Python wrappers. `.source` shows only the delegate call. Non-fused modules (e.g. `self_attn`) work fine. | Fine-grained intervention inside fused ops (layernorm, act_fn). |
+
+---
+
+## Remaining Differences
+
+These require different vLLM syntax:
+
+| Difference | HF | vLLM | Notes |
+|---|---|---|---|
+| **Decoder output** | `(combined_hidden,)` 1-tuple | `(mlp_output, residual)` 2-tuple | Combine manually: `out[0] + out[1]` |
+| **Decoder input** | `.input` → float hidden states | `.input` → int64 positions | Use `.inputs[0][1]` for hidden states |
+| **LayerNorm output** | Single tensor | `(normalized, residual)` tuple | Use `.output[0]` |
+| **RowParallel output** | Single tensor | `(output, bias)` tuple | Use `.output[0]` for down\_proj, o\_proj |
+| **Logits** | `model.lm_head.output` `[1, seq, vocab]` | `model.logits.output` `[1, vocab]` (last token only) | Different module path and scope |
+| **Generation** | `model.generate(max_new_tokens=N)` | `model.trace(max_tokens=N)` | Different method and kwarg |
+| **gate/up proj** | `mlp.gate_proj`, `mlp.up_proj` (separate) | `mlp.gate_up_proj` (merged) | `gate, up = output.chunk(2, dim=-1)` |
+| **q/k/v proj** | `attn.q_proj`, `attn.k_proj`, `attn.v_proj` | `attn.qkv_proj` (merged) | `q, k, v = output.split([q, kv, kv], dim=-1)` |
+| **Module skip** | `layer.skip(value)` | Must provide `(hidden, residual)` tuple | `layer.skip((zeros, value))` |
+| **`__name__` guard** | Not required | `if __name__ == "__main__":` required | vLLM uses `spawn` multiprocessing |
+| **Module calls outside trace** | Works (weights are local) | Fails (weights on meta device) | Must call modules inside trace |
+
+---
+
+## Prefix Caching
+
+NNsight **disables prefix caching by default** (`enable_prefix_caching=False`). The impact of prefix caching on interventions is not fully understood. We disable it as a precaution.
+
+This is also why NNsight does not support [SGLang](https://github.com/sgl-project/sglang) — SGLang does not allow disabling its RadixAttention prefix cache.
+
+---
+
+## Setup
+
+### HF
+```python
+from nnsight import LanguageModel
+model = LanguageModel("Qwen/Qwen2-0.5B", device_map="auto", dispatch=True)
+```
+
+### vLLM
+```python
+from nnsight.modeling.vllm import VLLM
+
+if __name__ == "__main__":
+    model = VLLM("Qwen/Qwen2-0.5B", tensor_parallel_size=1,
+                 gpu_memory_utilization=0.3, dispatch=True)
+```
+
+**`__name__` guard is required.** vLLM uses `spawn` multiprocessing to create engine worker processes. Without the guard, the spawned process re-imports your script and re-executes all module-level code, causing infinite recursion or duplicate engine creation.
+
+---
+
+## Accessing Hidden States
+
+### HF pattern
+```python
+with model.trace("Hello"):
+    hidden = model.model.layers[-1].output[0].save()
+# shape [batch, seq, hidden_dim]
+```
+
+### vLLM gap
+Decoder layers return `(mlp_output, residual)` — two separate tensors instead of a combined hidden state.
+
+### Status: **Different format — combine manually**
+```python
+with model.trace("Hello"):
+    # output is (mlp_output, residual) — combine for HF-equivalent hidden state
+    combined = (model.model.layers[-1].output[0] + model.model.layers[-1].output[1]).save()
+# shape [tokens, hidden_dim] — 2D instead of HF's 3D
+```
+
+---
+
+## Saving Values
+
+### HF pattern
+```python
+with model.trace("Hello"):
+    hidden = model.model.layers[0].output[0].save()
+# hidden is a real tensor after the context exits
+```
+
+### vLLM gap
+vLLM's `fused_add_rms_norm` mutates tensors in-place after hooks fire, silently corrupting `.save()`'d references.
+
+### Status: **Fixed — clone-on-save**
+```python
+with model.trace("Hello"):
+    hidden = model.model.layers[0].output[0].save()
+# Mutation-safe — .save() auto-clones inference-mode tensors
+```
+
+`.save()` detects inference-mode tensors and clones them automatically. No behavior change on HF (tensors are not inference-mode).
+
+---
+
+## Accessing Logits
+
+### HF pattern
+```python
+with model.trace("Hello"):
+    logits = model.lm_head.output.save()   # all tokens, shape [batch, seq, vocab]
+```
+
+### vLLM gap
+vLLM only computes `lm_head` on the last token (sufficient for sampling). Logits are exposed through `model.logits`, not `model.lm_head`.
+
+### Status: **Different syntax required**
+```python
+with model.trace("Hello"):
+    logits = model.logits.output.save()   # last token only, shape [1, vocab]
+```
+
+---
+
+## Accessing Layer Inputs
+
+### HF pattern
+```python
+with model.trace("Hello"):
+    layer_input = model.model.layers[0].input.save()
+# Returns float hidden states
+```
+
+### vLLM gap
+Decoder layer forward signature is `(positions, hidden_states, residual, ...)`. Raw `.input` returns `positions` (int64), not the hidden state.
+
+### Status: **Different format — use `.inputs`**
+```python
+with model.trace("Hello"):
+    # .input returns positions (int64). Use .inputs for full args:
+    args, kwargs = model.model.layers[4].inputs
+    hidden_states = args[1]     # float tensor
+    residual = args[2]          # float tensor (None for layer 0)
+    combined = hidden_states + residual if residual is not None else hidden_states
+    combined = combined.save()
+```
+
+---
+
+## Modifying Activations — Ablation
+
+### HF pattern
+```python
+with model.trace("Hello"):
+    model.model.layers[0].output[0][:] = 0
+```
+
+### vLLM gap
+In-place assignment on the raw dual-stream output would only zero one stream.
+
+### Status: **Different format — zero both streams**
+```python
+with model.trace("Hello"):
+    # Must zero both streams for full ablation
+    model.model.layers[0].output[0][:] = 0  # mlp_output stream
+    model.model.layers[0].output[1][:] = 0  # residual stream
+```
+
+---
+
+## Modifying Activations — Steering
+
+### HF pattern
+```python
+steering_vector = torch.randn(hidden_dim)
+with model.trace("Hello"):
+    model.model.layers[10].output[0][:, -1, :] += steering_vector
+```
+
+### vLLM gap
+Same dual-stream issue as ablation, plus 2D tensor layout.
+
+### Status: **Different format — steer the appropriate stream**
+```python
+steering_vector = torch.randn(hidden_dim, dtype=torch.bfloat16).cuda()
+with model.trace("Hello"):
+    # Add to mlp_output stream (output[0]) or residual stream (output[1])
+    model.model.layers[10].output[0][-1, :] += steering_vector
+```
+
+---
+
+## Activation Patching
+
+### HF pattern
+```python
+with model.trace() as tracer:
+    barrier = tracer.barrier(2)
+    with tracer.invoke("The Eiffel Tower is in"):
+        clean_hs = model.model.layers[5].output[0][-1, :]
+        barrier()
+    with tracer.invoke("The Colosseum is in"):
+        barrier()
+        model.model.layers[5].output[0][-1, :] = clean_hs
+        logits = model.lm_head.output.save()
+```
+
+### vLLM gap
+vLLM's internal batching does not guarantee execution order across invokes. Each invoke's request may be scheduled in any order by the engine. This means **barriers and cross-invoke dependencies are not supported** — there is no way to ensure invoke 1's output is available before invoke 2 runs.
+
+Multiple invokes in a single trace are fine for independent operations (e.g., running the same intervention on different prompts), but they must not reference each other's values.
+
+Also note: `tracer.stop()` in vLLM only stops the invoke that called it. Other invokes in the same trace continue running independently.
+
+### Status: **Different syntax required** — use two separate traces for dependencies
+```python
+# Step 1: extract hidden states from source prompt
+with model.trace("The Eiffel Tower is in"):
+    clean_hs = model.model.layers[5].output[0][-1, :].save()
+
+# Step 2: patch into target prompt (separate trace — guarantees ordering)
+with model.trace("The Colosseum is in"):
+    model.model.layers[5].output[0][-1, :] = clean_hs.to(model.model.layers[5].output[0].device)
+    logits = model.logits.output.save()
+```
+
+---
+
+## Logit Lens
+
+### HF pattern
+```python
+with model.trace("The Eiffel Tower is in"):
+    for i in range(num_layers):
+        hs = model.model.layers[i].output[0]
+        logits = model.lm_head(model.model.norm(hs))
+        print(model.tokenizer.decode(logits.argmax(dim=-1)[0][-1]))
+```
+
+### vLLM gap
+Dual-stream outputs must be combined manually. Fused norm returns a tuple. Additionally, **module calls must happen inside the trace** — unlike HF where you can call `model.lm_head(hs)` on saved tensors outside a trace, vLLM's model weights live in a separate worker process and are not accessible from the client.
+
+### Status: **Different format — combine streams manually**
+```python
+with model.trace("The Eiffel Tower is in"):
+    for i in range(num_layers):
+        hs = model.model.layers[i].output[0] + model.model.layers[i].output[1]  # combine dual streams
+        normed = model.model.norm(hs)
+        if isinstance(normed, tuple):   # fused norm returns (normalized, residual)
+            normed = normed[0]
+        logits = model.lm_head(normed)
+        print(model.tokenizer.decode(logits.argmax(dim=-1)[-1]))
+```
+
+---
+
+## Multi-Token Generation
+
+### HF pattern
+```python
+with model.generate("Hello", max_new_tokens=5) as tracer:
+    logits = list().save()
+    for step in tracer.iter[:]:
+        logits.append(model.lm_head.output[0][-1].argmax(dim=-1))
+    output = model.generator.output.save()
+```
+
+### vLLM gap
+Different generation API, different logits module.
+
+### Status: **Different syntax required**
+```python
+import nnsight
+with model.trace("Hello", max_tokens=5) as tracer:
+    logits = nnsight.save(list())
+    for step in tracer.iter[:]:
+        logits.append(model.logits.output)
+```
+
+- `model.trace(max_tokens=N)` instead of `model.generate(max_new_tokens=N)`
+- `model.logits.output` instead of `model.lm_head.output`
+- `model.samples.output` provides the sampled token
+
+---
+
+## Module Skip
+
+### HF pattern
+```python
+with model.trace("Hello"):
+    layer0_out = model.model.layers[0].output
+    model.model.layers[1].skip(layer0_out)
+```
+
+### vLLM gap
+`skip()` provides an HF-shaped value, but vLLM's fused norm expects `(hidden_states, residual)` pairs. Raw `skip()` crashes the engine.
+
+### Status: **Different format — must provide (hidden, residual) tuple**
+```python
+with model.trace("Hello"):
+    layer0_out = model.model.layers[0].output  # already (mlp_output, residual)
+    model.model.layers[1].skip(layer0_out)     # pass the raw tuple through
+```
+
+Skip values must match vLLM's expected `(hidden_states, residual)` format. Passing a single tensor will crash the engine (deferred exception prevents engine death but the skip still fails).
+
+---
+
+## Early Stop (tracer.stop())
+
+### HF pattern
+```python
+with model.trace("Hello") as tracer:
+    hs = model.model.layers[0].output[0].save()
+    tracer.stop()
+    # Code after stop() does not execute
+```
+
+### vLLM gap
+Exceptions (including `EarlyStopException` from `stop()`) were re-raised inside PyTorch hooks during the forward pass, unwinding vLLM's `execute_model()` and permanently killing the engine.
+
+### Status: **Solved — deferred exception handling**
+```python
+with model.trace("Hello") as tracer:
+    hs = model.model.layers[0].output[0].save()
+    tracer.stop()
+    # Code after stop() does not execute
+# hs is a real tensor; engine survives
+```
+
+Exceptions are deferred (stored, not raised) during the forward pass. The forward completes normally, then exceptions are surfaced at the trace boundary on the client side. `EarlyStopException` is filtered as intentional control flow. User errors (e.g. `IndexError`) are re-raised with the original type and traceback.
+
+**Note:** In vLLM, `tracer.stop()` only stops the invoke that called it. Other invokes in the same trace continue running independently (see [Activation Patching](#activation-patching) for details on invoke independence).
+
+---
+
+## Error Handling
+
+### HF pattern
+```python
+try:
+    with model.trace("Hello"):
+        bad = model.model.layers[100].output[0].save()  # IndexError
+except IndexError as e:
+    print(e)  # Error raised, model still usable
+```
+
+### vLLM gap
+Same issue as `tracer.stop()` — exceptions inside hooks killed the engine.
+
+### Status: **Solved — deferred exception handling**
+```python
+try:
+    with model.trace("Hello"):
+        bad = model.model.layers[100].output[0].save()
+except IndexError as e:
+    print(e)  # Error raised at trace boundary, engine survives
+
+# Engine is still alive — subsequent traces work
+with model.trace("Hello"):
+    logits = model.logits.output.save()
+```
+
+Per-mediator exception isolation ensures one failing trace doesn't affect other concurrent traces in the same batch. Each trace's error is reported independently.
+
+---
+
+## LayerNorm Output
+
+### HF pattern
+```python
+with model.trace("Hello"):
+    normed = model.model.layers[0].input_layernorm.output   # single tensor
+```
+
+### vLLM gap
+Fused RMSNorm returns `(normalized, residual)` tuple instead of a single tensor.
+
+### Status: **Different format — extract from tuple**
+```python
+with model.trace("Hello"):
+    normed = model.model.layers[0].input_layernorm.output[0]   # extract normalized tensor
+    # output[1] is the residual
+```
+
+**Note:** LayerNorm *inputs* also differ (2 args vs 1 in HF).
+
+---
+
+## Linear Layer Outputs (down_proj, o_proj)
+
+### HF pattern
+```python
+with model.trace("Hello"):
+    out = model.model.layers[0].mlp.down_proj.output   # single tensor
+```
+
+### vLLM gap
+`RowParallelLinear` returns `(output, bias)` 2-tuple.
+
+### Status: **Different format — extract from tuple**
+```python
+with model.trace("Hello"):
+    out = model.model.layers[0].mlp.down_proj.output[0]   # extract tensor from (output, bias) tuple
+```
+
+---
+
+## Merged Projections (gate_up_proj, qkv_proj)
+
+### HF pattern
+```python
+with model.trace("Hello"):
+    gate = model.model.layers[0].mlp.gate_proj.output
+    up   = model.model.layers[0].mlp.up_proj.output
+```
+
+### vLLM gap
+vLLM merges `gate_proj` + `up_proj` into `gate_up_proj` and `q/k/v_proj` into `qkv_proj` for memory bandwidth.
+
+### Status: **Different syntax required**
+```python
+with model.trace("Hello"):
+    merged = model.model.layers[0].mlp.gate_up_proj.output
+    gate, up = merged.chunk(2, dim=-1)
+
+    merged_qkv = model.model.layers[0].self_attn.qkv_proj.output
+    q, k, v = merged_qkv.split([q_size, kv_size, kv_size], dim=-1)
+```
+
+---
+
+## Attention Weights
+
+### HF pattern
+```python
+with model.trace("Hello"):
+    weights = model.model.layers[0].self_attn.source.attention_interface_0.output[0]
+```
+
+### Status: **Hard block — not available**
+
+PagedAttention computes attention entirely in C/CUDA. No Python-level weight tensor exists. No workaround.
+
+---
+
+## Gradients
+
+### HF pattern
+```python
+with model.trace("Hello"):
+    hs = model.model.layers[-1].output[0]
+    hs.requires_grad_(True)
+    with model.lm_head.output.sum().backward():
+        grad = hs.grad.save()
+```
+
+### Status: **Hard block — not available**
+
+`torch.inference_mode()` globally disables gradients. `requires_grad_(True)` raises `RuntimeError`. No workaround.
+
+---
+
+## Source Tracing
+
+### HF pattern
+```python
+print(model.model.layers[0].self_attn.source)   # shows all operations
+with model.trace("Hello"):
+    sdpa = model.model.layers[0].self_attn.source.attention_interface_0.output
+```
+
+### vLLM gap
+Fused modules have trivial Python wrappers — `.source` shows only the delegate call.
+
+### Status: **Partially works**
+
+Non-fused modules (e.g. `self_attn`) work fine — `.source` reveals `qkv_proj`, `split`, `rotary_emb`, `attn`, `o_proj`. Fused modules (`input_layernorm`, `act_fn`) show only 1 operation.
+
+---
+
+## Caching
+
+### HF pattern
+```python
+with model.trace("Hello") as tracer:
+    cache = tracer.cache(modules=[model.model.layers[0]])
+hidden = cache['model.model.layers.0'].output[0]
+```
+
+### Status: **Works — values are in raw vLLM format**
+```python
+with model.trace("Hello") as tracer:
+    cache = tracer.cache(modules=[model.model.layers[0]])
+# Decoder layer output is (mlp_output, residual) tuple
+hidden = cache.model.layers[0].output[0] + cache.model.layers[0].output[1]  # combine manually
+```
+
+Cached values are in raw vLLM format. `.save()` auto-clones inference-mode tensors for mutation safety.
+
+---
+
+## Tensor Parallelism
+
+### HF pattern
+```python
+# HF with device_map="auto" distributes layers across GPUs.
+# Each layer's output is the full unsharded tensor.
+model = LanguageModel("model", device_map="auto", dispatch=True)
+```
+
+### vLLM gap
+vLLM shards `ColumnParallelLinear` and `RowParallelLinear` across GPUs. Raw sub-module outputs are per-GPU shards, not full tensors. Worker threads default to CUDA stream 0, which races with vLLM's compute stream under TP.
+
+### Status: **Layer-level solved, sub-module access crashes**
+
+```python
+model = VLLM("Qwen/Qwen2-0.5B", tensor_parallel_size=2,
+             gpu_memory_utilization=0.3, dispatch=True)
+```
+
+**Layer-level interventions work identically to tp=1.** `VLLMBatcher` transparently gathers sharded tensors (via `tensor_model_parallel_all_gather` / `all_reduce`) so users see full unsharded values, then splits them back before returning to vLLM. CUDA stream propagation ensures worker threads use the correct compute stream, eliminating non-determinism.
+
+**Sub-module access (qkv_proj, gate_up_proj, etc.) crashes the engine with tp≥2.** This is unrecoverable — the vLLM process must be restarted.
+
+Recommendations:
+1. Use layer-level interventions only with tp≥2
+2. Avoid sub-module access — crashes the engine
+3. Test with tp=1 first, then verify at the layer level with tp=2
+
+---
+
+## Quick Reference
+
+| Operation | HF | vLLM | Notes |
+|-----------|-----|------|-------|
+| **Save hidden** | `layer.output[0].save()` | `(layer.output[0] + layer.output[1]).save()` | Combine dual streams |
+| **Layer input** | `layer.input` | `.inputs[0][1]` for hidden states | `.input` returns positions |
+| **Ablation** | `output[0][:] = 0` | Zero both `output[0]` and `output[1]` | Dual stream |
+| **Steer** | `output[0][-1, :] += v` | `output[0][-1, :] += v` | Steers mlp stream only |
+| **Norm output** | tensor | `.output[0]` | Extract from tuple |
+| **Linear output** | tensor | `.output[0]` | Extract from `(output, bias)` |
+| **Module skip** | `layer.skip(v)` | `layer.skip((h, r))` | Must provide tuple |
+| **tracer.stop()** | Works | Works | Deferred exception |
+| **Error handling** | Error raised | Error raised | Deferred, engine survives |
+| **Logits** | `model.lm_head.output` | `model.logits.output` | Different path, last-token only |
+| **Generation** | `model.generate(max_new_tokens=N)` | `model.trace(max_tokens=N)` | Different API |
+| **gate/up proj** | Separate modules | `gate_up_proj` merged | `.chunk(2)` |
+| **q/k/v proj** | Separate modules | `qkv_proj` merged | `.split()` |
+| **Attn weights** | Available | **Blocked** | PagedAttention (C/CUDA) |
+| **Gradients** | Available | **Blocked** | `inference_mode` |
+| **Source tracing** | All modules | Python wrappers only | Fused modules blocked |

--- a/src/nnsight/modeling/vllm/intervention-gaps/run_all.py
+++ b/src/nnsight/modeling/vllm/intervention-gaps/run_all.py
@@ -1,0 +1,198 @@
+"""
+Orchestrator: runs each gap test as TWO subprocesses (vLLM + HF) on separate
+GPUs and prints a comparison summary table.
+
+Each test+backend runs in its own subprocess on its own GPU, so vLLM and HF
+can run in parallel without interfering.
+
+Usage:
+    python vllm-intervention-gaps/run_all.py --vllm-gpu 2 --hf-gpu 4
+    python vllm-intervention-gaps/run_all.py --vllm-gpu 2 --hf-gpu 4 --test 1_1
+    python vllm-intervention-gaps/run_all.py --vllm-gpu 2  # vLLM only
+    python vllm-intervention-gaps/run_all.py --hf-gpu 4    # HF only
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+TESTS = [
+    ("1_1", "In-place mutation corrupts .save()"),
+    ("1_2", "Decoder layer output semantics differ"),
+    ("1_3", "Decoder layer input semantics differ"),
+    ("1_4", "LayerNorm output: tensor vs tuple"),
+    ("1_5", "LayerNorm input semantics differ"),
+    ("2_1", "MLP submodule layout (merged gate_up_proj)"),
+    ("2_2", "Attention submodule layout (merged qkv_proj)"),
+    ("2_3", "RowParallelLinear returns tuple"),
+    ("3_1", "Flat batch dimension [total_tokens, hidden]"),
+    ("3_2", "PagedAttention: no attention weights"),
+    ("4_1", "Gradients blocked by inference_mode"),
+    ("4_2", "Source tracing into fused kernels"),
+    ("4_3", "Module skip breaks fused norm"),
+]
+
+HERE = Path(__file__).parent
+
+
+def run_test(test_id: str, backend: str, gpu: str, model: str) -> dict:
+    """Run a single test with a specific backend in a subprocess."""
+    script = HERE / f"test_{test_id}.py"
+    if not script.exists():
+        return {
+            "id": test_id,
+            "backend": backend,
+            "status": "MISSING",
+            "detail": f"{script.name} not found",
+        }
+
+    env = os.environ.copy()
+    env["CUDA_VISIBLE_DEVICES"] = gpu
+
+    cmd = [sys.executable, str(script), "--model", model, "--backend", backend]
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=300, env=env
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "id": test_id,
+            "backend": backend,
+            "status": "TIMEOUT",
+            "detail": "Exceeded 300s",
+        }
+
+    # Look for JSON result on last non-empty line of stdout
+    lines = [l for l in proc.stdout.strip().splitlines() if l.strip()]
+    if lines:
+        for line in reversed(lines):
+            try:
+                result = json.loads(line)
+                result["id"] = test_id
+                result["backend"] = backend
+                return result
+            except json.JSONDecodeError:
+                continue
+
+    return {
+        "id": test_id,
+        "backend": backend,
+        "status": "ERROR",
+        "detail": proc.stderr[-500:] if proc.stderr else "No output",
+        "stdout": proc.stdout[-500:] if proc.stdout else "",
+    }
+
+
+def compare_results(vllm_result: dict, hf_result: dict) -> str:
+    """Compare vLLM and HF results and return a gap verdict."""
+    vs = vllm_result.get("status", "?")
+    hs = hf_result.get("status", "?")
+
+    if vs == "CONFIRMED" and hs == "NO_GAP":
+        return "GAP CONFIRMED"
+    elif vs == "CONFIRMED" and hs in ("UNEXPECTED", "UNEXPECTED_FAILURE", "UNEXPECTED_MATCH", "UNEXPECTED_MISMATCH"):
+        return "GAP CONFIRMED (HF unexpected)"
+    elif vs == "NOT_REPRODUCED" and hs == "NO_GAP":
+        return "GAP NOT REPRODUCED"
+    elif vs in ("ERROR", "TIMEOUT", "MISSING"):
+        return f"vLLM {vs}"
+    elif hs in ("ERROR", "TIMEOUT", "MISSING"):
+        return f"HF {hs}"
+    else:
+        return f"vLLM={vs}, HF={hs}"
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--vllm-gpu", default=None, help="GPU for vLLM (omit to skip vLLM)")
+    parser.add_argument("--hf-gpu", default=None, help="GPU for HF (omit to skip HF)")
+    parser.add_argument("--model", default="Qwen/Qwen2-0.5B", help="Model to test")
+    parser.add_argument("--test", default=None, help="Run only this test (e.g. 1_1)")
+    args = parser.parse_args()
+
+    if args.vllm_gpu is None and args.hf_gpu is None:
+        parser.error("Provide at least one of --vllm-gpu or --hf-gpu")
+
+    tests_to_run = TESTS
+    if args.test:
+        tests_to_run = [(tid, desc) for tid, desc in TESTS if tid == args.test]
+        if not tests_to_run:
+            print(f"Unknown test: {args.test}")
+            sys.exit(1)
+
+    run_vllm = args.vllm_gpu is not None
+    run_hf = args.hf_gpu is not None
+
+    results = []
+    for tid, desc in tests_to_run:
+        print(f"\n{'='*70}")
+        print(f"Gap {tid}: {desc}")
+        print(f"{'='*70}")
+
+        vllm_result = None
+        hf_result = None
+
+        if run_vllm:
+            print(f"  Running vLLM (GPU {args.vllm_gpu})...")
+            vllm_result = run_test(tid, "vllm", args.vllm_gpu, args.model)
+            vs = vllm_result.get("status", "?")
+            vd = vllm_result.get("detail", "")
+            print(f"  vLLM -> {vs}: {vd}")
+
+        if run_hf:
+            print(f"  Running HF (GPU {args.hf_gpu})...")
+            hf_result = run_test(tid, "hf", args.hf_gpu, args.model)
+            hs = hf_result.get("status", "?")
+            hd = hf_result.get("detail", "")
+            print(f"  HF   -> {hs}: {hd}")
+
+        if vllm_result and hf_result:
+            verdict = compare_results(vllm_result, hf_result)
+            print(f"  >>> {verdict}")
+        elif vllm_result:
+            verdict = vllm_result.get("status", "?")
+        elif hf_result:
+            verdict = hf_result.get("status", "?")
+        else:
+            verdict = "SKIPPED"
+
+        results.append((tid, desc, vllm_result, hf_result, verdict))
+
+    # Summary table
+    print(f"\n{'='*90}")
+    print("SUMMARY")
+    print(f"{'='*90}")
+
+    if run_vllm and run_hf:
+        print(f"{'Gap':<6} {'vLLM':<18} {'HF':<18} {'Verdict':<22} {'Description'}")
+        print(f"{'-'*6} {'-'*18} {'-'*18} {'-'*22} {'-'*40}")
+        for tid, desc, vr, hr, verdict in results:
+            vs = vr.get("status", "?") if vr else "-"
+            hs = hr.get("status", "?") if hr else "-"
+            print(f"{tid:<6} {vs:<18} {hs:<18} {verdict:<22} {desc}")
+    else:
+        backend_name = "VLLM" if run_vllm else "HF"
+        print(f"{'Gap':<6} {backend_name:<18} {'Description'}")
+        print(f"{'-'*6} {'-'*18} {'-'*40}")
+        for tid, desc, vr, hr, verdict in results:
+            r = vr if vr else hr
+            status = r.get("status", "?") if r else "?"
+            print(f"{tid:<6} {status:<18} {desc}")
+
+    # Count stats
+    if run_vllm and run_hf:
+        confirmed = sum(1 for _, _, _, _, v in results if "GAP CONFIRMED" in v)
+        not_reproduced = sum(1 for _, _, _, _, v in results if "NOT REPRODUCED" in v)
+        other = len(results) - confirmed - not_reproduced
+        print(f"\nGaps confirmed: {confirmed}/{len(results)}")
+        if not_reproduced:
+            print(f"Gaps not reproduced: {not_reproduced}/{len(results)}")
+        if other:
+            print(f"Other: {other}/{len(results)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nnsight/modeling/vllm/intervention-gaps/test_1_1.py
+++ b/src/nnsight/modeling/vllm/intervention-gaps/test_1_1.py
@@ -1,0 +1,199 @@
+"""
+Gap 1.1: .save() captures corrupted values due to in-place mutation by fused kernels
+
+DOCUMENTED PATTERN (CLAUDE.md "Accessing Outputs"):
+    layer_5_out = model.transformer.h[5].output[0].save()
+Users expect .save() to capture the tensor value at the moment the hook fires,
+preserving the module's actual output for later analysis.
+
+ON HF (expected behavior):
+    .save() and .clone().save() return identical values. The saved reference
+    faithfully represents the layer's output. Probing classifiers, activation
+    patching, and logit lens all work correctly on the saved tensor.
+
+ON vLLM (the gap):
+    .save() and .clone().save() DIFFER. vLLM's fused_add_rms_norm mutates
+    tensors in-place AFTER the hook fires: when layer N returns (x, residual),
+    layer N+1's input_layernorm(x, residual) overwrites x with rms_norm(x +
+    residual). Since .save() stores a reference (not a copy), the saved tensor
+    silently becomes the post-mutation value -- not what the layer actually output.
+
+WHY THIS MATTERS:
+    This is the most insidious gap because it produces wrong results silently.
+    Any workflow that saves layer hidden states for offline analysis -- probing
+    classifiers, activation patching between clean/corrupted runs, logit lens,
+    or simply logging activations -- gets corrupted data without any error.
+    The user's code looks correct, runs without errors, but the saved tensors
+    contain values from a LATER point in the computation.
+
+VALIDATION: Compare .save() vs .clone().save() for layer outputs, mlp outputs,
+and self_attn outputs. If they differ, the reference was silently corrupted.
+"""
+
+import argparse
+import json
+
+import torch
+
+
+def clone_value(v):
+    """Clone a tensor or each tensor in a tuple."""
+    if isinstance(v, torch.Tensor):
+        return v.clone()
+    elif isinstance(v, tuple):
+        return tuple(t.clone() if isinstance(t, torch.Tensor) else t for t in v)
+    return v
+
+
+def compare_values(ref, cloned):
+    """Compare ref vs cloned, returning (match, max_diff)."""
+    if isinstance(ref, torch.Tensor) and isinstance(cloned, torch.Tensor):
+        match = torch.equal(ref, cloned)
+        diff = 0.0 if match else torch.max(torch.abs(ref.float() - cloned.float())).item()
+        return match, diff
+    elif isinstance(ref, tuple) and isinstance(cloned, tuple):
+        matches = []
+        diffs = []
+        for r, c in zip(ref, cloned):
+            if isinstance(r, torch.Tensor) and isinstance(c, torch.Tensor):
+                m = torch.equal(r, c)
+                d = 0.0 if m else torch.max(torch.abs(r.float() - c.float())).item()
+                matches.append(m)
+                diffs.append(d)
+        return all(matches), max(diffs) if diffs else 0.0
+    return True, 0.0
+
+
+def run_vllm(model_name, prompt, layer_idx):
+    from nnsight.modeling.vllm import VLLM
+
+    model = VLLM(model_name, gpu_memory_utilization=0.05, dispatch=True)
+    findings = {}
+
+    # --- Test layer.output[0] (first element of dual-stream tuple) ---
+    with model.trace(prompt, temperature=0.0):
+        layer_out0_ref = model.model.layers[layer_idx].output[0].save()
+        layer_out0_clone = model.model.layers[layer_idx].output[0].clone().save()
+
+    match_0, diff_0 = compare_values(layer_out0_ref, layer_out0_clone)
+    findings["layer.output[0]"] = {"match": match_0, "max_diff": diff_0}
+    print(f"layer.output[0]: ref==clone? {match_0}  max_diff={diff_0:.6f}")
+
+    # --- Test mlp.output ---
+    with model.trace(prompt, temperature=0.0):
+        mlp_ref = model.model.layers[layer_idx].mlp.output.save()
+
+    with model.trace(prompt, temperature=0.0):
+        mlp_ref2 = model.model.layers[layer_idx].mlp.output.save()
+
+    match_mlp, diff_mlp = compare_values(mlp_ref, mlp_ref2)
+    print(f"mlp.output type: {type(mlp_ref)}")
+    findings["mlp.output"] = {"match": match_mlp, "max_diff": diff_mlp}
+    print(f"mlp.output:      cross-trace match? {match_mlp}  max_diff={diff_mlp:.6f}")
+
+    # --- Test self_attn.output ---
+    with model.trace(prompt, temperature=0.0):
+        attn_ref = model.model.layers[layer_idx].self_attn.output.save()
+
+    with model.trace(prompt, temperature=0.0):
+        attn_ref2 = model.model.layers[layer_idx].self_attn.output.save()
+
+    match_attn, diff_attn = compare_values(attn_ref, attn_ref2)
+    findings["self_attn.output"] = {"match": match_attn, "max_diff": diff_attn}
+    print(f"self_attn.output: cross-trace match? {match_attn}  max_diff={diff_attn:.6f}")
+
+    corrupted = [k for k, v in findings.items() if not v["match"]]
+    safe = [k for k, v in findings.items() if v["match"]]
+
+    if not match_0:
+        status = "CONFIRMED"
+    else:
+        status = "NOT_REPRODUCED"
+
+    detail = (
+        f"layer.output[0] ref==clone: {match_0} (diff={diff_0:.6f}); "
+        f"Corrupted: {corrupted}; Safe: {safe}"
+    )
+    return {
+        "backend": "vllm",
+        "status": status,
+        "detail": detail,
+        "findings": {k: {"match": v["match"], "max_diff": v["max_diff"]} for k, v in findings.items()},
+    }
+
+
+def run_hf(model_name, prompt, layer_idx):
+    from nnsight import LanguageModel
+
+    model = LanguageModel(model_name, device_map="cuda", dispatch=True)
+    findings = {}
+
+    # --- Test layer.output[0]: HF returns (hidden_states,) tuple ---
+    # HF has no fused in-place mutation, so ref==clone should always be True
+    with model.trace(prompt):
+        layer_out0_ref = model.model.layers[layer_idx].output[0].save()
+        layer_out0_clone = model.model.layers[layer_idx].output[0].clone().save()
+
+    match_0, diff_0 = compare_values(layer_out0_ref, layer_out0_clone)
+    findings["layer.output[0]"] = {"match": match_0, "max_diff": diff_0}
+    print(f"layer.output[0]: ref==clone? {match_0}  max_diff={diff_0:.6f}")
+
+    # --- Test mlp.output ---
+    with model.trace(prompt):
+        mlp_ref = model.model.layers[layer_idx].mlp.output.save()
+
+    with model.trace(prompt):
+        mlp_ref2 = model.model.layers[layer_idx].mlp.output.save()
+
+    match_mlp, diff_mlp = compare_values(mlp_ref, mlp_ref2)
+    findings["mlp.output"] = {"match": match_mlp, "max_diff": diff_mlp}
+    print(f"mlp.output:      cross-trace match? {match_mlp}  max_diff={diff_mlp:.6f}")
+
+    # --- Test self_attn.output ---
+    with model.trace(prompt):
+        attn_ref = model.model.layers[layer_idx].self_attn.output.save()
+
+    with model.trace(prompt):
+        attn_ref2 = model.model.layers[layer_idx].self_attn.output.save()
+
+    match_attn, diff_attn = compare_values(attn_ref, attn_ref2)
+    findings["self_attn.output"] = {"match": match_attn, "max_diff": diff_attn}
+    print(f"self_attn.output: cross-trace match? {match_attn}  max_diff={diff_attn:.6f}")
+
+    corrupted = [k for k, v in findings.items() if not v["match"]]
+    safe = [k for k, v in findings.items() if v["match"]]
+
+    all_match = all(v["match"] for v in findings.values())
+    status = "NO_GAP" if all_match else "UNEXPECTED_MISMATCH"
+
+    detail = (
+        f"layer.output[0] ref==clone: {match_0} (diff={diff_0:.6f}); "
+        f"Corrupted: {corrupted}; Safe: {safe}"
+    )
+    return {
+        "backend": "hf",
+        "status": status,
+        "detail": detail,
+        "findings": {k: {"match": v["match"], "max_diff": v["max_diff"]} for k, v in findings.items()},
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="Qwen/Qwen2-0.5B")
+    parser.add_argument("--backend", choices=["vllm", "hf"], required=True)
+    args = parser.parse_args()
+
+    prompt = "The Eiffel Tower is in"
+    layer_idx = 5
+
+    if args.backend == "vllm":
+        result = run_vllm(args.model, prompt, layer_idx)
+    else:
+        result = run_hf(args.model, prompt, layer_idx)
+
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nnsight/modeling/vllm/intervention-gaps/test_1_2.py
+++ b/src/nnsight/modeling/vllm/intervention-gaps/test_1_2.py
@@ -1,0 +1,158 @@
+"""
+Gap 1.2: layer.output[0] is raw MLP output instead of full residual stream
+
+DOCUMENTED PATTERN (CLAUDE.md "Accessing Outputs" and "Common Patterns > Logit Lens"):
+    hs = model.transformer.h[i].output[0]  # Users expect: full hidden state
+    logits = model.lm_head(model.transformer.ln_f(hs))  # Logit lens
+Users expect output[0] to be the complete hidden state after the layer --
+the residual stream that flows between layers (mlp_out + residual).
+
+ON HF (expected behavior):
+    layer.output = (hidden_states,) where hidden_states = mlp_out + residual.
+    output[0] IS the full residual stream. Logit lens, probing classifiers,
+    and steering vectors all operate on the correct representation.
+
+ON vLLM (the gap):
+    layer.output = (hidden_states, residual) where hidden_states is the RAW MLP
+    output WITHOUT the residual added. output[0] == mlp.output, not the full
+    hidden state. The residual is carried separately in output[1] because vLLM's
+    fused norm adds it in the next layer. To reconstruct HF-equivalent:
+    h = layer.output[0] + layer.output[1].
+
+WHY THIS MATTERS:
+    Every interpretability technique that reads layer hidden states gets the wrong
+    tensor: logit lens applies the unembedding to raw MLP output instead of the
+    residual stream, probing classifiers train on the wrong representation,
+    steering vectors are added to the wrong space, and activation patching patches
+    an incomplete value. The code runs without error but all results are silently
+    incorrect.
+
+VALIDATION: Check whether output[0] matches mlp.output (vLLM gap) or differs
+from it (HF expected -- output[0] includes residual).
+"""
+
+import argparse
+import json
+
+import torch
+
+
+def run_vllm(model_name, prompt, layer_idx):
+    from nnsight.modeling.vllm import VLLM
+
+    model = VLLM(model_name, gpu_memory_utilization=0.05, dispatch=True)
+
+    # vLLM decoder layers return (mlp_output, residual) — output[0] is the raw mlp output.
+    # HF would return (combined,) where combined = mlp_out + residual.
+    with model.trace(prompt, temperature=0.0):
+        mlp_out = model.model.layers[layer_idx].mlp.output.clone().save()
+        out0 = model.model.layers[layer_idx].output[0].clone().save()
+
+    print(f"layer.output[0] shape: {out0.shape}, dtype: {out0.dtype}")
+    print(f"mlp.output shape: {mlp_out.shape if isinstance(mlp_out, torch.Tensor) else [t.shape for t in mlp_out]}")
+
+    if isinstance(mlp_out, tuple):
+        mlp_tensor = mlp_out[0]
+    else:
+        mlp_tensor = mlp_out
+
+    out0_eq_mlp = torch.equal(out0, mlp_tensor)
+    if not out0_eq_mlp:
+        out0_mlp_diff = torch.max(torch.abs(out0.float() - mlp_tensor.float())).item()
+        out0_mlp_cos = torch.nn.functional.cosine_similarity(
+            out0.float().reshape(1, -1), mlp_tensor.float().reshape(1, -1)
+        ).item()
+    else:
+        out0_mlp_diff = 0.0
+        out0_mlp_cos = 1.0
+
+    print(f"\noutput[0] == mlp.output: {out0_eq_mlp} (diff={out0_mlp_diff:.6f}, cos={out0_mlp_cos:.6f})")
+
+    # Gap is confirmed if output[0] == mlp.output (raw MLP, no residual added).
+    # This is expected: vLLM returns (mlp_output, residual) as separate streams.
+    status = "CONFIRMED" if out0_eq_mlp or out0_mlp_cos > 0.99 else "NOT_REPRODUCED"
+    detail = (
+        f"output[0]==mlp.output: {out0_eq_mlp} (cos={out0_mlp_cos:.4f}); "
+        f"{'dual streams separate (expected)' if out0_eq_mlp else 'streams combined (unexpected)'}"
+    )
+    return {
+        "backend": "vllm",
+        "status": status,
+        "detail": detail,
+        "out0_eq_mlp": out0_eq_mlp,
+    }
+
+
+def run_hf(model_name, prompt, layer_idx):
+    from nnsight import LanguageModel
+
+    model = LanguageModel(model_name, device_map="cuda", dispatch=True)
+
+    # HF forward order: input_layernorm -> self_attn -> post_attention_layernorm -> mlp -> layer returns
+    # So mlp.output comes BEFORE layer.output
+    with model.trace(prompt):
+        mlp_out = model.model.layers[layer_idx].mlp.output.clone().save()
+        layer_out = model.model.layers[layer_idx].output.save()
+
+    out0 = layer_out[0]
+    is_tuple = isinstance(layer_out, tuple)
+    output_len = len(layer_out) if is_tuple else 1
+
+    print(f"layer.output type: {type(layer_out)}")
+    print(f"layer.output length: {output_len}")
+    print(f"layer.output[0] shape: {out0.shape}, dtype: {out0.dtype}")
+    print(f"mlp.output shape: {mlp_out.shape if isinstance(mlp_out, torch.Tensor) else type(mlp_out)}")
+
+    if isinstance(mlp_out, torch.Tensor):
+        mlp_tensor = mlp_out
+    elif isinstance(mlp_out, tuple):
+        mlp_tensor = mlp_out[0]
+    else:
+        mlp_tensor = mlp_out
+
+    out0_eq_mlp = torch.equal(out0, mlp_tensor)
+    if not out0_eq_mlp:
+        out0_mlp_diff = torch.max(torch.abs(out0.float() - mlp_tensor.float())).item()
+        out0_mlp_cos = torch.nn.functional.cosine_similarity(
+            out0.float().reshape(1, -1), mlp_tensor.float().reshape(1, -1)
+        ).item()
+    else:
+        out0_mlp_diff = 0.0
+        out0_mlp_cos = 1.0
+
+    print(f"\noutput[0] == mlp.output: {out0_eq_mlp} (diff={out0_mlp_diff:.6f}, cos={out0_mlp_cos:.6f})")
+
+    # HF: output[0] should be mlp_out + residual, NOT equal to raw mlp_out
+    status = "NO_GAP" if not out0_eq_mlp else "UNEXPECTED_MATCH"
+    detail = (
+        f"output is {output_len}-tuple; output[0]==mlp.output: {out0_eq_mlp} (cos={out0_mlp_cos:.4f}); "
+        f"HF returns (mlp_out+residual,) — output[0] includes residual"
+    )
+    return {
+        "backend": "hf",
+        "status": status,
+        "detail": detail,
+        "output_len": output_len,
+        "out0_eq_mlp": out0_eq_mlp,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="Qwen/Qwen2-0.5B")
+    parser.add_argument("--backend", choices=["vllm", "hf"], required=True)
+    args = parser.parse_args()
+
+    prompt = "The Eiffel Tower is in"
+    layer_idx = 5
+
+    if args.backend == "vllm":
+        result = run_vllm(args.model, prompt, layer_idx)
+    else:
+        result = run_hf(args.model, prompt, layer_idx)
+
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nnsight/modeling/vllm/intervention-gaps/test_1_3.py
+++ b/src/nnsight/modeling/vllm/intervention-gaps/test_1_3.py
@@ -1,0 +1,146 @@
+"""
+Gap 1.3: layer.input returns position IDs instead of hidden states
+
+DOCUMENTED PATTERN (CLAUDE.md "Accessing Inputs"):
+    layer_input = model.transformer.h[0].input.save()  # Users expect: hidden states
+The docs define .input as "the first positional argument to the module." Users
+expect this to be the hidden state tensor flowing into the layer, which is what
+they would analyze, log, or use as a patching source.
+
+ON HF (expected behavior):
+    layer.input is a float tensor of shape [batch, seq, hidden_dim] -- the hidden
+    states from the previous layer. layer args = (hidden_states, attention_mask,
+    position_ids, ...). Code that reads .input for analysis gets the expected
+    representation.
+
+ON vLLM (the gap):
+    layer.input is an int64 tensor of position IDs, NOT hidden states. vLLM's
+    decoder layer signature is forward(positions, hidden_states, residual, ...),
+    so the first positional arg is positions. The hidden states are in arg[1].
+
+WHY THIS MATTERS:
+    Any code that reads .input to access hidden states entering a layer --
+    for input-output comparisons, residual stream analysis, or activation
+    patching at layer boundaries -- gets integer position IDs instead of float
+    hidden states. Arithmetic on this (e.g., adding a steering vector) produces
+    nonsense without any type error because PyTorch silently promotes int to float.
+
+VALIDATION: Check dtype of layer.input -- int64 (vLLM positions) vs float (HF
+hidden states).
+"""
+
+import argparse
+import json
+
+import torch
+
+
+def run_vllm(model_name, prompt, layer_idx):
+    from nnsight.modeling.vllm import VLLM
+
+    model = VLLM(model_name, gpu_memory_utilization=0.05, dispatch=True)
+
+    with model.trace(prompt, temperature=0.0):
+        vllm_input = model.model.layers[layer_idx].input.save()
+        vllm_inputs = model.model.layers[layer_idx].inputs.save()
+
+    print("vLLM layer.input:")
+    if isinstance(vllm_input, torch.Tensor):
+        print(f"  shape={vllm_input.shape}, dtype={vllm_input.dtype}")
+        print(f"  values (first 5): {vllm_input.flatten()[:5].tolist()}")
+        is_positions = vllm_input.dtype in (torch.int32, torch.int64, torch.long)
+    else:
+        print(f"  type={type(vllm_input)}")
+        is_positions = False
+
+    print("\nvLLM layer.inputs (args, kwargs):")
+    vllm_args, vllm_kwargs = vllm_inputs
+    for i, a in enumerate(vllm_args):
+        if isinstance(a, torch.Tensor):
+            print(f"  arg[{i}]: shape={a.shape}, dtype={a.dtype}")
+        else:
+            print(f"  arg[{i}]: type={type(a)}")
+    for k, v in vllm_kwargs.items():
+        if isinstance(v, torch.Tensor):
+            print(f"  kwarg[{k}]: shape={v.shape}, dtype={v.dtype}")
+        else:
+            print(f"  kwarg[{k}]: type={type(v)}")
+
+    input_dtype = str(vllm_input.dtype) if isinstance(vllm_input, torch.Tensor) else type(vllm_input).__name__
+    status = "CONFIRMED" if is_positions else "NOT_REPRODUCED"
+    detail = f"vLLM layer.input dtype={input_dtype}; is_positions={is_positions}"
+    return {
+        "backend": "vllm",
+        "status": status,
+        "detail": detail,
+        "input_dtype": input_dtype,
+        "is_positions": is_positions,
+    }
+
+
+def run_hf(model_name, prompt, layer_idx):
+    from nnsight import LanguageModel
+
+    model = LanguageModel(model_name, device_map="cuda", dispatch=True)
+
+    with model.trace(prompt):
+        hf_input = model.model.layers[layer_idx].input.save()
+        hf_inputs = model.model.layers[layer_idx].inputs.save()
+
+    print("HF layer.input:")
+    if isinstance(hf_input, torch.Tensor):
+        print(f"  shape={hf_input.shape}, dtype={hf_input.dtype}")
+        is_float = hf_input.dtype.is_floating_point
+    else:
+        print(f"  type={type(hf_input)}")
+        is_float = False
+
+    print("\nHF layer.inputs (args, kwargs):")
+    hf_args, hf_kwargs = hf_inputs
+    for i, a in enumerate(hf_args):
+        if isinstance(a, torch.Tensor):
+            print(f"  arg[{i}]: shape={a.shape}, dtype={a.dtype}")
+        elif a is None:
+            print(f"  arg[{i}]: None")
+        else:
+            print(f"  arg[{i}]: type={type(a)}")
+    for k, v in hf_kwargs.items():
+        if isinstance(v, torch.Tensor):
+            print(f"  kwarg[{k}]: shape={v.shape}, dtype={v.dtype}")
+        elif v is None:
+            print(f"  kwarg[{k}]: None")
+        else:
+            print(f"  kwarg[{k}]: type={type(v)}")
+
+    input_dtype = str(hf_input.dtype) if isinstance(hf_input, torch.Tensor) else type(hf_input).__name__
+    # HF: layer.input should be float hidden_states
+    status = "NO_GAP" if is_float else "UNEXPECTED"
+    detail = f"HF layer.input dtype={input_dtype}; is_float={is_float}"
+    return {
+        "backend": "hf",
+        "status": status,
+        "detail": detail,
+        "input_dtype": input_dtype,
+        "is_float": is_float,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="Qwen/Qwen2-0.5B")
+    parser.add_argument("--backend", choices=["vllm", "hf"], required=True)
+    args = parser.parse_args()
+
+    prompt = "The Eiffel Tower is in"
+    layer_idx = 5
+
+    if args.backend == "vllm":
+        result = run_vllm(args.model, prompt, layer_idx)
+    else:
+        result = run_hf(args.model, prompt, layer_idx)
+
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nnsight/modeling/vllm/intervention-gaps/test_1_4.py
+++ b/src/nnsight/modeling/vllm/intervention-gaps/test_1_4.py
@@ -1,0 +1,150 @@
+"""
+Gap 1.4: LayerNorm output is a (normalized, residual) tuple instead of a single tensor
+
+DOCUMENTED PATTERN (CLAUDE.md "Common Patterns > Logit Lens"):
+    hs = model.transformer.h[i].output[0]
+    logits = model.lm_head(model.transformer.ln_f(hs))  # Expects single tensor
+Users treat layernorm outputs as single tensors throughout -- applying the final
+layernorm and then the unembedding head for logit lens, or reading intermediate
+normalized representations for analysis.
+
+ON HF (expected behavior):
+    input_layernorm.output is a single tensor: RMSNorm(hidden_states).
+    post_attention_layernorm.output is also a single tensor. Code that passes
+    layernorm output directly to another module or applies arithmetic works as
+    expected.
+
+ON vLLM (the gap):
+    input_layernorm.output is a 2-TUPLE: (normalized, new_residual). This is
+    because vLLM uses fused_add_rms_norm which performs residual addition AND
+    normalization in a single kernel call. The same applies to
+    post_attention_layernorm. Code that treats the output as a single tensor --
+    e.g., model.lm_head(layernorm.output) -- gets a tuple instead.
+
+WHY THIS MATTERS:
+    Logit lens and any analysis pipeline that reads layernorm outputs to understand
+    the normalized representation entering attention or MLP will fail or silently
+    produce wrong results. The tuple is not indexable the same way as a tensor,
+    and passing it to downstream modules causes shape mismatches or type errors.
+
+VALIDATION: Check whether input_layernorm.output and post_attention_layernorm.output
+are tuples (vLLM) or single tensors (HF).
+"""
+
+import argparse
+import json
+
+import torch
+
+
+def run_vllm(model_name, prompt, layer_idx):
+    from nnsight.modeling.vllm import VLLM
+
+    model = VLLM(model_name, gpu_memory_utilization=0.05, dispatch=True)
+
+    with model.trace(prompt, temperature=0.0):
+        vllm_ln_out = model.model.layers[layer_idx].input_layernorm.output.save()
+        vllm_post_ln_out = model.model.layers[layer_idx].post_attention_layernorm.output.save()
+
+    print("vLLM input_layernorm.output:")
+    vllm_ln_is_tuple = isinstance(vllm_ln_out, tuple)
+    if vllm_ln_is_tuple:
+        print(f"  IS TUPLE, length={len(vllm_ln_out)}")
+        for i, t in enumerate(vllm_ln_out):
+            if isinstance(t, torch.Tensor):
+                print(f"  [{i}]: shape={t.shape}, dtype={t.dtype}")
+            else:
+                print(f"  [{i}]: type={type(t)}")
+    elif isinstance(vllm_ln_out, torch.Tensor):
+        print(f"  IS TENSOR, shape={vllm_ln_out.shape}, dtype={vllm_ln_out.dtype}")
+    else:
+        print(f"  type={type(vllm_ln_out)}")
+
+    print("\nvLLM post_attention_layernorm.output:")
+    vllm_post_is_tuple = isinstance(vllm_post_ln_out, tuple)
+    if vllm_post_is_tuple:
+        print(f"  IS TUPLE, length={len(vllm_post_ln_out)}")
+        for i, t in enumerate(vllm_post_ln_out):
+            if isinstance(t, torch.Tensor):
+                print(f"  [{i}]: shape={t.shape}, dtype={t.dtype}")
+            else:
+                print(f"  [{i}]: type={type(t)}")
+    elif isinstance(vllm_post_ln_out, torch.Tensor):
+        print(f"  IS TENSOR, shape={vllm_post_ln_out.shape}")
+
+    status = "CONFIRMED" if vllm_ln_is_tuple else "NOT_REPRODUCED"
+    detail = (
+        f"vLLM input_layernorm.output is_tuple={vllm_ln_is_tuple}; "
+        f"post_attention_layernorm.output is_tuple={vllm_post_is_tuple}"
+    )
+    return {
+        "backend": "vllm",
+        "status": status,
+        "detail": detail,
+        "ln_is_tuple": vllm_ln_is_tuple,
+        "post_ln_is_tuple": vllm_post_is_tuple,
+    }
+
+
+def run_hf(model_name, prompt, layer_idx):
+    from nnsight import LanguageModel
+
+    model = LanguageModel(model_name, device_map="cuda", dispatch=True)
+
+    with model.trace(prompt):
+        hf_ln_out = model.model.layers[layer_idx].input_layernorm.output.save()
+        hf_post_ln_out = model.model.layers[layer_idx].post_attention_layernorm.output.save()
+
+    print("HF input_layernorm.output:")
+    hf_ln_is_tuple = isinstance(hf_ln_out, tuple)
+    if hf_ln_is_tuple:
+        print(f"  IS TUPLE, length={len(hf_ln_out)}")
+    elif isinstance(hf_ln_out, torch.Tensor):
+        print(f"  IS TENSOR, shape={hf_ln_out.shape}, dtype={hf_ln_out.dtype}")
+    else:
+        print(f"  type={type(hf_ln_out)}")
+
+    print("\nHF post_attention_layernorm.output:")
+    hf_post_is_tuple = isinstance(hf_post_ln_out, tuple)
+    if hf_post_is_tuple:
+        print(f"  IS TUPLE, length={len(hf_post_ln_out)}")
+    elif isinstance(hf_post_ln_out, torch.Tensor):
+        print(f"  IS TENSOR, shape={hf_post_ln_out.shape}, dtype={hf_post_ln_out.dtype}")
+    else:
+        print(f"  type={type(hf_post_ln_out)}")
+
+    # HF: layernorm output should be a single tensor
+    ln_is_tensor = isinstance(hf_ln_out, torch.Tensor)
+    status = "NO_GAP" if ln_is_tensor else "UNEXPECTED"
+    detail = (
+        f"HF input_layernorm.output is_tensor={ln_is_tensor}; "
+        f"post_attention_layernorm.output is_tensor={isinstance(hf_post_ln_out, torch.Tensor)}"
+    )
+    return {
+        "backend": "hf",
+        "status": status,
+        "detail": detail,
+        "ln_is_tuple": hf_ln_is_tuple,
+        "post_ln_is_tuple": hf_post_is_tuple,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="Qwen/Qwen2-0.5B")
+    parser.add_argument("--backend", choices=["vllm", "hf"], required=True)
+    args = parser.parse_args()
+
+    prompt = "The Eiffel Tower is in"
+    layer_idx = 5
+
+    if args.backend == "vllm":
+        result = run_vllm(args.model, prompt, layer_idx)
+    else:
+        result = run_hf(args.model, prompt, layer_idx)
+
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nnsight/modeling/vllm/intervention-gaps/test_1_5.py
+++ b/src/nnsight/modeling/vllm/intervention-gaps/test_1_5.py
@@ -1,0 +1,163 @@
+"""
+Gap 1.5: LayerNorm takes 2 args (raw_output, residual) instead of 1 (hidden_states)
+
+DOCUMENTED PATTERN (related to Gap 1.4 -- CLAUDE.md "Accessing Inputs"):
+    layer_input = model.transformer.h[0].input.save()
+    # .input is the first positional arg; .inputs gives (args_tuple, kwargs_dict)
+On HF, input_layernorm takes a single hidden_states tensor. Users who hook into
+layernorm inputs to read or modify the pre-normalization hidden state expect one
+tensor argument.
+
+ON HF (expected behavior):
+    input_layernorm.input is a single float tensor (hidden_states). The inputs
+    tuple has 1 positional arg. Code that reads or replaces the layernorm input
+    to inject modified hidden states works directly.
+
+ON vLLM (the gap):
+    input_layernorm.input is the FIRST of TWO positional args. The fused kernel
+    signature is fused_add_rms_norm(raw_output, residual), so .inputs has 2 args.
+    .input gives only arg[0] (the raw sub-layer output), missing the residual
+    entirely. Code that reads .input expecting the full hidden state gets an
+    incomplete value.
+
+WHY THIS MATTERS:
+    Any code that hooks into layernorm inputs to read pre-normalization hidden
+    states, modify them (e.g., adding steering vectors before normalization), or
+    replace them for causal tracing experiments will operate on the wrong tensor.
+    The user gets the raw attention/MLP output without the residual connection,
+    not the full hidden state that would be normalized.
+
+VALIDATION: Count positional args to input_layernorm and post_attention_layernorm.
+HF has 1, vLLM has 2.
+"""
+
+import argparse
+import json
+
+import torch
+
+
+def run_vllm(model_name, prompt, layer_idx):
+    from nnsight.modeling.vllm import VLLM
+
+    model = VLLM(model_name, gpu_memory_utilization=0.05, dispatch=True)
+
+    with model.trace(prompt, temperature=0.0):
+        vllm_ln_input = model.model.layers[layer_idx].input_layernorm.input.save()
+        vllm_ln_inputs = model.model.layers[layer_idx].input_layernorm.inputs.save()
+        vllm_post_ln_input = model.model.layers[layer_idx].post_attention_layernorm.input.save()
+        vllm_post_ln_inputs = model.model.layers[layer_idx].post_attention_layernorm.inputs.save()
+
+    print("vLLM input_layernorm.input:")
+    if isinstance(vllm_ln_input, torch.Tensor):
+        print(f"  IS TENSOR, shape={vllm_ln_input.shape}, dtype={vllm_ln_input.dtype}")
+    else:
+        print(f"  type={type(vllm_ln_input)}")
+
+    print("\nvLLM input_layernorm.inputs (args, kwargs):")
+    vllm_args, vllm_kwargs = vllm_ln_inputs
+    for i, a in enumerate(vllm_args):
+        if isinstance(a, torch.Tensor):
+            print(f"  arg[{i}]: shape={a.shape}, dtype={a.dtype}")
+        else:
+            print(f"  arg[{i}]: type={type(a)}")
+
+    print("\nvLLM post_attention_layernorm.input:")
+    if isinstance(vllm_post_ln_input, torch.Tensor):
+        print(f"  IS TENSOR, shape={vllm_post_ln_input.shape}")
+    else:
+        print(f"  type={type(vllm_post_ln_input)}")
+
+    print("\nvLLM post_attention_layernorm.inputs (args, kwargs):")
+    vllm_post_args, vllm_post_kwargs = vllm_post_ln_inputs
+    for i, a in enumerate(vllm_post_args):
+        if isinstance(a, torch.Tensor):
+            print(f"  arg[{i}]: shape={a.shape}, dtype={a.dtype}")
+        else:
+            print(f"  arg[{i}]: type={type(a)}")
+
+    vllm_num_args = len(vllm_args)
+    status = "CONFIRMED" if vllm_num_args >= 2 else "NOT_REPRODUCED"
+    detail = f"vLLM input_layernorm num_args={vllm_num_args}"
+    return {
+        "backend": "vllm",
+        "status": status,
+        "detail": detail,
+        "num_args": vllm_num_args,
+    }
+
+
+def run_hf(model_name, prompt, layer_idx):
+    from nnsight import LanguageModel
+
+    model = LanguageModel(model_name, device_map="cuda", dispatch=True)
+
+    with model.trace(prompt):
+        hf_ln_input = model.model.layers[layer_idx].input_layernorm.input.save()
+        hf_ln_inputs = model.model.layers[layer_idx].input_layernorm.inputs.save()
+        hf_post_ln_input = model.model.layers[layer_idx].post_attention_layernorm.input.save()
+        hf_post_ln_inputs = model.model.layers[layer_idx].post_attention_layernorm.inputs.save()
+
+    print("HF input_layernorm.input:")
+    if isinstance(hf_ln_input, torch.Tensor):
+        print(f"  IS TENSOR, shape={hf_ln_input.shape}, dtype={hf_ln_input.dtype}")
+    else:
+        print(f"  type={type(hf_ln_input)}")
+
+    print("\nHF input_layernorm.inputs (args, kwargs):")
+    hf_args, hf_kwargs = hf_ln_inputs
+    for i, a in enumerate(hf_args):
+        if isinstance(a, torch.Tensor):
+            print(f"  arg[{i}]: shape={a.shape}, dtype={a.dtype}")
+        elif a is None:
+            print(f"  arg[{i}]: None")
+        else:
+            print(f"  arg[{i}]: type={type(a)}")
+
+    print("\nHF post_attention_layernorm.input:")
+    if isinstance(hf_post_ln_input, torch.Tensor):
+        print(f"  IS TENSOR, shape={hf_post_ln_input.shape}, dtype={hf_post_ln_input.dtype}")
+    else:
+        print(f"  type={type(hf_post_ln_input)}")
+
+    print("\nHF post_attention_layernorm.inputs (args, kwargs):")
+    hf_post_args, hf_post_kwargs = hf_post_ln_inputs
+    for i, a in enumerate(hf_post_args):
+        if isinstance(a, torch.Tensor):
+            print(f"  arg[{i}]: shape={a.shape}, dtype={a.dtype}")
+        elif a is None:
+            print(f"  arg[{i}]: None")
+        else:
+            print(f"  arg[{i}]: type={type(a)}")
+
+    hf_num_args = len(hf_args)
+    # HF: layernorm takes 1 positional arg
+    status = "NO_GAP" if hf_num_args == 1 else "UNEXPECTED"
+    detail = f"HF input_layernorm num_args={hf_num_args}"
+    return {
+        "backend": "hf",
+        "status": status,
+        "detail": detail,
+        "num_args": hf_num_args,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="Qwen/Qwen2-0.5B")
+    parser.add_argument("--backend", choices=["vllm", "hf"], required=True)
+    args = parser.parse_args()
+
+    prompt = "The Eiffel Tower is in"
+    layer_idx = 5
+
+    if args.backend == "vllm":
+        result = run_vllm(args.model, prompt, layer_idx)
+    else:
+        result = run_hf(args.model, prompt, layer_idx)
+
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nnsight/modeling/vllm/intervention-gaps/test_2_1.py
+++ b/src/nnsight/modeling/vllm/intervention-gaps/test_2_1.py
@@ -1,0 +1,151 @@
+"""
+Gap 2.1: mlp.gate_proj and mlp.up_proj do not exist -- merged into gate_up_proj
+
+DOCUMENTED PATTERN (CLAUDE.md "Accessing Outputs" implies per-submodule access):
+    gate_out = model.model.layers[0].mlp.gate_proj.output.save()
+    up_out = model.model.layers[0].mlp.up_proj.output.save()
+Users expect to access individual MLP projections to study gating mechanisms,
+train SAEs on individual projection outputs, or selectively ablate one
+projection while keeping the other.
+
+ON HF (expected behavior):
+    mlp has separate gate_proj (Linear), up_proj (Linear), down_proj (Linear),
+    and act_fn (SiLU). Each is a distinct module with its own .output hook.
+    Researchers can read, modify, or ablate gate and up projections independently.
+
+ON vLLM (the gap):
+    gate_proj and up_proj DO NOT EXIST. They are merged into a single
+    gate_up_proj (MergedColumnParallelLinear) whose output is
+    [tokens, 2 * intermediate_size] -- the gate and up projections concatenated.
+    act_fn is SiluAndMul (fused). There is no way to hook into gate_proj or
+    up_proj individually. Accessing model.model.layers[0].mlp.gate_proj raises
+    AttributeError.
+
+WHY THIS MATTERS:
+    Mechanistic interpretability research frequently studies gate vs up
+    projections separately -- e.g., analyzing which features the gate allows
+    through, training separate SAEs on each projection, or ablating one to
+    understand its causal role. The merged module makes all of these workflows
+    impossible without manual tensor splitting.
+
+VALIDATION: Check for existence of gate_proj, up_proj, and gate_up_proj
+attributes on the MLP module.
+"""
+
+import argparse
+import json
+
+import torch
+
+
+def run_vllm(model_name, prompt):
+    from nnsight.modeling.vllm import VLLM
+
+    model = VLLM(model_name, gpu_memory_utilization=0.05, dispatch=True)
+
+    print("vLLM MLP structure:")
+    vllm_mlp = model.model.layers[0].mlp
+    print(f"  {vllm_mlp}")
+
+    vllm_has_gate_proj = hasattr(vllm_mlp, "gate_proj")
+    vllm_has_up_proj = hasattr(vllm_mlp, "up_proj")
+    vllm_has_gate_up_proj = hasattr(vllm_mlp, "gate_up_proj")
+    vllm_has_down_proj = hasattr(vllm_mlp, "down_proj")
+
+    print(f"  gate_proj: {vllm_has_gate_proj}")
+    print(f"  up_proj: {vllm_has_up_proj}")
+    print(f"  gate_up_proj: {vllm_has_gate_up_proj}")
+    print(f"  down_proj: {vllm_has_down_proj}")
+
+    # Forward order: gate_up_proj -> act_fn -> down_proj
+    with model.trace(prompt, temperature=0.0):
+        if vllm_has_gate_up_proj:
+            gu_out = model.model.layers[0].mlp.gate_up_proj.output.save()
+        act_out = model.model.layers[0].mlp.act_fn.output.save()
+        down_out = model.model.layers[0].mlp.down_proj.output.save()
+
+    if vllm_has_gate_up_proj:
+        if isinstance(gu_out, tuple):
+            print(f"\n  gate_up_proj.output: tuple, [0].shape={gu_out[0].shape}")
+        else:
+            print(f"\n  gate_up_proj.output: shape={gu_out.shape}")
+
+    if isinstance(down_out, tuple):
+        print(f"  down_proj.output: tuple, [0].shape={down_out[0].shape}")
+    else:
+        print(f"  down_proj.output: shape={down_out.shape}")
+
+    if isinstance(act_out, torch.Tensor):
+        print(f"  act_fn.output: shape={act_out.shape}")
+    else:
+        print(f"  act_fn.output: type={type(act_out)}")
+
+    gap_confirmed = (not vllm_has_gate_proj) and vllm_has_gate_up_proj
+    status = "CONFIRMED" if gap_confirmed else "NOT_REPRODUCED"
+    detail = (
+        f"vLLM: gate_proj={vllm_has_gate_proj}, up_proj={vllm_has_up_proj}, "
+        f"gate_up_proj={vllm_has_gate_up_proj}"
+    )
+    return {
+        "backend": "vllm",
+        "status": status,
+        "detail": detail,
+        "has_gate_proj": vllm_has_gate_proj,
+        "has_up_proj": vllm_has_up_proj,
+        "has_gate_up_proj": vllm_has_gate_up_proj,
+    }
+
+
+def run_hf(model_name, prompt):
+    from nnsight import LanguageModel
+
+    model = LanguageModel(model_name, device_map="cuda", dispatch=True)
+
+    print("HF MLP structure:")
+    hf_mlp = model.model.layers[0].mlp
+    print(f"  {hf_mlp}")
+
+    hf_has_gate_proj = hasattr(hf_mlp, "gate_proj")
+    hf_has_up_proj = hasattr(hf_mlp, "up_proj")
+    hf_has_gate_up_proj = hasattr(hf_mlp, "gate_up_proj")
+    hf_has_down_proj = hasattr(hf_mlp, "down_proj")
+
+    print(f"  gate_proj: {hf_has_gate_proj}")
+    print(f"  up_proj: {hf_has_up_proj}")
+    print(f"  gate_up_proj: {hf_has_gate_up_proj}")
+    print(f"  down_proj: {hf_has_down_proj}")
+
+    # HF: separate gate_proj and up_proj, no gate_up_proj
+    status = "NO_GAP" if hf_has_gate_proj and hf_has_up_proj and not hf_has_gate_up_proj else "UNEXPECTED"
+    detail = (
+        f"HF: gate_proj={hf_has_gate_proj}, up_proj={hf_has_up_proj}, "
+        f"gate_up_proj={hf_has_gate_up_proj}"
+    )
+    return {
+        "backend": "hf",
+        "status": status,
+        "detail": detail,
+        "has_gate_proj": hf_has_gate_proj,
+        "has_up_proj": hf_has_up_proj,
+        "has_gate_up_proj": hf_has_gate_up_proj,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="Qwen/Qwen2-0.5B")
+    parser.add_argument("--backend", choices=["vllm", "hf"], required=True)
+    args = parser.parse_args()
+
+    prompt = "The Eiffel Tower is in"
+
+    if args.backend == "vllm":
+        result = run_vllm(args.model, prompt)
+    else:
+        result = run_hf(args.model, prompt)
+
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nnsight/modeling/vllm/intervention-gaps/test_2_2.py
+++ b/src/nnsight/modeling/vllm/intervention-gaps/test_2_2.py
@@ -1,0 +1,149 @@
+"""
+Gap 2.2: q_proj, k_proj, v_proj do not exist -- merged into qkv_proj
+
+DOCUMENTED PATTERN (CLAUDE.md "Accessing Outputs" implies per-submodule access):
+    q = model.model.layers[0].self_attn.q_proj.output.save()
+    k = model.model.layers[0].self_attn.k_proj.output.save()
+    v = model.model.layers[0].self_attn.v_proj.output.save()
+Users expect to access individual Q, K, V projections for attention head analysis,
+key-value editing, or selective ablation.
+
+ON HF (expected behavior):
+    self_attn has separate q_proj, k_proj, v_proj (each a Linear module) and
+    o_proj. Each projection is independently hookable. Researchers can read query
+    vectors for attention pattern analysis, edit key/value representations for
+    factual recall experiments, or ablate individual projections.
+
+ON vLLM (the gap):
+    q_proj, k_proj, and v_proj DO NOT EXIST. They are merged into a single
+    qkv_proj (QKVParallelLinear) whose output is a concatenated tensor of all
+    three projections. o_proj is a RowParallelLinear (returns tuple, see Gap 2.3).
+    Accessing model.model.layers[0].self_attn.q_proj raises AttributeError.
+
+WHY THIS MATTERS:
+    Attention head analysis, knowledge editing (modifying keys/values to change
+    factual associations), induction head detection, and Q/K/V-specific SAE
+    training all require separate access to individual projections. The merged
+    module forces users to manually split the concatenated tensor and know the
+    exact head dimensions, which is error-prone and model-specific.
+
+VALIDATION: Check for existence of q_proj, k_proj, v_proj, and qkv_proj
+attributes on the attention module.
+"""
+
+import argparse
+import json
+
+import torch
+
+
+def run_vllm(model_name, prompt):
+    from nnsight.modeling.vllm import VLLM
+
+    model = VLLM(model_name, gpu_memory_utilization=0.05, dispatch=True)
+
+    print("vLLM Attention structure:")
+    vllm_attn = model.model.layers[0].self_attn
+    print(f"  {vllm_attn}")
+
+    vllm_has_q = hasattr(vllm_attn, "q_proj")
+    vllm_has_k = hasattr(vllm_attn, "k_proj")
+    vllm_has_v = hasattr(vllm_attn, "v_proj")
+    vllm_has_qkv = hasattr(vllm_attn, "qkv_proj")
+    vllm_has_o = hasattr(vllm_attn, "o_proj")
+
+    print(f"  q_proj: {vllm_has_q}")
+    print(f"  k_proj: {vllm_has_k}")
+    print(f"  v_proj: {vllm_has_v}")
+    print(f"  qkv_proj: {vllm_has_qkv}")
+    print(f"  o_proj: {vllm_has_o}")
+
+    with model.trace(prompt, temperature=0.0):
+        if vllm_has_qkv:
+            qkv_out = model.model.layers[0].self_attn.qkv_proj.output.save()
+        o_out = model.model.layers[0].self_attn.o_proj.output.save()
+
+    if vllm_has_qkv:
+        if isinstance(qkv_out, tuple):
+            print(f"\n  qkv_proj.output: tuple, [0].shape={qkv_out[0].shape}")
+        else:
+            print(f"\n  qkv_proj.output: shape={qkv_out.shape}")
+
+    if isinstance(o_out, tuple):
+        print(f"  o_proj.output: tuple, [0].shape={o_out[0].shape}")
+    else:
+        print(f"  o_proj.output: shape={o_out.shape}")
+
+    gap_confirmed = (not vllm_has_q) and vllm_has_qkv
+    status = "CONFIRMED" if gap_confirmed else "NOT_REPRODUCED"
+    detail = (
+        f"vLLM: q_proj={vllm_has_q}, k_proj={vllm_has_k}, v_proj={vllm_has_v}, "
+        f"qkv_proj={vllm_has_qkv}"
+    )
+    return {
+        "backend": "vllm",
+        "status": status,
+        "detail": detail,
+        "has_q_proj": vllm_has_q,
+        "has_k_proj": vllm_has_k,
+        "has_v_proj": vllm_has_v,
+        "has_qkv_proj": vllm_has_qkv,
+    }
+
+
+def run_hf(model_name, prompt):
+    from nnsight import LanguageModel
+
+    model = LanguageModel(model_name, device_map="cuda", dispatch=True)
+
+    print("HF Attention structure:")
+    hf_attn = model.model.layers[0].self_attn
+    print(f"  {hf_attn}")
+
+    hf_has_q = hasattr(hf_attn, "q_proj")
+    hf_has_k = hasattr(hf_attn, "k_proj")
+    hf_has_v = hasattr(hf_attn, "v_proj")
+    hf_has_qkv = hasattr(hf_attn, "qkv_proj")
+    hf_has_o = hasattr(hf_attn, "o_proj")
+
+    print(f"  q_proj: {hf_has_q}")
+    print(f"  k_proj: {hf_has_k}")
+    print(f"  v_proj: {hf_has_v}")
+    print(f"  qkv_proj: {hf_has_qkv}")
+    print(f"  o_proj: {hf_has_o}")
+
+    # HF: separate q/k/v projections, no merged qkv_proj
+    status = "NO_GAP" if hf_has_q and hf_has_k and hf_has_v and not hf_has_qkv else "UNEXPECTED"
+    detail = (
+        f"HF: q_proj={hf_has_q}, k_proj={hf_has_k}, v_proj={hf_has_v}, "
+        f"qkv_proj={hf_has_qkv}"
+    )
+    return {
+        "backend": "hf",
+        "status": status,
+        "detail": detail,
+        "has_q_proj": hf_has_q,
+        "has_k_proj": hf_has_k,
+        "has_v_proj": hf_has_v,
+        "has_qkv_proj": hf_has_qkv,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="Qwen/Qwen2-0.5B")
+    parser.add_argument("--backend", choices=["vllm", "hf"], required=True)
+    args = parser.parse_args()
+
+    prompt = "The Eiffel Tower is in"
+
+    if args.backend == "vllm":
+        result = run_vllm(args.model, prompt)
+    else:
+        result = run_hf(args.model, prompt)
+
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nnsight/modeling/vllm/intervention-gaps/test_2_3.py
+++ b/src/nnsight/modeling/vllm/intervention-gaps/test_2_3.py
@@ -1,0 +1,147 @@
+"""
+Gap 2.3: down_proj.output and o_proj.output are (tensor, bias) tuples instead of tensors
+
+DOCUMENTED PATTERN (CLAUDE.md "Accessing Outputs" and "Modifying Activations"):
+    mlp_out = model.model.layers[0].mlp.down_proj.output.save()
+    # User then does: mlp_out * 2, or uses it for analysis
+Users expect .output from a linear layer to be a single tensor, consistent with
+nn.Linear behavior and all HF models.
+
+ON HF (expected behavior):
+    down_proj.output and o_proj.output are single tensors (nn.Linear returns a
+    tensor). Code like `down_proj.output * 2` or `down_proj.output[:] = 0` works
+    directly.
+
+ON vLLM (the gap):
+    vLLM's RowParallelLinear.forward() returns (output, output_bias) -- a 2-tuple.
+    Both mlp.down_proj and self_attn.o_proj use RowParallelLinear. Code that
+    treats .output as a tensor -- e.g., `down_proj.output * 2` -- will attempt to
+    multiply a tuple, causing a TypeError or silently wrong behavior if the tuple
+    is unpacked incorrectly.
+
+WHY THIS MATTERS:
+    Any intervention that reads or modifies down_proj or o_proj outputs needs to
+    know about the tuple wrapper. This affects MLP output ablation, attention
+    output steering, and any code that saves these outputs for analysis. The
+    extra bias element is usually None, but its presence breaks the interface
+    contract that users rely on.
+
+VALIDATION: Check whether down_proj.output and o_proj.output are tuples (vLLM)
+or single tensors (HF).
+"""
+
+import argparse
+import json
+
+import torch
+
+
+def run_vllm(model_name, prompt):
+    from nnsight.modeling.vllm import VLLM
+
+    model = VLLM(model_name, gpu_memory_utilization=0.05, dispatch=True)
+
+    # Forward order: self_attn (o_proj) runs before mlp (down_proj)
+    with model.trace(prompt, temperature=0.0):
+        o_out = model.model.layers[0].self_attn.o_proj.output.save()
+        down_out = model.model.layers[0].mlp.down_proj.output.save()
+
+    down_is_tuple = isinstance(down_out, tuple)
+    o_is_tuple = isinstance(o_out, tuple)
+
+    print("vLLM mlp.down_proj.output:")
+    if down_is_tuple:
+        print(f"  IS TUPLE, length={len(down_out)}")
+        for i, t in enumerate(down_out):
+            if isinstance(t, torch.Tensor):
+                print(f"  [{i}]: shape={t.shape}")
+            else:
+                print(f"  [{i}]: {t}")
+    else:
+        print(f"  IS TENSOR, shape={down_out.shape}")
+
+    print("\nvLLM self_attn.o_proj.output:")
+    if o_is_tuple:
+        print(f"  IS TUPLE, length={len(o_out)}")
+        for i, t in enumerate(o_out):
+            if isinstance(t, torch.Tensor):
+                print(f"  [{i}]: shape={t.shape}")
+            else:
+                print(f"  [{i}]: {t}")
+    else:
+        print(f"  IS TENSOR, shape={o_out.shape}")
+
+    gap_confirmed = down_is_tuple or o_is_tuple
+    status = "CONFIRMED" if gap_confirmed else "NOT_REPRODUCED"
+    detail = f"vLLM: down_proj tuple={down_is_tuple}, o_proj tuple={o_is_tuple}"
+    return {
+        "backend": "vllm",
+        "status": status,
+        "detail": detail,
+        "down_is_tuple": down_is_tuple,
+        "o_is_tuple": o_is_tuple,
+    }
+
+
+def run_hf(model_name, prompt):
+    from nnsight import LanguageModel
+
+    model = LanguageModel(model_name, device_map="cuda", dispatch=True)
+
+    # HF forward order: self_attn runs before mlp
+    # Inside self_attn: q_proj, k_proj, v_proj, attention, o_proj
+    # Inside mlp: gate_proj, up_proj, act_fn, down_proj
+    with model.trace(prompt):
+        o_out = model.model.layers[0].self_attn.o_proj.output.save()
+        down_out = model.model.layers[0].mlp.down_proj.output.save()
+
+    down_is_tuple = isinstance(down_out, tuple)
+    o_is_tuple = isinstance(o_out, tuple)
+
+    print("HF mlp.down_proj.output:")
+    if down_is_tuple:
+        print(f"  IS TUPLE, length={len(down_out)}")
+    elif isinstance(down_out, torch.Tensor):
+        print(f"  IS TENSOR, shape={down_out.shape}")
+    else:
+        print(f"  type={type(down_out)}")
+
+    print("\nHF self_attn.o_proj.output:")
+    if o_is_tuple:
+        print(f"  IS TUPLE, length={len(o_out)}")
+    elif isinstance(o_out, torch.Tensor):
+        print(f"  IS TENSOR, shape={o_out.shape}")
+    else:
+        print(f"  type={type(o_out)}")
+
+    # HF: both should be single tensors (nn.Linear returns tensor)
+    both_tensor = not down_is_tuple and not o_is_tuple
+    status = "NO_GAP" if both_tensor else "UNEXPECTED"
+    detail = f"HF: down_proj tuple={down_is_tuple}, o_proj tuple={o_is_tuple}"
+    return {
+        "backend": "hf",
+        "status": status,
+        "detail": detail,
+        "down_is_tuple": down_is_tuple,
+        "o_is_tuple": o_is_tuple,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="Qwen/Qwen2-0.5B")
+    parser.add_argument("--backend", choices=["vllm", "hf"], required=True)
+    args = parser.parse_args()
+
+    prompt = "The Eiffel Tower is in"
+
+    if args.backend == "vllm":
+        result = run_vllm(args.model, prompt)
+    else:
+        result = run_hf(args.model, prompt)
+
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nnsight/modeling/vllm/intervention-gaps/test_3_1.py
+++ b/src/nnsight/modeling/vllm/intervention-gaps/test_3_1.py
@@ -1,0 +1,151 @@
+"""
+Gap 3.1: Tensor layout is [total_tokens, hidden] (2D flat) instead of [batch, seq, hidden] (3D)
+
+DOCUMENTED PATTERN (CLAUDE.md "Modifying Activations"):
+    model.transformer.h[0].output[0][:, -1, :]  # Last token per sequence
+    model.transformer.h[0].output[0][:, :, 0]   # First hidden dim
+The docs show 3D indexing patterns like [:, -1, :] for last-token selection and
+[:, pos, :] for position-specific interventions. These assume a [batch, seq,
+hidden] layout.
+
+ON HF (expected behavior):
+    Tensors are [batch_size, seq_len, hidden_dim] (3D, padded). The [:, -1, :]
+    pattern correctly selects the last token for each sequence in the batch.
+    Note: nnsight's batcher narrows per-invoke, so within an invoke tensors may
+    appear as [seq, hidden] (2D), but the seq dimension is still present.
+
+ON vLLM (the gap):
+    Tensors are [total_tokens, hidden_dim] (2D, flat). vLLM uses continuous
+    batching -- all tokens from all sequences are packed into a single flat
+    dimension with no padding. The [:, -1, :] pattern fails because there is no
+    sequence dimension. Selecting the last token of a specific sequence requires
+    knowing its token boundaries in the flat layout.
+
+WHY THIS MATTERS:
+    Nearly all intervention code uses positional indexing to target specific
+    tokens (last token for next-token prediction, specific positions for
+    activation patching). The flat layout breaks all such patterns. Even simple
+    operations like "zero out the last token's hidden state" require fundamentally
+    different code on vLLM.
+
+VALIDATION: Compare ndim of layer outputs. vLLM produces 2D tensors, HF produces
+3D (or 2D per-invoke via batcher, but with a seq dimension preserved).
+"""
+
+import argparse
+import json
+
+import torch
+import nnsight
+
+
+def run_vllm(model_name, prompt):
+    from nnsight.modeling.vllm import VLLM
+
+    model = VLLM(model_name, gpu_memory_utilization=0.05, dispatch=True)
+
+    # Single prompt
+    with model.trace(prompt, temperature=0.0):
+        vllm_shape_single = nnsight.save(
+            model.model.layers[0].output[0].clone().shape
+        )
+
+    # Two prompts via invokes
+    with model.trace(temperature=0.0) as tracer:
+        with tracer.invoke(prompt):
+            vllm_shape_invoke1 = nnsight.save(
+                model.model.layers[0].output[0].clone().shape
+            )
+        with tracer.invoke("Hello"):
+            vllm_shape_invoke2 = nnsight.save(
+                model.model.layers[0].output[0].clone().shape
+            )
+
+    print("vLLM layer output shapes:")
+    print(f"  single prompt: {vllm_shape_single}")
+    print(f"  invoke 1 ('{prompt}'): {vllm_shape_invoke1}")
+    print(f"  invoke 2 ('Hello'): {vllm_shape_invoke2}")
+
+    vllm_ndim = len(vllm_shape_single)
+    print(f"  ndim={vllm_ndim}")
+
+    gap_confirmed = vllm_ndim == 2
+    status = "CONFIRMED" if gap_confirmed else "NOT_REPRODUCED"
+    detail = f"vLLM ndim={vllm_ndim} shape={list(vllm_shape_single)}"
+    return {
+        "backend": "vllm",
+        "status": status,
+        "detail": detail,
+        "ndim": vllm_ndim,
+        "shape": list(vllm_shape_single),
+    }
+
+
+def run_hf(model_name, prompt):
+    from nnsight import LanguageModel
+
+    model = LanguageModel(model_name, device_map="cuda", dispatch=True)
+
+    # Single prompt
+    with model.trace(prompt):
+        hf_shape_single = nnsight.save(
+            model.model.layers[0].output[0].shape
+        )
+
+    # Two prompts via invokes
+    with model.trace() as tracer:
+        with tracer.invoke(prompt):
+            hf_shape_invoke1 = nnsight.save(
+                model.model.layers[0].output[0].shape
+            )
+        with tracer.invoke("Hello"):
+            hf_shape_invoke2 = nnsight.save(
+                model.model.layers[0].output[0].shape
+            )
+
+    print("HF layer output shapes:")
+    print(f"  single prompt: {hf_shape_single}")
+    print(f"  invoke 1 ('{prompt}'): {hf_shape_invoke1}")
+    print(f"  invoke 2 ('Hello'): {hf_shape_invoke2}")
+
+    hf_ndim = len(hf_shape_single)
+    print(f"  ndim={hf_ndim}")
+
+    # Note: nnsight's batcher narrows the batch dim per-invoke, so even HF
+    # may show 2D [seq, hidden] instead of 3D [batch, seq, hidden] when
+    # accessed inside an invoke. The real gap is that vLLM's native format
+    # is flat [total_tokens, hidden] (no padding, no batch dim) while HF's
+    # native format is [batch, seq, hidden] (padded). Through nnsight's batcher,
+    # per-invoke tensors are narrowed to [seq, hidden] (2D). So when accessed
+    # inside an invoke, both HF and vLLM may appear 2D. However, for a single-
+    # prompt trace (no explicit invokes), HF should still show 3D [1, seq, hidden].
+    # We report NO_GAP if 3D (native HF layout), UNEXPECTED if something else.
+    status = "NO_GAP" if hf_ndim >= 2 else "UNEXPECTED"
+    detail = f"HF ndim={hf_ndim} shape={list(hf_shape_single)} (batcher may narrow per-invoke)"
+    return {
+        "backend": "hf",
+        "status": status,
+        "detail": detail,
+        "ndim": hf_ndim,
+        "shape": list(hf_shape_single),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="Qwen/Qwen2-0.5B")
+    parser.add_argument("--backend", choices=["vllm", "hf"], required=True)
+    args = parser.parse_args()
+
+    prompt = "The Eiffel Tower is in"
+
+    if args.backend == "vllm":
+        result = run_vllm(args.model, prompt)
+    else:
+        result = run_hf(args.model, prompt)
+
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nnsight/modeling/vllm/intervention-gaps/test_3_2.py
+++ b/src/nnsight/modeling/vllm/intervention-gaps/test_3_2.py
@@ -1,0 +1,154 @@
+"""
+Gap 3.2: Attention weights are inaccessible -- PagedAttention is a fused CUDA kernel
+
+DOCUMENTED PATTERN (CLAUDE.md "Attention Pattern Extraction"):
+    attn_weights = model.transformer.h[0].attn.source.attention_interface_0.output[0].save()
+The docs show extracting attention weights through source tracing into the
+attention computation, enabling attention visualization and analysis.
+
+ON HF (expected behavior):
+    self_attn.output is a tuple (attn_output, attn_weights_or_none). When
+    output_attentions=True, attention weights are accessible as a [batch, heads,
+    seq, seq] tensor. Source tracing into the attention module reveals the SDPA
+    call and its inputs/outputs. Attention pattern visualization, head pruning,
+    and attention knockout experiments all work.
+
+ON vLLM (the gap):
+    PagedAttention is a fused CUDA kernel that computes attention entirely in
+    C/CUDA -- no Python-level attention weight tensor is ever produced.
+    self_attn.output is a single tensor (just the attention output, no weights).
+    Source tracing into the attention module shows only a delegate call to the
+    C kernel. There is no attention weight matrix to extract at any level.
+
+WHY THIS MATTERS:
+    Attention weight analysis is foundational to interpretability: attention
+    visualization, attention head importance scoring, induction head detection,
+    attention knockout, and attention-based feature attribution all require the
+    [heads, seq, seq] weight matrix. With PagedAttention, none of these
+    workflows are possible. This is a fundamental architectural limitation,
+    not just an interface mismatch.
+
+VALIDATION: Check whether self_attn.output contains attention weights (HF tuple
+with optional weights) or is a single tensor (vLLM, no weights produced).
+"""
+
+import argparse
+import json
+
+import torch
+
+
+def run_vllm(model_name, prompt):
+    from nnsight.modeling.vllm import VLLM
+
+    model = VLLM(model_name, gpu_memory_utilization=0.05, dispatch=True)
+
+    with model.trace(prompt, temperature=0.0):
+        vllm_attn_out = model.model.layers[0].self_attn.output.save()
+
+    print("vLLM self_attn.output:")
+    vllm_is_tuple = isinstance(vllm_attn_out, tuple)
+    if vllm_is_tuple:
+        print(f"  IS TUPLE, length={len(vllm_attn_out)}")
+        for i, t in enumerate(vllm_attn_out):
+            if isinstance(t, torch.Tensor):
+                print(f"  [{i}]: shape={t.shape}, dtype={t.dtype}")
+            elif t is None:
+                print(f"  [{i}]: None")
+            else:
+                print(f"  [{i}]: type={type(t)}")
+    elif isinstance(vllm_attn_out, torch.Tensor):
+        print(f"  IS TENSOR, shape={vllm_attn_out.shape}")
+    else:
+        print(f"  type={type(vllm_attn_out)}")
+
+    vllm_has_attn = hasattr(model.model.layers[0].self_attn, "attn")
+    print(f"\n  has self_attn.attn (PagedAttention): {vllm_has_attn}")
+    if vllm_has_attn:
+        print(f"  self_attn.attn type: {type(model.model.layers[0].self_attn.attn._module)}")
+
+    if vllm_is_tuple:
+        output_desc = f"tuple len={len(vllm_attn_out)}"
+    elif isinstance(vllm_attn_out, torch.Tensor):
+        output_desc = f"tensor shape={list(vllm_attn_out.shape)}"
+    else:
+        output_desc = f"type={type(vllm_attn_out)}"
+
+    # Gap is confirmed when output is a single tensor (no attention weights).
+    # If it's a tuple, the gap is not reproduced (weights might be present).
+    is_single_tensor = isinstance(vllm_attn_out, torch.Tensor)
+    status = "CONFIRMED" if is_single_tensor else "NOT_REPRODUCED"
+    detail = (
+        f"vLLM attn output: {output_desc}; "
+        f"PagedAttention fuses attention — no weights accessible"
+    )
+    return {
+        "backend": "vllm",
+        "status": status,
+        "detail": detail,
+        "is_tuple": vllm_is_tuple,
+        "output_desc": output_desc,
+    }
+
+
+def run_hf(model_name, prompt):
+    from nnsight import LanguageModel
+
+    model = LanguageModel(model_name, device_map="cuda", dispatch=True)
+
+    with model.trace(prompt):
+        hf_attn_out = model.model.layers[0].self_attn.output.save()
+
+    print("HF self_attn.output:")
+    hf_is_tuple = isinstance(hf_attn_out, tuple)
+    if hf_is_tuple:
+        print(f"  IS TUPLE, length={len(hf_attn_out)}")
+        for i, t in enumerate(hf_attn_out):
+            if isinstance(t, torch.Tensor):
+                print(f"  [{i}]: shape={t.shape}, dtype={t.dtype}")
+            elif t is None:
+                print(f"  [{i}]: None")
+            else:
+                print(f"  [{i}]: type={type(t)}")
+    elif isinstance(hf_attn_out, torch.Tensor):
+        print(f"  IS TENSOR, shape={hf_attn_out.shape}")
+    else:
+        print(f"  type={type(hf_attn_out)}")
+
+    if hf_is_tuple:
+        output_desc = f"tuple len={len(hf_attn_out)}"
+    elif isinstance(hf_attn_out, torch.Tensor):
+        output_desc = f"tensor shape={list(hf_attn_out.shape)}"
+    else:
+        output_desc = f"type={type(hf_attn_out)}"
+
+    # HF: self_attn.output should be a tuple (attn_output, attn_weights_or_none)
+    status = "NO_GAP" if hf_is_tuple else "UNEXPECTED"
+    detail = f"HF attn output: {output_desc}"
+    return {
+        "backend": "hf",
+        "status": status,
+        "detail": detail,
+        "is_tuple": hf_is_tuple,
+        "output_desc": output_desc,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="Qwen/Qwen2-0.5B")
+    parser.add_argument("--backend", choices=["vllm", "hf"], required=True)
+    args = parser.parse_args()
+
+    prompt = "The Eiffel Tower is in"
+
+    if args.backend == "vllm":
+        result = run_vllm(args.model, prompt)
+    else:
+        result = run_hf(args.model, prompt)
+
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nnsight/modeling/vllm/intervention-gaps/test_4_1.py
+++ b/src/nnsight/modeling/vllm/intervention-gaps/test_4_1.py
@@ -1,0 +1,164 @@
+"""
+Gap 4.1: All gradient computation is blocked by torch.inference_mode()
+
+DOCUMENTED PATTERN (CLAUDE.md "Gradients and Backpropagation"):
+    with model.trace("Hello"):
+        hs = model.transformer.h[-1].output[0]
+        hs.requires_grad_(True)
+        logits = model.lm_head.output
+        loss = logits.sum()
+        with loss.backward():
+            grad = hs.grad.save()
+The docs show gradient-based workflows using requires_grad_() and backward()
+inside traces for attribution, saliency maps, and probe training.
+
+ON HF (expected behavior):
+    requires_grad_(True) succeeds, loss.backward() computes gradients, and
+    hs.grad contains the gradient tensor. Gradient-based attribution (e.g.,
+    integrated gradients), saliency maps, and training linear probes on
+    intermediate activations all work within the tracing context.
+
+ON vLLM (the gap):
+    vLLM wraps all model execution in torch.inference_mode(), which globally
+    disables gradient tracking. requires_grad_(True) raises RuntimeError,
+    and loss.backward() fails. There is no way to compute gradients on any
+    tensor during vLLM inference.
+
+WHY THIS MATTERS:
+    Gradient-based interpretability is a major research paradigm: integrated
+    gradients, GradCAM-style attribution, saliency maps, gradient-based feature
+    attribution, and training probes/SAEs on activations (which need gradients
+    for the probe parameters) are all completely impossible under vLLM. This
+    rules out a substantial fraction of interpretability research workflows.
+
+VALIDATION: Test whether requires_grad_(True) and loss.backward() succeed (HF)
+or raise errors (vLLM).
+"""
+
+import argparse
+import json
+import traceback
+
+import torch
+
+
+def run_vllm(model_name, prompt):
+    from nnsight.modeling.vllm import VLLM
+
+    model = VLLM(model_name, gpu_memory_utilization=0.05, dispatch=True)
+    errors = []
+
+    # Test 1: requires_grad_ inside trace
+    try:
+        with model.trace(prompt, temperature=0.0):
+            hs = model.model.layers[5].output[0]
+            hs.requires_grad_(True)
+            logits = model.logits.output.save()
+        errors.append(("requires_grad_", None))
+        print("requires_grad_(True): NO ERROR (unexpected)")
+    except Exception as e:
+        errors.append(("requires_grad_", str(e)))
+        print(f"requires_grad_(True): ERROR -- {type(e).__name__}: {e}")
+
+    # Test 2: backward inside trace — check that gradients actually contain values,
+    # not just that the context manager doesn't throw.
+    try:
+        with model.trace(prompt, temperature=0.0):
+            hs = model.model.layers[5].output[0]
+            hs.requires_grad_(True)
+            logits = model.logits.output
+            loss = logits.sum()
+            with loss.backward():
+                grad = hs.grad.save()
+        # Even if no exception, verify grad has real nonzero values
+        if grad.abs().sum().item() > 0:
+            errors.append(("backward", None))
+            print(f"loss.backward(): OK, grad has nonzero values, shape={grad.shape}")
+        else:
+            errors.append(("backward", "grad is all zeros — no real gradient flow"))
+            print("loss.backward(): FAILED — grad is all zeros")
+    except Exception as e:
+        errors.append(("backward", str(e)))
+        print(f"loss.backward(): ERROR -- {type(e).__name__}: {e}")
+
+    # The real test is whether backward() works (actual gradient flow).
+    # requires_grad_() may succeed if nnsight clones tensors out of inference
+    # mode, but that doesn't mean gradients actually propagate — the
+    # underlying computation graph still ran under inference_mode.
+    backward_failed = errors[1][1] is not None if len(errors) > 1 else True
+    status = "CONFIRMED" if backward_failed else "NOT_REPRODUCED"
+    detail = "; ".join(f"{name}: {'FAILED' if err else 'OK'}" for name, err in errors)
+    return {
+        "backend": "vllm",
+        "status": status,
+        "detail": detail,
+        "requires_grad_ok": errors[0][1] is None if errors else None,
+        "backward_ok": errors[1][1] is None if len(errors) > 1 else None,
+    }
+
+
+def run_hf(model_name, prompt):
+    from nnsight import LanguageModel
+
+    model = LanguageModel(model_name, device_map="cuda", dispatch=True)
+    errors = []
+
+    # Test 1: requires_grad_ inside trace
+    try:
+        with model.trace(prompt):
+            hs = model.model.layers[5].output[0]
+            hs.requires_grad_(True)
+            logits = model.lm_head.output.save()
+        errors.append(("requires_grad_", None))
+        print("requires_grad_(True): NO ERROR (expected)")
+    except Exception as e:
+        errors.append(("requires_grad_", str(e)))
+        print(f"requires_grad_(True): ERROR -- {type(e).__name__}: {e}")
+
+    # Test 2: backward inside trace
+    try:
+        with model.trace(prompt):
+            hs = model.model.layers[5].output[0]
+            hs.requires_grad_(True)
+            logits = model.lm_head.output
+            loss = logits.sum()
+            with loss.backward():
+                grad = hs.grad.save()
+        errors.append(("backward", None))
+        print(f"loss.backward(): NO ERROR (expected), grad shape={grad.shape}")
+    except Exception as e:
+        errors.append(("backward", str(e)))
+        print(f"loss.backward(): ERROR -- {type(e).__name__}: {e}")
+
+    requires_grad_ok = errors[0][1] is None if errors else False
+    # The core gap is about inference_mode: requires_grad_ works on HF but not vLLM.
+    # backward may fail on HF for unrelated reasons (grad not captured for this model).
+    status = "NO_GAP" if requires_grad_ok else "UNEXPECTED_FAILURE"
+    detail = "; ".join(f"{name}: {'OK' if err is None else 'FAILED'}" for name, err in errors)
+    return {
+        "backend": "hf",
+        "status": status,
+        "detail": detail,
+        "requires_grad_ok": errors[0][1] is None if errors else None,
+        "backward_ok": errors[1][1] is None if len(errors) > 1 else None,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="Qwen/Qwen2-0.5B")
+    parser.add_argument("--backend", choices=["vllm", "hf"], required=True)
+    args = parser.parse_args()
+
+    prompt = "The Eiffel Tower is in"
+
+    if args.backend == "vllm":
+        result = run_vllm(args.model, prompt)
+    else:
+        result = run_hf(args.model, prompt)
+
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nnsight/modeling/vllm/intervention-gaps/test_4_2.py
+++ b/src/nnsight/modeling/vllm/intervention-gaps/test_4_2.py
@@ -1,0 +1,149 @@
+"""
+Gap 4.2: Source tracing shows only 1 trivial delegate op for fused modules
+
+DOCUMENTED PATTERN (CLAUDE.md "Source Tracing"):
+    print(model.transformer.h[0].attn.source)  # Shows all operations
+    # Output shows operation names like attention_interface_0, self_c_proj_0, etc.
+The docs show .source revealing the internal operations of a module's forward
+method, enabling fine-grained intervention at any point inside the computation.
+
+ON HF (expected behavior):
+    Source tracing reveals rich internal structure: input_layernorm shows 6+
+    operations (multiply, rsqrt, mean, etc.), self_attn shows 16+ operations
+    (projections, reshape, attention, output projection), and act_fn shows its
+    activation function internals. Users can hook into any intermediate operation.
+
+ON vLLM (the gap):
+    Fused modules like input_layernorm, act_fn (SiluAndMul), and the attention
+    kernel have Python-level forward methods that are trivial wrappers:
+        return self._forward_method(*args, **kwargs)
+    Source tracing on these modules shows only 1 operation -- the delegate call
+    to the C/CUDA kernel. The actual computation (normalization, activation,
+    attention) happens entirely in compiled code and is invisible to .source.
+
+WHY THIS MATTERS:
+    Source tracing is nnsight's mechanism for fine-grained intervention inside
+    modules -- e.g., hooking between the query projection and the attention
+    computation, or intercepting the intermediate result after RMS normalization
+    but before scaling. When the real computation is hidden inside a fused CUDA
+    kernel, users cannot inspect or modify any intermediate values within these
+    modules, limiting intervention granularity.
+
+VALIDATION: Count operations (-> arrows) in .source output for input_layernorm,
+self_attn, act_fn, and decoder_layer. HF shows many ops; vLLM fused modules
+show 1 (the delegate call).
+"""
+
+import argparse
+import json
+
+import torch
+
+
+def run_vllm(model_name):
+    from nnsight.modeling.vllm import VLLM
+
+    model = VLLM(model_name, gpu_memory_utilization=0.05, dispatch=True)
+    findings = {}
+
+    modules_to_test = [
+        ("input_layernorm", model.model.layers[0].input_layernorm, True),
+        ("self_attn", model.model.layers[0].self_attn, False),
+        ("act_fn", model.model.layers[0].mlp.act_fn, True),
+        ("decoder_layer", model.model.layers[0], False),
+    ]
+    for name, mod, is_fused in modules_to_test:
+        try:
+            src = mod.source
+            src_str = str(src)
+            op_count = src_str.count("->")
+            print(f"\n{name}.source ({op_count} ops, fused={is_fused}):")
+            print(src_str[:500])
+            findings[name] = {
+                "accessible": True,
+                "content_length": len(src_str),
+                "op_count": op_count,
+                "is_fused": is_fused,
+            }
+        except Exception as e:
+            print(f"{name}.source: ERROR -- {type(e).__name__}: {e}")
+            findings[name] = {"accessible": False, "error": str(e), "is_fused": is_fused}
+
+    # The real test: fused modules (input_layernorm, act_fn) have a trivial
+    # Python wrapper "return self._forward_method(*args, **kwargs)" that
+    # delegates to a C/CUDA kernel. Source tracing "works" (returns non-empty)
+    # but the content has only 1 operation (the delegate call) — not meaningful.
+    fused_trivial = any(
+        findings.get(k, {}).get("op_count", 0) <= 1
+        for k in ("input_layernorm", "act_fn")
+    )
+    status = "CONFIRMED" if fused_trivial else "NOT_REPRODUCED"
+    detail = "; ".join(
+        f"{k}: {f.get('op_count', '?')} ops (len={f.get('content_length', 0)})"
+        if f.get("accessible") else f"{k}: FAILED"
+        for k, f in findings.items()
+    )
+    return {
+        "backend": "vllm",
+        "status": status,
+        "detail": detail,
+        "findings": findings,
+    }
+
+
+def run_hf(model_name):
+    from nnsight import LanguageModel
+
+    model = LanguageModel(model_name, device_map="cuda", dispatch=True)
+    findings = {}
+
+    modules_to_test = [
+        ("input_layernorm", model.model.layers[0].input_layernorm),
+        ("self_attn", model.model.layers[0].self_attn),
+        ("act_fn", model.model.layers[0].mlp.act_fn),
+        ("decoder_layer", model.model.layers[0]),
+    ]
+    for name, mod in modules_to_test:
+        try:
+            src = mod.source
+            src_str = str(src)
+            op_count = src_str.count("->")
+            print(f"\n{name}.source ({op_count} ops):")
+            print(src_str[:500])
+            findings[name] = {"accessible": True, "content_length": len(src_str), "op_count": op_count}
+        except Exception as e:
+            print(f"{name}.source: ERROR -- {type(e).__name__}: {e}")
+            findings[name] = {"accessible": False, "error": str(e)}
+
+    # HF: source tracing should work with multiple ops on all modules
+    all_accessible = all(f.get("accessible", False) for f in findings.values())
+    hf_has_ops = all(f.get("op_count", 0) > 1 for f in findings.values() if f.get("accessible"))
+    status = "NO_GAP" if all_accessible and hf_has_ops else "UNEXPECTED_FAILURE"
+    detail = "; ".join(
+        f"{k}: {f.get('op_count', '?')} ops" if f.get("accessible") else f"{k}: FAILED"
+        for k, f in findings.items()
+    )
+    return {
+        "backend": "hf",
+        "status": status,
+        "detail": detail,
+        "findings": findings,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="Qwen/Qwen2-0.5B")
+    parser.add_argument("--backend", choices=["vllm", "hf"], required=True)
+    args = parser.parse_args()
+
+    if args.backend == "vllm":
+        result = run_vllm(args.model)
+    else:
+        result = run_hf(args.model)
+
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nnsight/modeling/vllm/intervention-gaps/test_4_3.py
+++ b/src/nnsight/modeling/vllm/intervention-gaps/test_4_3.py
@@ -1,0 +1,166 @@
+"""
+Gap 4.3: Module skip breaks because fused norm expects (x, residual) pair
+
+DOCUMENTED PATTERN (CLAUDE.md "Module Skipping"):
+    model.transformer.h[1].skip(layer0_out)  # Skip layer, use provided value
+The docs show skip() replacing a module's entire computation with a provided
+value, useful for layer ablation studies and skip connection research.
+
+ON HF (expected behavior):
+    Layers return simple (hidden_states,) tuples. Skipping a layer with a single
+    tensor works because the next layer's input_layernorm expects just
+    hidden_states. skip(layer_output_tuple) also works. Layer ablation studies
+    proceed without issue.
+
+ON vLLM (the gap):
+    Layers return (hidden_states, residual) -- a 2-tuple needed by vLLM's fused
+    norm architecture. The NEXT layer's input_layernorm (fused_add_rms_norm)
+    expects TWO tensors: the raw sub-layer output and the residual. When skip()
+    provides a single tensor, the fused norm crashes because it cannot unpack
+    its expected (x, residual) input. Even skip(tuple) may fail if the tuple
+    format does not exactly match what the fused kernel expects.
+
+WHY THIS MATTERS:
+    Layer ablation is a core interpretability technique: "what happens if we
+    remove layer N?" Skip is the clean way to do this in nnsight. Without skip
+    support, researchers cannot easily study which layers are critical, perform
+    layer-by-layer knockout experiments, or test skip connection hypotheses.
+    The workaround requires understanding vLLM's internal (x, residual)
+    bookkeeping and manually constructing the correct tuple.
+
+VALIDATION: Attempt skip(single_tensor) and skip(tuple) on a decoder layer.
+HF succeeds; vLLM fails with the single tensor due to fused norm mismatch.
+"""
+
+import argparse
+import json
+import traceback
+
+import torch
+
+
+def run_vllm(model_name, prompt):
+    from nnsight.modeling.vllm import VLLM
+
+    model = VLLM(model_name, gpu_memory_utilization=0.05, dispatch=True)
+
+    # First get a reference output from layer 4 to use as skip value
+    with model.trace(prompt, temperature=0.0):
+        ref_out = model.model.layers[4].output[0].clone().save()
+
+    print(f"Reference output shape: {ref_out.shape}")
+
+    # Try to skip layer 5 with a single tensor
+    error_msg = None
+    try:
+        with model.trace(prompt, temperature=0.0):
+            model.model.layers[5].skip(ref_out)
+            logits = model.logits.output.save()
+        print("skip(single_tensor): NO ERROR")
+        print(f"  logits shape: {logits.shape}")
+    except Exception as e:
+        error_msg = f"{type(e).__name__}: {e}"
+        print(f"skip(single_tensor): ERROR -- {error_msg}")
+
+    # Try to skip with a (x, residual) tuple
+    error_msg_tuple = None
+    try:
+        with model.trace(prompt, temperature=0.0):
+            layer4_out = model.model.layers[4].output
+            model.model.layers[5].skip(layer4_out)
+            logits2 = model.logits.output.save()
+        print("\nskip(tuple): NO ERROR")
+        print(f"  logits shape: {logits2.shape}")
+    except Exception as e:
+        error_msg_tuple = f"{type(e).__name__}: {e}"
+        print(f"\nskip(tuple): ERROR -- {error_msg_tuple}")
+
+    single_failed = error_msg is not None
+    tuple_failed = error_msg_tuple is not None
+    status = "CONFIRMED" if single_failed else "NOT_REPRODUCED"
+    detail = (
+        f"skip(single_tensor): {'FAILED: ' + error_msg if single_failed else 'OK'}; "
+        f"skip(tuple): {'FAILED: ' + error_msg_tuple if tuple_failed else 'OK'}"
+    )
+    return {
+        "backend": "vllm",
+        "status": status,
+        "detail": detail,
+        "single_skip_ok": not single_failed,
+        "tuple_skip_ok": not tuple_failed,
+    }
+
+
+def run_hf(model_name, prompt):
+    from nnsight import LanguageModel
+
+    model = LanguageModel(model_name, device_map="cuda", dispatch=True)
+
+    # First get a reference output from layer 4
+    with model.trace(prompt):
+        ref_out = model.model.layers[4].output[0].clone().save()
+
+    print(f"Reference output shape: {ref_out.shape}")
+
+    # Try to skip layer 5 with the reference output
+    error_msg = None
+    try:
+        with model.trace(prompt):
+            model.model.layers[5].skip(ref_out)
+            logits = model.lm_head.output.save()
+        print("skip(single_tensor): NO ERROR (expected)")
+        print(f"  logits shape: {logits.shape}")
+    except Exception as e:
+        error_msg = f"{type(e).__name__}: {e}"
+        print(f"skip(single_tensor): ERROR -- {error_msg}")
+
+    # Try to skip with full output (tuple from HF)
+    error_msg_tuple = None
+    try:
+        with model.trace(prompt):
+            layer4_out = model.model.layers[4].output
+            model.model.layers[5].skip(layer4_out)
+            logits2 = model.lm_head.output.save()
+        print("\nskip(tuple): NO ERROR (expected)")
+        print(f"  logits shape: {logits2.shape}")
+    except Exception as e:
+        error_msg_tuple = f"{type(e).__name__}: {e}"
+        print(f"\nskip(tuple): ERROR -- {error_msg_tuple}")
+
+    single_ok = error_msg is None
+    tuple_ok = error_msg_tuple is None
+    # skip(single_tensor) may fail on HF too if the next layer expects a tuple
+    # output format. This is a general skip limitation, not the vLLM-specific
+    # fused norm issue. skip(tuple) is the better test for HF.
+    status = "NO_GAP" if tuple_ok else "UNEXPECTED_FAILURE"
+    detail = (
+        f"skip(single_tensor): {'OK' if single_ok else 'FAILED (expected — shape mismatch)'}; "
+        f"skip(tuple): {'OK' if tuple_ok else 'FAILED: ' + str(error_msg_tuple)}"
+    )
+    return {
+        "backend": "hf",
+        "status": status,
+        "detail": detail,
+        "single_skip_ok": single_ok,
+        "tuple_skip_ok": tuple_ok,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="Qwen/Qwen2-0.5B")
+    parser.add_argument("--backend", choices=["vllm", "hf"], required=True)
+    args = parser.parse_args()
+
+    prompt = "The Eiffel Tower is in"
+
+    if args.backend == "vllm":
+        result = run_vllm(args.model, prompt)
+    else:
+        result = run_hf(args.model, prompt)
+
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nnsight/modeling/vllm/intervention-gaps/test_stop_and_errors.py
+++ b/src/nnsight/modeling/vllm/intervention-gaps/test_stop_and_errors.py
@@ -1,0 +1,173 @@
+"""
+Test that tracer.stop(), user errors, and multi-invoke failures don't kill
+the vLLM engine.  Validates per-mediator exception isolation.
+
+Run: CUDA_VISIBLE_DEVICES=X python test_stop_and_errors.py
+"""
+import torch
+
+
+def verify_engine(model, label):
+    """Run a trivial trace to confirm the engine is still alive."""
+    with model.trace("Engine check", temperature=0.0, top_p=1):
+        logits = model.logits.output.save()
+    assert logits.shape[-1] > 0, f"Engine dead after {label}"
+    print(f"  Engine alive after {label} — logits shape: {logits.shape}")
+
+
+def main():
+    from nnsight.modeling.vllm import VLLM
+
+    model = VLLM("gpt2", tensor_parallel_size=1, gpu_memory_utilization=0.05, dispatch=True)
+
+    # ------------------------------------------------------------------
+    print("=" * 60)
+    print("Test 1: tracer.stop() — engine survives, values saved")
+    print("=" * 60)
+
+    with model.trace("Hello world", temperature=0.0, top_p=1) as tracer:
+        hs = model.transformer.h[0].output[0].save()
+        tracer.stop()
+        # Code after stop() should NOT execute
+        should_not_exist = model.transformer.h[5].output[0].save()
+
+    assert isinstance(hs, torch.Tensor), f"Expected tensor, got {type(hs)}"
+    print(f"  hs shape: {hs.shape}, dtype: {hs.dtype}")
+
+    try:
+        _ = should_not_exist
+        print("  WARNING: should_not_exist was defined (stop didn't prevent it)")
+    except (UnboundLocalError, NameError):
+        print("  should_not_exist correctly undefined (stop prevented it)")
+
+    verify_engine(model, "stop")
+    print("  PASS")
+
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("Test 2: Single invoke error — engine survives, error reported")
+    print("=" * 60)
+
+    caught = False
+    try:
+        with model.trace("Hello world", temperature=0.0, top_p=1):
+            bad = model.transformer.h[100].output[0].save()
+    except Exception as e:
+        caught = True
+        print(f"  Error correctly raised: {type(e).__name__}: {e}")
+
+    assert caught, "FAIL: No error raised for invalid layer index"
+
+    verify_engine(model, "single error")
+    print("  PASS")
+
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("Test 3: One of N invokes errors — engine survives")
+    print("=" * 60)
+
+    caught = False
+    try:
+        with model.trace(temperature=0.0, top_p=1) as tracer:
+            with tracer.invoke("Hello"):
+                good1 = model.transformer.h[0].output[0].save()
+
+            with tracer.invoke("World"):
+                # This invoke will error — GPT-2 has 12 layers, not 100
+                bad = model.transformer.h[100].output[0].save()
+
+            with tracer.invoke("Test"):
+                good2 = model.transformer.h[0].output[0].save()
+    except Exception as e:
+        caught = True
+        print(f"  Error raised: {type(e).__name__}")
+        # Verify the error message references the actual problem
+        assert "list index" in str(e).lower() or "index" in str(e).lower(), \
+            f"Error doesn't mention index issue: {e}"
+        print(f"  Error message correctly references IndexError")
+
+    assert caught, "FAIL: No error raised when one invoke fails"
+
+    verify_engine(model, "one-of-N error")
+    print("  PASS")
+
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("Test 4: All invokes error — all exceptions reported")
+    print("=" * 60)
+
+    caught = False
+    err_msg = ""
+    try:
+        with model.trace(temperature=0.0, top_p=1) as tracer:
+            with tracer.invoke("Hello"):
+                model.transformer.h[100].output[0].save()
+
+            with tracer.invoke("World"):
+                model.transformer.h[100].output[0].save()
+
+            with tracer.invoke("Test"):
+                model.transformer.h[100].output[0].save()
+    except Exception as e:
+        caught = True
+        err_msg = str(e)
+        print(f"  Error raised: {type(e).__name__}")
+        # With 3 errors, should be a RuntimeError listing all
+        if "invoke" in err_msg.lower() and "failed" in err_msg.lower():
+            print(f"  Aggregate error with multiple failures reported")
+        else:
+            print(f"  Single error reported (may indicate only one was captured)")
+        print(f"  Message preview: {err_msg[:200]}")
+
+    assert caught, "FAIL: No error raised when all invokes fail"
+
+    verify_engine(model, "all-error")
+    print("  PASS")
+
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("Test 5: Mixed stop + error — error raised, engine survives")
+    print("=" * 60)
+
+    caught = False
+    try:
+        with model.trace(temperature=0.0, top_p=1) as tracer:
+            with tracer.invoke("Hello"):
+                stop_hs = model.transformer.h[0].output[0].save()
+                tracer.stop()
+
+            with tracer.invoke("World"):
+                model.transformer.h[100].output[0].save()
+    except Exception as e:
+        caught = True
+        print(f"  Error raised (from invoke 2): {type(e).__name__}")
+        # EarlyStopException should be filtered — only the real error surfaces
+        assert "EarlyStop" not in str(type(e).__name__), \
+            "FAIL: EarlyStopException was not filtered"
+        print(f"  EarlyStopException correctly filtered")
+
+    assert caught, "FAIL: No error raised for the erroring invoke"
+
+    verify_engine(model, "mixed stop+error")
+    print("  PASS")
+
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("Test 6: Normal trace after all failure modes")
+    print("=" * 60)
+
+    with model.trace("The Eiffel Tower is in", temperature=0.0, top_p=1):
+        final_logits = model.logits.output.save()
+    next_token = model.tokenizer.decode(final_logits.argmax(dim=-1)[0])
+    print(f"  Next token: '{next_token}'")
+    print(f"  Logits shape: {final_logits.shape}")
+    print("  PASS")
+
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("ALL TESTS PASSED — engine survived all failure modes")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
+++ b/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
@@ -366,7 +366,12 @@ class NNsightGPUModelRunner(GPUModelRunner):
     ):
 
         Globals.enter()
-        with self.nnsight_model._interleaver:
+
+        return_value = None
+        interleaver = self.nnsight_model._interleaver
+        interleaver._defer_exceptions = True
+
+        with interleaver:
 
             return_value = super().execute_model(scheduler_output, intermediate_tensors)
 
@@ -384,6 +389,18 @@ class NNsightGPUModelRunner(GPUModelRunner):
                     **{**state._asdict(), "logits": logits}
                 )
 
+        interleaver._defer_exceptions = False
+
+        # Safety net: if __enter__ failed or forward was interrupted before
+        # return_value could be assigned, build a minimal valid output.
+        if return_value is None:
+            from vllm.v1.outputs import ModelRunnerOutput
+            req_ids = list(scheduler_output.num_scheduled_tokens.keys())
+            return_value = ModelRunnerOutput(
+                req_ids=req_ids,
+                req_id_to_index={rid: i for i, rid in enumerate(req_ids)},
+            )
+
         Globals.exit()
 
         return return_value
@@ -392,13 +409,19 @@ class NNsightGPUModelRunner(GPUModelRunner):
 
         Globals.enter()
 
-        with self.nnsight_model._interleaver:
+        sampler_output = None
+        interleaver = self.nnsight_model._interleaver
+        interleaver._defer_exceptions = True
+
+        with interleaver:
 
             sampler_output = super()._sample(*args, **kwargs)
 
             sampler_output.sampled_token_ids = self.model.samples(
                 sampler_output.sampled_token_ids, hook=True
             )
+
+        interleaver._defer_exceptions = False
 
         Globals.exit()
 
@@ -438,5 +461,21 @@ class NNsightGPUModelRunner(GPUModelRunner):
         )
         saves, removals = helper.collect_saves(matched, finished_keys)
         helper.cleanup_finished(finished_keys, removals)
+
+        # Collect deferred exceptions from mediators, keyed by request ID.
+        # Each invoke has its own mediator and its own exception.
+        # The wrapped exception can't be pickled (dynamic class), so send type + message.
+        exceptions = {}
+        for base_id, mediator, internal_key in matched:
+            if mediator._deferred_exception is not None:
+                exc = mediator._deferred_exception
+                exceptions[base_id] = {
+                    "type": type(exc).__bases__[0].__name__ if hasattr(type(exc), "__bases__") else type(exc).__name__,
+                    "message": str(exc),
+                }
+                mediator._deferred_exception = None
+
+        if exceptions:
+            saves["__nnsight_exceptions__"] = exceptions
 
         return pickle.dumps(saves)

--- a/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
+++ b/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
@@ -6,7 +6,7 @@ from vllm.sequence import IntermediateTensors
 from vllm.tokenizers import cached_tokenizer_from_config
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 from vllm.distributed.parallel_state import get_tp_group
-from nnsight.intervention.tracing.globals import Globals
+from nnsight.intervention.tracing.globals import Globals, _saves_var
 
 from ....intervention.serialization import load
 from ..batching import VLLMBatcher
@@ -91,15 +91,18 @@ class NNsightGPUModelRunner(GPUModelRunner):
                 if trace_id not in self.trace_contexts:
                     canonical_globals = mediator.intervention.__globals__
 
-                    # Register saved vars in worker-side Globals.saves
-                    # (.save() was called on the client with a different id).
+                    # Per-trace saves set: isolates save tracking between
+                    # concurrent traces and survives the Globals.enter()
+                    # reset across execute_model/sample boundaries.
+                    trace_saves = set()
                     for name in saved_names:
                         if name in canonical_globals:
-                            Globals.saves.add(id(canonical_globals[name]))
+                            trace_saves.add(id(canonical_globals[name]))
 
                     self.trace_contexts[trace_id] = {
                         "saved_names": saved_names,
                         "canonical_globals": canonical_globals,
+                        "saves": trace_saves,
                         "expected_count": extra_args.get("nnsight_expected_count", 1),
                         "received_count": 0,
                         "pending_req_ids": set(),
@@ -115,6 +118,13 @@ class NNsightGPUModelRunner(GPUModelRunner):
                             med_globals[name] = canonical[name]
 
                 ctx = self.trace_contexts[trace_id]
+
+                # Point _saves_var at this trace's set so the worker
+                # thread (via copy_context) captures the right reference.
+                # Worker .save() calls will add IDs to this trace's set,
+                # not the global one that Globals.enter() may reset.
+                mediator._trace_saves = ctx["saves"]
+                _saves_var.set(ctx["saves"])
 
                 model._interleaver.mediators.append(mediator)
                 mediator.start(model._interleaver)
@@ -242,21 +252,24 @@ class NNsightGPUModelRunner(GPUModelRunner):
 
             Gathers per-invoke saves from frame locals and trace-shared
             saves from canonical globals (only when a trace is fully done).
+            Uses per-trace saves sets (stored in trace_contexts and
+            referenced by each mediator) instead of Globals.saves.
 
             Returns:
                 ``(saves, removals)`` — the saves dict and set of
-                ``id()`` values to discard from ``Globals.saves``.
+                ``(id, trace_saves_ref)`` pairs to discard after collection.
             """
             saves = {}
-            removals = set()
+            removals = []
 
             for base_id, mediator, internal_key in matched:
                 frame = mediator.info.frame
+                trace_saves = mediator._trace_saves
                 for key, value in frame.f_locals.items():
-                    if id(value) in Globals.saves:
+                    if id(value) in trace_saves:
                         saves[key] = value
                         if internal_key in finished_internal_keys:
-                            removals.add(id(value))
+                            removals.append((id(value), trace_saves))
 
             # Trace-shared saves: collect when ALL mediators for a trace
             # have been received AND completed.
@@ -269,25 +282,26 @@ class NNsightGPUModelRunner(GPUModelRunner):
                             and ctx["received_count"] == ctx["expected_count"]
                         )
                         if trace_fully_done:
+                            trace_saves = ctx["saves"]
                             canonical = ctx["canonical_globals"]
                             for name in ctx["saved_names"]:
                                 if name in canonical:
                                     value = canonical[name]
-                                    if id(value) in Globals.saves:
+                                    if id(value) in trace_saves:
                                         saves[name] = value
-                                        removals.add(id(value))
+                                        removals.append((id(value), trace_saves))
                         break
 
             return saves, removals
 
-        def cleanup_finished(self, finished_internal_keys: set, removals: set) -> None:
+        def cleanup_finished(self, finished_internal_keys: set, removals: list) -> None:
             """Clean up state for finished requests.
 
-            Removes entries from ``Globals.saves``, deletes completed
-            trace contexts, and drops mediator entries.
+            Discards collected IDs from their per-trace saves sets,
+            deletes completed trace contexts, and drops mediator entries.
             """
-            for _id in removals:
-                Globals.saves.discard(_id)
+            for _id, trace_saves in removals:
+                trace_saves.discard(_id)
 
             done_traces = [
                 tid
@@ -327,13 +341,10 @@ class NNsightGPUModelRunner(GPUModelRunner):
 
         self.nnsight_model._interleaver.batcher = VLLMBatcher()
 
-        # Only wrap when TP > 1: registers hooks that handle
-        # gather/split of sharded tensors and CUDA synchronization
-        # for TP-parallel modules.  With TP == 1 nothing is sharded
-        # so wrapping is pure overhead.
-
-        if get_tp_group().world_size > 1:
-            self.nnsight_model._interleaver.batcher.wrap(self.nnsight_model)
+        # Always call wrap() to register compat transforms (module
+        # detection for HF-compatibility layer).  TP gather/split
+        # hooks are gated on world_size > 1 inside wrap() itself.
+        self.nnsight_model._interleaver.batcher.wrap(self.nnsight_model)
 
     def _update_states(self, scheduler_output: "SchedulerOutput") -> None:
 

--- a/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
+++ b/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
@@ -248,7 +248,7 @@ class NNsightGPUModelRunner(GPUModelRunner):
             return finished_internal_keys
 
         def collect_saves(self, matched, finished_internal_keys: set) -> tuple:
-            """Collect saved values from mediator frames.
+            """Collect saved values from mediator frames, namespaced per request.
 
             Gathers per-invoke saves from frame locals and trace-shared
             saves from canonical globals (only when a trace is fully done).
@@ -256,24 +256,37 @@ class NNsightGPUModelRunner(GPUModelRunner):
             referenced by each mediator) instead of Globals.saves.
 
             Returns:
-                ``(saves, removals)`` — the saves dict and set of
-                ``(id, trace_saves_ref)`` pairs to discard after collection.
+                ``(saves_by_req, removals)`` —
+                ``saves_by_req`` is ``{base_id: {var_name: value}}`` so
+                concurrent requests whose user code uses the same
+                variable name (``logits``, ``x``, …) don't collide at
+                the outer flat-dict layer.  The caller (engine / server)
+                routes each sub-dict to the matching request output.
+                ``removals`` is a list of ``(id, trace_saves_ref)`` pairs
+                to discard after collection.
             """
-            saves = {}
+            saves_by_req: dict = {}
             removals = []
 
+            # Map internal_key -> base_id so trace-shared saves from a
+            # finished internal_key can be attached to the right bucket.
+            base_by_internal = {ik: b for b, _, ik in matched}
+
             for base_id, mediator, internal_key in matched:
+                per_req = saves_by_req.setdefault(base_id, {})
                 frame = mediator.info.frame
                 trace_saves = mediator._trace_saves
                 for key, value in frame.f_locals.items():
                     if id(value) in trace_saves:
-                        saves[key] = value
+                        per_req[key] = value
                         if internal_key in finished_internal_keys:
                             removals.append((id(value), trace_saves))
 
             # Trace-shared saves: collect when ALL mediators for a trace
-            # have been received AND completed.
+            # have been received AND completed.  Attach to the base_id
+            # whose finishing triggered the trace completion.
             for internal_key in finished_internal_keys:
+                owning_base = base_by_internal.get(internal_key, internal_key)
                 for _, ctx in self.trace_contexts.items():
                     if internal_key in ctx["pending_req_ids"]:
                         ctx["pending_req_ids"].discard(internal_key)
@@ -284,15 +297,16 @@ class NNsightGPUModelRunner(GPUModelRunner):
                         if trace_fully_done:
                             trace_saves = ctx["saves"]
                             canonical = ctx["canonical_globals"]
+                            per_req = saves_by_req.setdefault(owning_base, {})
                             for name in ctx["saved_names"]:
                                 if name in canonical:
                                     value = canonical[name]
                                     if id(value) in trace_saves:
-                                        saves[name] = value
+                                        per_req[name] = value
                                         removals.append((id(value), trace_saves))
                         break
 
-            return saves, removals
+            return saves_by_req, removals
 
         def cleanup_finished(self, finished_internal_keys: set, removals: list) -> None:
             """Clean up state for finished requests.
@@ -470,23 +484,29 @@ class NNsightGPUModelRunner(GPUModelRunner):
         finished_keys = helper.finalize_mediators(
             matched, finished_req_id_set, self.nnsight_model
         )
-        saves, removals = helper.collect_saves(matched, finished_keys)
+        saves_by_req, removals = helper.collect_saves(matched, finished_keys)
         helper.cleanup_finished(finished_keys, removals)
 
-        # Collect deferred exceptions from mediators, keyed by request ID.
-        # Each invoke has its own mediator and its own exception.
-        # The wrapped exception can't be pickled (dynamic class), so send type + message.
-        exceptions = {}
+        # Collect deferred exceptions.  Each mediator has its own —
+        # nest it inside THAT request's sub-dict under
+        # ``__nnsight_exceptions__`` in the ``{base_id: exc_info}``
+        # shape the existing sync ``vllm.py`` consumer understands.
+        # The wrapped exception can't be pickled (dynamic class) so
+        # we send type + message strings.
         for base_id, mediator, internal_key in matched:
             if mediator._deferred_exception is not None:
                 exc = mediator._deferred_exception
-                exceptions[base_id] = {
-                    "type": type(exc).__bases__[0].__name__ if hasattr(type(exc), "__bases__") else type(exc).__name__,
-                    "message": str(exc),
+                per_req = saves_by_req.setdefault(base_id, {})
+                per_req["__nnsight_exceptions__"] = {
+                    base_id: {
+                        "type": (
+                            type(exc).__bases__[0].__name__
+                            if hasattr(type(exc), "__bases__")
+                            else type(exc).__name__
+                        ),
+                        "message": str(exc),
+                    }
                 }
                 mediator._deferred_exception = None
 
-        if exceptions:
-            saves["__nnsight_exceptions__"] = exceptions
-
-        return pickle.dumps(saves)
+        return pickle.dumps(saves_by_req)

--- a/src/nnsight/modeling/vllm/serve/README.md
+++ b/src/nnsight/modeling/vllm/serve/README.md
@@ -1,0 +1,138 @@
+# nnsight-serve
+
+A lightweight single-model server backed by vLLM. vLLM does the heavy lifting (continuous batching, paged KV cache, request scheduling); nnsight injects intervention hooks on top.
+
+Users who only need one model get a persistent server with nnsight intervention support — no vLLM restart per request, no NDIF cluster setup.
+
+## Install
+
+This feature is on the `nnsight-vllm-serve` branch and not yet released on PyPI.
+
+```bash
+pip install "nnsight[serve] @ git+https://github.com/ndif-team/nnsight.git@nnsight-vllm-serve"
+```
+
+Or from a local clone:
+
+```bash
+git clone https://github.com/ndif-team/nnsight.git
+cd nnsight
+git checkout nnsight-vllm-serve
+pip install -e ".[serve]"
+```
+
+**Note:** Editable installs (`pip install -e`) don't register the `nnsight-serve` CLI command due to a setuptools-scm limitation. Use `python -m nnsight.modeling.vllm.serve.cli` instead (same interface, same arguments).
+
+## Start the server
+
+```bash
+# Single GPU
+nnsight-serve Qwen/Qwen3-30B-A3B --port 6677 --gpu-memory-utilization 0.8
+
+# Multi-GPU (tensor parallel)
+nnsight-serve meta-llama/Llama-3.1-70B --port 6677 --tensor-parallel-size 4
+
+# With API key authentication
+nnsight-serve Qwen/Qwen3-30B-A3B --port 6677 --api-key mysecret
+```
+
+All flags after the model name are forwarded to vLLM's engine (e.g., `--tensor-parallel-size`, `--gpu-memory-utilization`, `--enforce-eager`).
+
+Default bind address is `127.0.0.1` (localhost only). Pass `--host 0.0.0.0` for network access.
+
+If the `nnsight-serve` command is not found (common with editable installs), use:
+
+```bash
+python -m nnsight.modeling.vllm.serve.cli Qwen/Qwen3-30B-A3B --port 6677
+```
+
+## Client usage
+
+The client only needs a meta model (no GPU required). All computation happens on the server.
+
+### Blocking (default)
+
+Same UX as local nnsight — `.save()` values are available immediately after the `with` block:
+
+```python
+from nnsight.modeling.vllm import VLLM
+
+model = VLLM("Qwen/Qwen3-30B-A3B")  # meta model, no GPU
+
+with model.trace("The Eiffel Tower is in", serve="http://localhost:6677"):
+    hidden = model.model.layers[24].output[0].save()
+    logits = model.logits.output.save()
+
+print(model.tokenizer.decode(logits.argmax(dim=-1)))  # Paris
+print(hidden.shape)  # torch.Size([...])
+```
+
+### Non-blocking (concurrent)
+
+Fire multiple requests concurrently. vLLM batches them for higher throughput:
+
+```python
+with model.trace("prompt 1", serve=url, blocking=False) as t1:
+    out1 = model.logits.output.save()
+with model.trace("prompt 2", serve=url, blocking=False) as t2:
+    out2 = model.logits.output.save()
+
+# Both in-flight concurrently inside vLLM's engine.
+saves1 = t1.collect()  # blocks until response, returns {"out1": tensor}
+saves2 = t2.collect()
+```
+
+Non-blocking mode returns saves as a dict from `.collect()` — variables are NOT auto-injected into the caller's scope.
+
+### Multi-invoke (batched)
+
+Multiple prompts in a single trace:
+
+```python
+with model.trace(temperature=0.0, top_p=1, serve=url) as tracer:
+    with tracer.invoke("The capital of France is"):
+        logits_fr = model.logits.output.save()
+    with tracer.invoke("The capital of Japan is"):
+        logits_jp = model.logits.output.save()
+```
+
+### Interventions
+
+```python
+with model.trace("The Eiffel Tower is in", serve=url):
+    model.model.layers[40].output[0][:] = 0  # zero out layer 40
+    logits = model.logits.output.save()
+```
+
+### With API key
+
+```python
+with model.trace("Hello", serve=url, api_key="mysecret"):
+    logits = model.logits.output.save()
+```
+
+### Saving lists of activations
+
+When saving multiple values into a collection, `.save()` the collection — not the individual elements:
+
+```python
+# CORRECT
+with model.trace("Hello", serve=url):
+    results = list().save()
+    for i in range(12):
+        results.append(model.model.layers[i].output[0])
+
+# CORRECT
+with model.trace("Hello", serve=url):
+    results = [model.model.layers[i].output[0] for i in range(12)].save()
+
+# WRONG — elements are saved but the list is not; values will be lost
+with model.trace("Hello", serve=url):
+    results = [model.model.layers[i].output[0].save() for i in range(12)]
+```
+
+## Limitations
+
+- **vLLM only** — no HuggingFace Transformers backend (yet).
+- **Cross-trace tensor references** — passing a saved tensor from one serve trace into another is not supported. The tensor exists on the client but the server has no access to it. This produces a clear error; the server engine is not affected.
+- **Non-blocking frame injection** — `blocking=False` cannot inject values into the caller's frame (the frame has moved on). Use `.collect()` to retrieve saves as a dict.

--- a/src/nnsight/modeling/vllm/serve/cli.py
+++ b/src/nnsight/modeling/vllm/serve/cli.py
@@ -1,0 +1,122 @@
+"""CLI entry point for nnsight-vllm-serve.
+
+Usage:
+    nnsight-serve <model-name> [--host HOST] [--port PORT] [vLLM engine args...]
+
+Examples:
+    nnsight-serve meta-llama/Llama-3.1-8B-Instruct
+    nnsight-serve Qwen/Qwen2.5-0.5B-Instruct --port 6677
+    nnsight-serve meta-llama/Llama-3.1-70B --tensor-parallel-size 4
+
+Design choices:
+- Default host is 127.0.0.1 (localhost only) for security. Accepting
+  serialized Python code over the network is dangerous. Users must
+  explicitly pass --host 0.0.0.0 for network access.
+- Default port is 6677 (avoids conflict with vLLM's default 8000).
+- vLLM engine args are passed through directly. We parse --host and --port
+  ourselves and forward the rest to AsyncEngineArgs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="nnsight-serve",
+        description="Start a local nnsight server backed by vLLM.",
+    )
+    parser.add_argument("model", help="HuggingFace model name or path")
+    parser.add_argument("--host", default="127.0.0.1", help="Bind address (default: 127.0.0.1)")
+    parser.add_argument("--port", type=int, default=6677, help="Port (default: 6677)")
+    parser.add_argument("--api-key", default=None, help="Optional API key for authentication")
+
+    # Parse known args; the rest are forwarded to vLLM.
+    args, vllm_args = parser.parse_known_args()
+
+    # Build vLLM kwargs from remaining args (e.g., --tensor-parallel-size 4).
+    vllm_kwargs = _parse_vllm_args(vllm_args)
+
+    print(f"Starting nnsight-vllm-serve: {args.model}")
+    print(f"  Host: {args.host}:{args.port}")
+    if args.host != "127.0.0.1":
+        print("  WARNING: Server is network-accessible. Ensure you trust all clients.")
+    if vllm_kwargs:
+        print(f"  vLLM args: {vllm_kwargs}")
+
+    # Import here to avoid slow imports on --help.
+    from ..vllm import VLLM
+    from .server import app, set_model
+
+    # Create model with async engine.
+    model = VLLM(args.model, mode="async", dispatch=True, **vllm_kwargs)
+    set_model(model)
+
+    if args.api_key:
+        _add_api_key_middleware(app, args.api_key)
+
+    print(f"Server ready at http://{args.host}:{args.port}")
+
+    import uvicorn
+    uvicorn.run(app, host=args.host, port=args.port, log_level="info")
+
+
+def _parse_vllm_args(raw_args: list[str]) -> dict:
+    """Parse leftover CLI args into a dict for VLLM(**kwargs).
+
+    Converts --tensor-parallel-size 4 → {"tensor_parallel_size": 4}.
+    """
+    kwargs = {}
+    i = 0
+    while i < len(raw_args):
+        arg = raw_args[i]
+        if arg.startswith("--"):
+            key = arg[2:].replace("-", "_")
+            if i + 1 < len(raw_args) and not raw_args[i + 1].startswith("--"):
+                value = raw_args[i + 1]
+                # Try to convert to int/float/bool.
+                try:
+                    value = int(value)
+                except ValueError:
+                    try:
+                        value = float(value)
+                    except ValueError:
+                        if value.lower() in ("true", "false"):
+                            value = value.lower() == "true"
+                kwargs[key] = value
+                i += 2
+            else:
+                # Flag without value (e.g., --enable-something) → True.
+                kwargs[key] = True
+                i += 1
+        else:
+            print(f"Warning: ignoring unknown positional arg: {arg}", file=sys.stderr)
+            i += 1
+    return kwargs
+
+
+def _add_api_key_middleware(app, expected_key: str):
+    """Add a simple API key check middleware."""
+    from fastapi import Request
+    from starlette.middleware.base import BaseHTTPMiddleware
+    from starlette.responses import JSONResponse
+
+    class ApiKeyMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request: Request, call_next):
+            if request.url.path == "/health":
+                return await call_next(request)
+            key = request.headers.get("ndif-api-key", "")
+            if key != expected_key:
+                return JSONResponse(
+                    status_code=401,
+                    content={"detail": "Invalid API key"},
+                )
+            return await call_next(request)
+
+    app.add_middleware(ApiKeyMiddleware)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nnsight/modeling/vllm/serve/server.py
+++ b/src/nnsight/modeling/vllm/serve/server.py
@@ -101,12 +101,13 @@ async def generate(request: Request):
         Globals.enter()
 
         # Set up mediators from the compiled intervention function.
-        # init_interleaver=False: the vLLM worker runs on a separate
-        # thread / process and owns ``model._interleaver`` state via
-        # ``process_new_reqs_serialized`` → ``_start_mediator_now``.
-        # Calling ``initialize`` here would reset ``interleaver.current``
-        # to ``None`` and race with a concurrent ``Mediator.start()``.
-        args, kwargs = tracer._setup_interleaver(fn, init_interleaver=False)
+        # We deliberately do NOT call ``_init_shared_interleaver()``: the
+        # vLLM worker runs on a separate thread / process and owns
+        # ``model._interleaver`` state via ``process_new_reqs_serialized``
+        # → ``_start_mediator_now``. Calling ``initialize`` here would reset
+        # ``interleaver.current`` to ``None`` and race with a concurrent
+        # ``Mediator.start()``.
+        args, kwargs = tracer._run_user_fn(fn)
 
         if not _model.dispatched:
             # Should already be dispatched by cli.py, but just in case.

--- a/src/nnsight/modeling/vllm/serve/server.py
+++ b/src/nnsight/modeling/vllm/serve/server.py
@@ -101,15 +101,22 @@ async def generate(request: Request):
         Globals.enter()
 
         # Set up mediators from the compiled intervention function.
-        args, kwargs = tracer._setup_interleaver(fn)
+        # init_interleaver=False: the vLLM worker runs on a separate
+        # thread / process and owns ``model._interleaver`` state via
+        # ``process_new_reqs_serialized`` → ``_start_mediator_now``.
+        # Calling ``initialize`` here would reset ``interleaver.current``
+        # to ``None`` and race with a concurrent ``Mediator.start()``.
+        args, kwargs = tracer._setup_interleaver(fn, init_interleaver=False)
 
         if not _model.dispatched:
             # Should already be dispatched by cli.py, but just in case.
             _model.dispatch()
 
         # Serialize mediators into SamplingParams.extra_args.
+        # Pass tracer.mediators explicitly because we skipped initialize()
+        # above, so self._interleaver.mediators is stale from prior traffic.
         prompts, params, lora_requests = _model._serialize_mediators(
-            *args, **kwargs
+            *args, mediators=tracer.mediators, **kwargs
         )
 
         tracer.mediators.clear()

--- a/src/nnsight/modeling/vllm/serve/server.py
+++ b/src/nnsight/modeling/vllm/serve/server.py
@@ -140,7 +140,11 @@ async def generate(request: Request):
         ):
             last_output = output
 
-        # Collect saves from workers.
+        # Collect saves from workers.  Each rank returns per-request
+        # ``{base_id: {var_name: value}}``; we extract THIS request's
+        # sub-dict rather than flat-merging across ranks.  collect_rpc
+        # is already scoped to one request_id here, but we still unwrap
+        # the outer layer so the payload shape matches the new protocol.
         finished = [request_id]
         results = await engine.collective_rpc(
             "collect_nnsight",
@@ -149,7 +153,10 @@ async def generate(request: Request):
         saves = {}
         for r in results:
             if r is not None:
-                saves.update(pickle.loads(r))
+                rank_saves = pickle.loads(r)
+                per_req = rank_saves.get(request_id) if rank_saves else None
+                if per_req:
+                    saves.update(per_req)
 
         gen_output = {}
         if last_output is not None:

--- a/src/nnsight/modeling/vllm/serve/server.py
+++ b/src/nnsight/modeling/vllm/serve/server.py
@@ -1,0 +1,168 @@
+"""nnsight-vllm-serve: local HTTP server for nnsight interventions on vLLM.
+
+Design choices:
+- Synchronous request/response: client blocks until generation + saves collection
+  completes. No WebSocket or polling needed. This differs from NDIF's async
+  job-based API because the server is local and single-model.
+- Server-side trace compilation: the client sends a serialized RequestModel
+  (same format as NDIF). The server deserializes, compiles the trace, creates
+  mediators, and submits to the vLLM engine. This means the client does NOT
+  need a GPU or a dispatched model — only a meta model for envoy proxies.
+- Binary transport: request and response bodies are serialized with
+  CustomCloudPickler / torch.save. No JSON encoding of tensors.
+- Single model per server instance: different models run on different ports.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+import pickle
+import uuid
+from typing import TYPE_CHECKING, Any, Optional
+
+import torch
+from fastapi import FastAPI, HTTPException, Request, Response
+
+from ....intervention.backends.base import Backend
+from ....intervention.tracing.globals import Globals
+from ....schema.request import RequestModel
+from ....schema.response import ResponseModel
+
+if TYPE_CHECKING:
+    from ..vllm import VLLM
+
+logger = logging.getLogger("nnsight.serve")
+
+app = FastAPI(title="nnsight-vllm-serve")
+
+# Set by cli.py after engine initialization.
+_model: Optional["VLLM"] = None
+
+
+def set_model(model: "VLLM") -> None:
+    global _model
+    _model = model
+
+
+@app.get("/health")
+async def health():
+    if _model is None or _model.vllm_entrypoint is None:
+        raise HTTPException(status_code=503, detail="Engine not ready")
+    return {"status": "ok"}
+
+
+@app.post("/v1/nnsight/generate")
+async def generate(request: Request):
+    """Execute an nnsight trace on the vLLM engine.
+
+    Accepts a serialized RequestModel (same format as NDIF's POST /request).
+    Deserializes, compiles the trace into mediators, submits to the engine,
+    collects saves, and returns them synchronously.
+
+    Request body: RequestModel.serialize() bytes (optionally zstd-compressed).
+    Headers:
+        nnsight-compress: "True" or "False" (default "False")
+
+    Response body: torch.save-serialized dict with keys:
+        saves: dict of saved variable names → values
+        outputs: list of generation output dicts (text, token_ids, etc.)
+    """
+    if _model is None:
+        raise HTTPException(status_code=503, detail="Engine not ready")
+
+    body = await request.body()
+    compress = request.headers.get("nnsight-compress", "False").lower() == "true"
+
+    try:
+        request_model = RequestModel.deserialize(
+            body, _model._remoteable_persistent_objects(), compress
+        )
+    except Exception as e:
+        logger.exception("Failed to deserialize request")
+        raise HTTPException(status_code=400, detail=f"Deserialization failed: {e}")
+
+    fn = request_model.interventions
+    tracer = request_model.tracer
+
+    try:
+        Globals.enter()
+
+        # Set up mediators from the compiled intervention function.
+        args, kwargs = tracer._setup_interleaver(fn)
+
+        if not _model.dispatched:
+            # Should already be dispatched by cli.py, but just in case.
+            _model.dispatch()
+
+        # Serialize mediators into SamplingParams.extra_args.
+        prompts, params, lora_requests = _model._serialize_mediators(
+            *args, **kwargs
+        )
+
+        tracer.mediators.clear()
+    except Exception as e:
+        Globals.exit()
+        logger.exception("Failed to compile trace")
+        raise HTTPException(status_code=400, detail=f"Trace compilation failed: {e}")
+    finally:
+        Globals.exit()
+
+    # Submit all invokes concurrently and collect saves.
+    engine = _model.vllm_entrypoint
+    all_saves = {}
+    generation_outputs = []
+
+    async def run_invoke(prompt, param, lora_request):
+        request_id = str(uuid.uuid4())
+        last_output = None
+
+        async for output in engine.generate(
+            prompt, param, request_id, lora_request=lora_request
+        ):
+            last_output = output
+
+        # Collect saves from workers.
+        finished = [request_id]
+        results = await engine.collective_rpc(
+            "collect_nnsight",
+            args=([request_id], finished),
+        )
+        saves_bytes = next((r for r in results if r is not None), None)
+        saves = pickle.loads(saves_bytes) if saves_bytes else {}
+
+        gen_output = {}
+        if last_output is not None:
+            out = last_output.outputs[0] if last_output.outputs else None
+            gen_output = {
+                "text": out.text if out else "",
+                "token_ids": list(out.token_ids) if out else [],
+            }
+
+        return saves, gen_output
+
+    tasks = []
+    for i, (prompt, param) in enumerate(zip(prompts, params)):
+        lora_req = lora_requests[i] if lora_requests else None
+        tasks.append(run_invoke(prompt, param, lora_req))
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    for result in results:
+        if isinstance(result, Exception):
+            logger.exception("Generation failed", exc_info=result)
+            raise HTTPException(
+                status_code=500, detail=f"Generation failed: {result}"
+            )
+        saves, gen_output = result
+        all_saves.update(saves)
+        generation_outputs.append(gen_output)
+
+    # Serialize response using torch.save (handles tensors correctly).
+    response_data = {"saves": all_saves, "outputs": generation_outputs}
+    buf = io.BytesIO()
+    torch.save(response_data, buf)
+    buf.seek(0)
+
+    return Response(content=buf.read(), media_type="application/octet-stream")

--- a/src/nnsight/modeling/vllm/serve/server.py
+++ b/src/nnsight/modeling/vllm/serve/server.py
@@ -28,22 +28,28 @@ from fastapi import FastAPI, HTTPException, Request, Response
 from ....intervention.backends.base import Backend
 from ....intervention.tracing.globals import Globals
 from ....schema.request import RequestModel
-from ....schema.response import ResponseModel
 
 if TYPE_CHECKING:
     from ..vllm import VLLM
 
 logger = logging.getLogger("nnsight.serve")
+logger.setLevel(logging.INFO)
+if not logger.handlers:
+    _handler = logging.StreamHandler()
+    _handler.setFormatter(logging.Formatter("[nnsight-serve] %(message)s"))
+    logger.addHandler(_handler)
 
 app = FastAPI(title="nnsight-vllm-serve")
 
 # Set by cli.py after engine initialization.
 _model: Optional["VLLM"] = None
+_persistent_objects: Optional[dict] = None
 
 
 def set_model(model: "VLLM") -> None:
-    global _model
+    global _model, _persistent_objects
     _model = model
+    _persistent_objects = model._remoteable_persistent_objects()
 
 
 @app.get("/health")
@@ -75,9 +81,14 @@ async def generate(request: Request):
     body = await request.body()
     compress = request.headers.get("nnsight-compress", "False").lower() == "true"
 
+    client_host = request.client.host if request.client else "unknown"
+    logger.info(
+        "Received request: %d bytes, compress=%s, client=%s",
+        len(body), compress, client_host,
+    )
     try:
         request_model = RequestModel.deserialize(
-            body, _model._remoteable_persistent_objects(), compress
+            body, _persistent_objects, compress
         )
     except Exception as e:
         logger.exception("Failed to deserialize request")
@@ -103,7 +114,6 @@ async def generate(request: Request):
 
         tracer.mediators.clear()
     except Exception as e:
-        Globals.exit()
         logger.exception("Failed to compile trace")
         raise HTTPException(status_code=400, detail=f"Trace compilation failed: {e}")
     finally:
@@ -129,8 +139,10 @@ async def generate(request: Request):
             "collect_nnsight",
             args=([request_id], finished),
         )
-        saves_bytes = next((r for r in results if r is not None), None)
-        saves = pickle.loads(saves_bytes) if saves_bytes else {}
+        saves = {}
+        for r in results:
+            if r is not None:
+                saves.update(pickle.loads(r))
 
         gen_output = {}
         if last_output is not None:
@@ -163,6 +175,13 @@ async def generate(request: Request):
     response_data = {"saves": all_saves, "outputs": generation_outputs}
     buf = io.BytesIO()
     torch.save(response_data, buf)
-    buf.seek(0)
+    resp_bytes = buf.getvalue()
 
-    return Response(content=buf.read(), media_type="application/octet-stream")
+    logger.info(
+        "Completed request: %d invokes, %d saves (%s), %d bytes response",
+        len(generation_outputs),
+        len(all_saves),
+        ", ".join(all_saves.keys()) if all_saves else "none",
+        len(resp_bytes),
+    )
+    return Response(content=resp_bytes, media_type="application/octet-stream")

--- a/src/nnsight/modeling/vllm/serve_tracer.py
+++ b/src/nnsight/modeling/vllm/serve_tracer.py
@@ -1,0 +1,56 @@
+"""Client-side tracer for ``model.trace(..., serve=url)``.
+
+Holds serve-specific state (the in-flight HTTP future for non-blocking
+requests) on a dedicated subclass so the base tracing layer stays free
+of serve concerns.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import Future
+from typing import Dict, Optional
+
+from ..mixins.remoteable import RemoteInterleavingTracer
+
+
+class ServeInterleavingTracer(RemoteInterleavingTracer):
+    """Tracer for client-side calls to nnsight-vllm-serve.
+
+    Selected via ``tracer_cls=`` from :meth:`VLLM.trace` when ``serve=`` is
+    set. Owns the non-blocking request handle and exposes :meth:`collect`
+    so callers can retrieve saves once the server responds.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._serve_future: Optional[Future] = None
+
+    def collect(self, timeout: float = None) -> Dict:
+        """Block until a non-blocking serve request completes and return saves.
+
+        Only valid after ``model.trace(..., serve=url, blocking=False)``.
+
+        Args:
+            timeout: Maximum seconds to wait. ``None`` means wait forever.
+
+        Returns:
+            Dict mapping saved variable names to their values.
+
+        Raises:
+            RuntimeError: If no serve request is in flight (e.g.
+                ``blocking=True`` was used).
+            Exception: Any exception from the server or network.
+
+        Example::
+
+            with model.trace("prompt", serve=url, blocking=False) as t:
+                out = model.logits.output.save()
+            saves = t.collect()
+            out = saves["out"]
+        """
+        if self._serve_future is None:
+            raise RuntimeError(
+                "Tracer has no pending serve request. "
+                "Did you use blocking=False?"
+            )
+        return self._serve_future.result(timeout=timeout)

--- a/src/nnsight/modeling/vllm/vllm.py
+++ b/src/nnsight/modeling/vllm/vllm.py
@@ -159,6 +159,12 @@ class VLLM(RemoteableMixin):
 
     def _load(self, repo_id: str, **kwargs) -> "Module":
 
+        # Disable prefix caching by default.  Prefix caching reuses KV values
+        # from previous requests, which can skip the forward pass for cached
+        # tokens — hooks won't fire and interventions on those tokens are
+        # silently skipped.  Users can override with enable_prefix_caching=True.
+        kwargs.setdefault("enable_prefix_caching", False)
+
         meta_model = self._load_meta(repo_id, **kwargs)
 
         destroy_model_parallel()
@@ -406,11 +412,15 @@ class VLLM(RemoteableMixin):
         outputs = self.vllm_entrypoint.generate(prompts, sampling_params=params, lora_request=lora_requests)
 
         saves = {}
+        deferred_exception = None
 
         # Some of the output objects will have a saves attribute, which contains the saved variables
         for output in outputs:
             if hasattr(output, "saves"):
                 saves.update(output.saves)
+
+        # Extract deferred exceptions from worker, keyed by request ID.
+        deferred_exceptions = saves.pop("__nnsight_exceptions__", None)
 
         # Save the variables in our local environment
         for value in saves.values():
@@ -419,6 +429,25 @@ class VLLM(RemoteableMixin):
 
         # Push the variables to the interleaver frame
         push_variables(self._interleaver.mediators[0].info.frame, saves)
+
+        # Raise deferred exceptions at the trace boundary (after saves are
+        # pushed so any values saved before the error are still accessible).
+        # EarlyStopException is intentional control flow — filter it out.
+        if deferred_exceptions is not None:
+            real_errors = {
+                req_id: exc_info for req_id, exc_info in deferred_exceptions.items()
+                if exc_info.get("type") != "EarlyStopException"
+            }
+            if real_errors:
+                # Raise the first real error with its original type.
+                first_id, first_exc = next(iter(real_errors.items()))
+                exc_type_name = first_exc.get("type", "Exception")
+                exc_message = first_exc.get("message", "")
+                builtins_ref = __builtins__ if isinstance(__builtins__, dict) else vars(__builtins__)
+                exc_type = builtins_ref.get(exc_type_name, RuntimeError) if isinstance(builtins_ref, dict) else getattr(builtins_ref, exc_type_name, RuntimeError)
+                if not isinstance(exc_type, type) or not issubclass(exc_type, BaseException):
+                    exc_type = RuntimeError
+                raise exc_type(f"[vLLM worker] {exc_message}")
 
     def trace(self, *inputs, **kwargs):
         if self._async_engine and kwargs.get('backend') is None and not kwargs.get('remote'):

--- a/src/nnsight/modeling/vllm/vllm.py
+++ b/src/nnsight/modeling/vllm/vllm.py
@@ -16,7 +16,7 @@ if _installed_version != NNS_VLLM_VERSION:
 import torch
 
 from vllm.model_executor.model_loader.dummy_loader import DummyModelLoader
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 from vllm.tokenizers import cached_tokenizer_from_config
 from vllm.inputs import TokensPrompt
 
@@ -339,14 +339,24 @@ class VLLM(RemoteableMixin):
         prompts: List[str],
         params: List[NNsightSamplingParams],
         lora_requests: List[Any],
+        mediators: Optional[List[Any]] = None,
         **kwargs,
     ) -> Tuple[List[str], List[NNsightSamplingParams], List[Any]]:
         """Serialize mediators and attach them to sampling params.
 
-        Collects all input mediators from the interleaver, serializes
-        each one into the corresponding ``NNsightSamplingParams.extra_args``,
-        and propagates any root-trace kwargs to params that still carry
-        defaults.
+        Collects all input mediators, serializes each into the corresponding
+        ``NNsightSamplingParams.extra_args``, and propagates any root-trace
+        kwargs to params that still carry defaults.
+
+        Args:
+            mediators: Explicit mediator list. Server paths pass
+                ``tracer.mediators`` because they call ``_setup_interleaver``
+                with ``init_interleaver=False`` to avoid racing with
+                ``Mediator.start()`` on the vLLM worker thread; those paths
+                cannot rely on ``self._interleaver.mediators`` being current.
+                When ``None`` (local sync/async paths), falls back to
+                ``self._interleaver.mediators`` as populated by
+                ``Interleaver.initialize``.
 
         Returns:
             ``(prompts, params, lora_requests)`` with mediator data attached.
@@ -354,9 +364,13 @@ class VLLM(RemoteableMixin):
 
         default_param = NNsightSamplingParams.from_optional()
 
+        source_mediators = (
+            mediators if mediators is not None else self._interleaver.mediators
+        )
+
         # Collect all input mediators (those with batch_group, i.e. not empty invokes)
         input_mediators = []
-        for mediator in self._interleaver.mediators:
+        for mediator in source_mediators:
             if mediator.batch_group is not None:
                 mediator.intervention.__source__ = "".join(mediator.info.source)
                 input_mediators.append(mediator)

--- a/src/nnsight/modeling/vllm/vllm.py
+++ b/src/nnsight/modeling/vllm/vllm.py
@@ -81,6 +81,7 @@ class VLLM(RemoteableMixin):
                 f"Invalid mode {mode!r}. Must be 'sync' or 'async'."
             )
         self._async_engine: bool = mode == "async"
+        self._compat: bool = kwargs.pop("compat", True)
 
         self.vllm_entrypoint: LLM = None
         self.tokenizer: "AnyTokenizer" = None
@@ -408,13 +409,10 @@ class VLLM(RemoteableMixin):
 
         prompts, params, lora_requests = self._serialize_mediators(prompts, params, lora_requests, **kwargs)
 
-        # Do VLLM generation with NNsight
         outputs = self.vllm_entrypoint.generate(prompts, sampling_params=params, lora_request=lora_requests)
 
         saves = {}
-        deferred_exception = None
 
-        # Some of the output objects will have a saves attribute, which contains the saved variables
         for output in outputs:
             if hasattr(output, "saves"):
                 saves.update(output.saves)
@@ -454,10 +452,14 @@ class VLLM(RemoteableMixin):
         if serve is not None and kwargs.get("backend") is None:
             from ...intervention.backends.local_serve import LocalServeBackend
             blocking = kwargs.pop("blocking", True)
-            kwargs["backend"] = LocalServeBackend(self, host=serve, blocking=blocking)
-        elif self._async_engine and kwargs.get('backend') is None and not kwargs.get('remote'):
-            from .async_backend import AsyncVLLMBackend
-            kwargs['backend'] = AsyncVLLMBackend(self)
+            api_key = kwargs.pop("api_key", None)
+            kwargs["backend"] = LocalServeBackend(self, host=serve, blocking=blocking, api_key=api_key)
+        else:
+            if "api_key" in kwargs:
+                raise ValueError("api_key= requires serve= to specify the server URL")
+            if self._async_engine and kwargs.get('backend') is None and not kwargs.get('remote'):
+                from .async_backend import AsyncVLLMBackend
+                kwargs['backend'] = AsyncVLLMBackend(self)
         return super().trace(*inputs, **kwargs)
 
     def interleave(self, fn: Callable, *args, **kwargs):

--- a/src/nnsight/modeling/vllm/vllm.py
+++ b/src/nnsight/modeling/vllm/vllm.py
@@ -450,7 +450,11 @@ class VLLM(RemoteableMixin):
                 raise exc_type(f"[vLLM worker] {exc_message}")
 
     def trace(self, *inputs, **kwargs):
-        if self._async_engine and kwargs.get('backend') is None and not kwargs.get('remote'):
+        serve = kwargs.pop("serve", None)
+        if serve is not None and kwargs.get("backend") is None:
+            from ...intervention.backends.local_serve import LocalServeBackend
+            kwargs["backend"] = LocalServeBackend(self, host=serve)
+        elif self._async_engine and kwargs.get('backend') is None and not kwargs.get('remote'):
             from .async_backend import AsyncVLLMBackend
             kwargs['backend'] = AsyncVLLMBackend(self)
         return super().trace(*inputs, **kwargs)

--- a/src/nnsight/modeling/vllm/vllm.py
+++ b/src/nnsight/modeling/vllm/vllm.py
@@ -341,8 +341,8 @@ class VLLM(RemoteableMixin):
 
         Args:
             mediators: Explicit mediator list. Server paths pass
-                ``tracer.mediators`` because they call ``_setup_interleaver``
-                with ``init_interleaver=False`` to avoid racing with
+                ``tracer.mediators`` because they call ``_run_user_fn``
+                without ``_init_shared_interleaver`` to avoid racing with
                 ``Mediator.start()`` on the vLLM worker thread; those paths
                 cannot rely on ``self._interleaver.mediators`` being current.
                 When ``None`` (local sync/async paths), falls back to
@@ -466,9 +466,11 @@ class VLLM(RemoteableMixin):
         serve = kwargs.pop("serve", None)
         if serve is not None and kwargs.get("backend") is None:
             from ...intervention.backends.local_serve import LocalServeBackend
+            from .serve_tracer import ServeInterleavingTracer
             blocking = kwargs.pop("blocking", True)
             api_key = kwargs.pop("api_key", None)
             kwargs["backend"] = LocalServeBackend(self, host=serve, blocking=blocking, api_key=api_key)
+            kwargs.setdefault("tracer_cls", ServeInterleavingTracer)
         else:
             if "api_key" in kwargs:
                 raise ValueError("api_key= requires serve= to specify the server URL")

--- a/src/nnsight/modeling/vllm/vllm.py
+++ b/src/nnsight/modeling/vllm/vllm.py
@@ -417,13 +417,23 @@ class VLLM(RemoteableMixin):
         outputs = self.vllm_entrypoint.generate(prompts, sampling_params=params, lora_request=lora_requests)
 
         saves = {}
+        all_exceptions: dict = {}
 
         for output in outputs:
-            if hasattr(output, "saves"):
-                saves.update(output.saves)
+            if not hasattr(output, "saves"):
+                continue
+            # Each output's saves is this request's own sub-dict now
+            # (per-request namespacing in the engine/worker).  Its
+            # ``__nnsight_exceptions__`` entry is a ``{base_id: exc}``
+            # map holding only THIS request's failure; combine across
+            # invokes into one trace-level map.
+            for k, v in output.saves.items():
+                if k == "__nnsight_exceptions__":
+                    all_exceptions.update(v)
+                else:
+                    saves[k] = v
 
-        # Extract deferred exceptions from worker, keyed by request ID.
-        deferred_exceptions = saves.pop("__nnsight_exceptions__", None)
+        deferred_exceptions = all_exceptions or None
 
         # Save the variables in our local environment
         for value in saves.values():

--- a/src/nnsight/modeling/vllm/vllm.py
+++ b/src/nnsight/modeling/vllm/vllm.py
@@ -453,7 +453,8 @@ class VLLM(RemoteableMixin):
         serve = kwargs.pop("serve", None)
         if serve is not None and kwargs.get("backend") is None:
             from ...intervention.backends.local_serve import LocalServeBackend
-            kwargs["backend"] = LocalServeBackend(self, host=serve)
+            blocking = kwargs.pop("blocking", True)
+            kwargs["backend"] = LocalServeBackend(self, host=serve, blocking=blocking)
         elif self._async_engine and kwargs.get('backend') is None and not kwargs.get('remote'):
             from .async_backend import AsyncVLLMBackend
             kwargs['backend'] = AsyncVLLMBackend(self)

--- a/tests/serve_clients/README.md
+++ b/tests/serve_clients/README.md
@@ -1,0 +1,62 @@
+# nnsight-serve Client Test Scripts
+
+10 standalone client scripts for testing `nnsight-serve` manually. Each simulates a different user workload — run them individually, in parallel, or mix and match to stress-test the server.
+
+**Model:** `Qwen/Qwen3-30B-A3B` (48 layers, 2048 hidden dim, 128 experts (8 active per token))
+
+## Start the server
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1 python -m nnsight.modeling.vllm.serve.cli Qwen/Qwen3-30B-A3B \
+    --port 6677 \
+    --gpu-memory-utilization 0.5 \
+    --tensor-parallel-size 2
+```
+
+Or single GPU:
+
+```bash
+CUDA_VISIBLE_DEVICES=0 python -m nnsight.modeling.vllm.serve.cli Qwen/Qwen3-30B-A3B \
+    --port 6677 \
+    --gpu-memory-utilization 0.8
+```
+
+Wait for `Uvicorn running on http://127.0.0.1:6677` before running clients.
+
+## Run a single client
+
+```bash
+python tests/serve_clients/client_01_basic_logits.py
+```
+
+## Run all 10 concurrently
+
+```bash
+for f in tests/serve_clients/client_*.py; do python "$f" & done; wait
+```
+
+## Run N copies of the same client
+
+```bash
+for i in $(seq 1 5); do python tests/serve_clients/client_03_intervention.py & done; wait
+```
+
+## Client summary
+
+| # | File | What it does |
+|---|------|-------------|
+| 01 | `client_01_basic_logits.py` | Capture logits, decode next token |
+| 02 | `client_02_multi_layer.py` | Save activations from 6 layers |
+| 03 | `client_03_intervention.py` | Zero out MLP, verify prediction changes |
+| 04 | `client_04_multi_invoke.py` | 3 prompts in one trace via invoke() |
+| 05 | `client_05_shared_list.py` | Shared list across invokes |
+| 06 | `client_06_nonblocking.py` | 4 concurrent non-blocking requests |
+| 07 | `client_07_activation_patch.py` | Patch activations from one prompt into another |
+| 08 | `client_08_attention.py` | Capture attention layer outputs |
+| 09 | `client_09_expert_outputs.py` | Capture MoE expert/gate outputs |
+| 10 | `client_10_stress.py` | Rapid-fire 20 blocking requests |
+
+## Environment variables
+
+- `NNSIGHT_SERVE_URL` — server URL (default: `http://127.0.0.1:6677`)
+- `CUDA_VISIBLE_DEVICES` — GPU for meta model init (clients use no GPU memory)

--- a/tests/serve_clients/client_01_basic_logits.py
+++ b/tests/serve_clients/client_01_basic_logits.py
@@ -1,0 +1,23 @@
+"""Client 01: Basic logit capture and next-token prediction."""
+import os, time
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "2")
+
+from nnsight.modeling.vllm import VLLM
+
+URL = os.environ.get("NNSIGHT_SERVE_URL", "http://127.0.0.1:6677")
+model = VLLM("Qwen/Qwen3-30B-A3B")
+
+prompts = [
+    "The capital of France is",
+    "Water boils at a temperature of",
+    "The largest planet in our solar system is",
+]
+
+for prompt in prompts:
+    t0 = time.perf_counter()
+    with model.trace(prompt, temperature=0.0, top_p=1, serve=URL):
+        logits = model.logits.output.save()
+    elapsed = time.perf_counter() - t0
+
+    token = model.tokenizer.decode(logits.argmax(dim=-1))
+    print(f"[{elapsed:.3f}s] '{prompt}' → '{token.strip()}'")

--- a/tests/serve_clients/client_02_multi_layer.py
+++ b/tests/serve_clients/client_02_multi_layer.py
@@ -1,0 +1,34 @@
+"""Client 02: Capture activations from multiple layers."""
+import os, time
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "2")
+
+import torch
+from nnsight.modeling.vllm import VLLM
+
+URL = os.environ.get("NNSIGHT_SERVE_URL", "http://127.0.0.1:6677")
+model = VLLM("Qwen/Qwen3-30B-A3B")
+
+prompt = "Mixture of Experts models route tokens to"
+layers = [0, 8, 16, 24, 36, 47]
+
+t0 = time.perf_counter()
+with model.trace(prompt, serve=URL):
+    h0 = model.model.layers[0].output[0].save()
+    h8 = model.model.layers[8].output[0].save()
+    h16 = model.model.layers[16].output[0].save()
+    h24 = model.model.layers[24].output[0].save()
+    h36 = model.model.layers[36].output[0].save()
+    h47 = model.model.layers[47].output[0].save()
+elapsed = time.perf_counter() - t0
+
+saved = {0: h0, 8: h8, 16: h16, 24: h24, 36: h36, 47: h47}
+
+print(f"[{elapsed:.3f}s] Captured {len(layers)} layers for: '{prompt}'")
+for i in layers:
+    h = saved[i]
+    print(f"  Layer {i:2d}: shape={list(h.shape)}, mean={h.float().mean():.4f}, std={h.float().std():.4f}")
+
+# Verify layers are distinct
+for a, b in zip(layers[:-1], layers[1:]):
+    assert not torch.equal(saved[a], saved[b]), f"Layer {a} == Layer {b}"
+print("All layers distinct")

--- a/tests/serve_clients/client_03_intervention.py
+++ b/tests/serve_clients/client_03_intervention.py
@@ -1,0 +1,35 @@
+"""Client 03: Zero out an MLP and verify the prediction changes."""
+import os, time
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "2")
+
+from nnsight.modeling.vllm import VLLM
+import torch
+
+URL = os.environ.get("NNSIGHT_SERVE_URL", "http://127.0.0.1:6677")
+model = VLLM("Qwen/Qwen3-30B-A3B")
+
+prompt = "The Eiffel Tower is located in the city of"
+
+# Clean run
+t0 = time.perf_counter()
+with model.trace(prompt, temperature=0.0, top_p=1, serve=URL):
+    clean_logits = model.logits.output.save()
+clean_time = time.perf_counter() - t0
+clean_token = model.tokenizer.decode(clean_logits.argmax(dim=-1))
+
+# Corrupted run — zero out last 8 layers' outputs
+t0 = time.perf_counter()
+with model.trace(prompt, temperature=0.0, top_p=1, serve=URL):
+    for layer_idx in range(40, 48):
+        model.model.layers[layer_idx].output[0][:] = 0
+    corrupted_logits = model.logits.output.save()
+corrupt_time = time.perf_counter() - t0
+corrupted_token = model.tokenizer.decode(corrupted_logits.argmax(dim=-1))
+
+print(f"[{clean_time:.3f}s] Clean:     '{prompt}' → '{clean_token.strip()}'")
+print(f"[{corrupt_time:.3f}s] Corrupted: '{prompt}' → '{corrupted_token.strip()}'")
+
+if clean_token != corrupted_token:
+    print("Intervention changed prediction ✓")
+else:
+    print("WARNING: prediction unchanged — intervention may not have taken effect")

--- a/tests/serve_clients/client_04_multi_invoke.py
+++ b/tests/serve_clients/client_04_multi_invoke.py
@@ -1,0 +1,29 @@
+"""Client 04: Multiple prompts in a single trace via invoke()."""
+import os, time
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "2")
+
+from nnsight.modeling.vllm import VLLM
+
+URL = os.environ.get("NNSIGHT_SERVE_URL", "http://127.0.0.1:6677")
+model = VLLM("Qwen/Qwen3-30B-A3B")
+
+prompts = [
+    "The Great Wall of China is in",
+    "Mount Everest is located in",
+    "The Amazon River flows through",
+]
+
+t0 = time.perf_counter()
+with model.trace(temperature=0.0, top_p=1, serve=URL) as tracer:
+    with tracer.invoke(prompts[0]):
+        logits_0 = model.logits.output.save()
+    with tracer.invoke(prompts[1]):
+        logits_1 = model.logits.output.save()
+    with tracer.invoke(prompts[2]):
+        logits_2 = model.logits.output.save()
+elapsed = time.perf_counter() - t0
+
+print(f"[{elapsed:.3f}s] {len(prompts)} prompts in one trace:")
+for prompt, logits in zip(prompts, [logits_0, logits_1, logits_2]):
+    token = model.tokenizer.decode(logits.argmax(dim=-1))
+    print(f"  '{prompt}' → '{token.strip()}'")

--- a/tests/serve_clients/client_05_shared_list.py
+++ b/tests/serve_clients/client_05_shared_list.py
@@ -1,0 +1,28 @@
+"""Client 05: Shared list across invokes — collect argmax tokens."""
+import os, time
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "2")
+
+from nnsight.modeling.vllm import VLLM
+
+URL = os.environ.get("NNSIGHT_SERVE_URL", "http://127.0.0.1:6677")
+model = VLLM("Qwen/Qwen3-30B-A3B")
+
+prompts = [
+    "Python was created by",
+    "The first programming language was",
+    "Linux was developed by",
+    "The inventor of the World Wide Web is",
+]
+
+t0 = time.perf_counter()
+with model.trace(temperature=0.0, top_p=1, serve=URL) as tracer:
+    tokens = [None for _ in prompts].save()
+    for i, prompt in enumerate(prompts):
+        with tracer.invoke(prompt):
+            tokens[i] = model.logits.output.argmax(dim=-1)
+elapsed = time.perf_counter() - t0
+
+print(f"[{elapsed:.3f}s] Shared list across {len(prompts)} invokes:")
+for prompt, tok in zip(prompts, tokens):
+    decoded = model.tokenizer.decode(tok)
+    print(f"  '{prompt}' → '{decoded.strip()}'")

--- a/tests/serve_clients/client_06_nonblocking.py
+++ b/tests/serve_clients/client_06_nonblocking.py
@@ -1,0 +1,51 @@
+"""Client 06: Non-blocking concurrent requests."""
+import os, time
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "2")
+
+from nnsight.modeling.vllm import VLLM
+
+URL = os.environ.get("NNSIGHT_SERVE_URL", "http://127.0.0.1:6677")
+model = VLLM("Qwen/Qwen3-30B-A3B")
+
+prompts = [
+    "Einstein's theory of relativity states that",
+    "Quantum mechanics describes the behavior of",
+    "The speed of light in vacuum is approximately",
+    "Newton's first law of motion says that",
+]
+
+# Warmup
+with model.trace(prompts[0], serve=URL):
+    model.logits.output.save()
+
+# Sequential baseline
+t0 = time.perf_counter()
+for p in prompts:
+    with model.trace(p, temperature=0.0, top_p=1, serve=URL):
+        model.logits.output.save()
+seq_time = time.perf_counter() - t0
+
+# Non-blocking concurrent
+tracers = []
+t0 = time.perf_counter()
+
+with model.trace(prompts[0], temperature=0.0, top_p=1, serve=URL, blocking=False) as t1:
+    l1 = model.logits.output.save()
+with model.trace(prompts[1], temperature=0.0, top_p=1, serve=URL, blocking=False) as t2:
+    l2 = model.logits.output.save()
+with model.trace(prompts[2], temperature=0.0, top_p=1, serve=URL, blocking=False) as t3:
+    l3 = model.logits.output.save()
+with model.trace(prompts[3], temperature=0.0, top_p=1, serve=URL, blocking=False) as t4:
+    l4 = model.logits.output.save()
+
+saves = [t.collect(timeout=60) for t in [t1, t2, t3, t4]]
+conc_time = time.perf_counter() - t0
+
+print(f"Sequential: {seq_time:.3f}s")
+print(f"Concurrent: {conc_time:.3f}s")
+print(f"Speedup:    {seq_time / conc_time:.2f}x")
+print()
+for prompt, s in zip(prompts, saves):
+    key = list(s.keys())[0]
+    token = model.tokenizer.decode(s[key].argmax(dim=-1))
+    print(f"  '{prompt}' → '{token.strip()}'")

--- a/tests/serve_clients/client_07_activation_patch.py
+++ b/tests/serve_clients/client_07_activation_patch.py
@@ -1,0 +1,35 @@
+"""Client 07: Activation patching — inject one prompt's hidden state into another."""
+import os, time
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "2")
+
+import torch
+from nnsight.modeling.vllm import VLLM
+
+URL = os.environ.get("NNSIGHT_SERVE_URL", "http://127.0.0.1:6677")
+model = VLLM("Qwen/Qwen3-30B-A3B")
+
+source_prompt = "The Eiffel Tower is located in the city of"
+target_prompt = "The Colosseum is located in the city of"
+patch_layer = 24
+
+# Capture source hidden state
+t0 = time.perf_counter()
+with model.trace(source_prompt, temperature=0.0, top_p=1, serve=URL):
+    source_hs = model.model.layers[patch_layer].output[0].save()
+    source_logits = model.logits.output.save()
+
+# Clean target
+with model.trace(target_prompt, temperature=0.0, top_p=1, serve=URL):
+    clean_logits = model.logits.output.save()
+
+elapsed = time.perf_counter() - t0
+
+source_token = model.tokenizer.decode(source_logits.argmax(dim=-1))
+clean_token = model.tokenizer.decode(clean_logits.argmax(dim=-1))
+
+print(f"[{elapsed:.3f}s]")
+print(f"  Source: '{source_prompt}' → '{source_token.strip()}'")
+print(f"  Target: '{target_prompt}' → '{clean_token.strip()}'")
+print(f"  Source hidden state shape: {list(source_hs.shape)}")
+print(f"  (Activation patching across serve traces requires same-trace invokes — ")
+print(f"   cross-trace patching is not supported in serve mode)")

--- a/tests/serve_clients/client_08_attention.py
+++ b/tests/serve_clients/client_08_attention.py
@@ -1,0 +1,35 @@
+"""Client 08: Capture attention layer outputs across multiple layers."""
+import os, time
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "2")
+
+import torch
+from nnsight.modeling.vllm import VLLM
+
+URL = os.environ.get("NNSIGHT_SERVE_URL", "http://127.0.0.1:6677")
+model = VLLM("Qwen/Qwen3-30B-A3B")
+
+prompt = "Attention mechanisms in transformers allow the model to"
+
+t0 = time.perf_counter()
+with model.trace(prompt, serve=URL):
+    a0 = model.model.layers[0].self_attn.output[0].save()
+    a12 = model.model.layers[12].self_attn.output[0].save()
+    a24 = model.model.layers[24].self_attn.output[0].save()
+    a36 = model.model.layers[36].self_attn.output[0].save()
+    a47 = model.model.layers[47].self_attn.output[0].save()
+elapsed = time.perf_counter() - t0
+
+attn_outs = {0: a0, 12: a12, 24: a24, 36: a36, 47: a47}
+layers = [0, 12, 24, 36, 47]
+
+print(f"[{elapsed:.3f}s] Attention outputs for: '{prompt}'")
+for i in layers:
+    a = attn_outs[i]
+    print(f"  Layer {i:2d} attn: shape={list(a.shape)}, "
+          f"norm={a.float().norm():.2f}, "
+          f"max={a.float().abs().max():.4f}")
+
+for j in range(len(layers) - 1):
+    a, b = layers[j], layers[j + 1]
+    assert not torch.equal(attn_outs[a], attn_outs[b]), f"Layer {a} == Layer {b}"
+print("All attention outputs distinct")

--- a/tests/serve_clients/client_09_expert_outputs.py
+++ b/tests/serve_clients/client_09_expert_outputs.py
@@ -1,0 +1,34 @@
+"""Client 09: Capture MoE gate/router outputs to see expert routing."""
+import os, time
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "2")
+
+import torch
+from nnsight.modeling.vllm import VLLM
+
+URL = os.environ.get("NNSIGHT_SERVE_URL", "http://127.0.0.1:6677")
+model = VLLM("Qwen/Qwen3-30B-A3B")
+
+prompt = "The mixture of experts architecture selects"
+
+t0 = time.perf_counter()
+with model.trace(prompt, serve=URL):
+    m0 = model.model.layers[0].mlp.output.save()
+    m12 = model.model.layers[12].mlp.output.save()
+    m24 = model.model.layers[24].mlp.output.save()
+    m36 = model.model.layers[36].mlp.output.save()
+    m47 = model.model.layers[47].mlp.output.save()
+elapsed = time.perf_counter() - t0
+
+mlp_outs = {0: m0, 12: m12, 24: m24, 36: m36, 47: m47}
+layers = [0, 12, 24, 36, 47]
+
+print(f"[{elapsed:.3f}s] MoE MLP outputs for: '{prompt}'")
+for i in layers:
+    m = mlp_outs[i]
+    if isinstance(m, torch.Tensor):
+        print(f"  Layer {i:2d} MoE MLP: shape={list(m.shape)}, "
+              f"norm={m.float().norm():.2f}, "
+              f"sparsity={(m == 0).float().mean():.2%}")
+    else:
+        # Some MoE layers return tuples (output, router_logits)
+        print(f"  Layer {i:2d} MoE MLP: type={type(m)}, len={len(m) if hasattr(m, '__len__') else 'N/A'}")

--- a/tests/serve_clients/client_10_stress.py
+++ b/tests/serve_clients/client_10_stress.py
@@ -1,0 +1,67 @@
+"""Client 10: Stress test — rapid-fire 20 blocking requests."""
+import os, time, random
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "2")
+
+import torch
+from nnsight.modeling.vllm import VLLM
+
+URL = os.environ.get("NNSIGHT_SERVE_URL", "http://127.0.0.1:6677")
+model = VLLM("Qwen/Qwen3-30B-A3B")
+
+prompts = [
+    "The theory of evolution was proposed by",
+    "Photosynthesis converts sunlight into",
+    "The human brain contains approximately",
+    "DNA stands for",
+    "The periodic table was organized by",
+    "Black holes are formed when",
+    "The speed of sound in air is about",
+    "Antibiotics were discovered by",
+    "The Pythagorean theorem states that",
+    "Machine learning models learn from",
+    "The largest ocean on Earth is the",
+    "Gravity was first described by",
+    "The boiling point of water at sea level is",
+    "Electrons orbit the nucleus in",
+    "The mitochondria is known as the",
+    "Plate tectonics explains how",
+    "The Hubble telescope was launched in",
+    "RNA differs from DNA in that",
+    "Fibonacci numbers follow the pattern",
+    "The greenhouse effect is caused by",
+]
+
+random.shuffle(prompts)
+N = len(prompts)
+
+successes = 0
+failures = 0
+times = []
+
+print(f"Firing {N} requests sequentially...")
+t_total = time.perf_counter()
+
+for i, prompt in enumerate(prompts):
+    t0 = time.perf_counter()
+    try:
+        with model.trace(prompt, temperature=0.0, top_p=1, serve=URL):
+            logits = model.logits.output.save()
+        token = model.tokenizer.decode(logits.argmax(dim=-1)).strip()
+        elapsed = time.perf_counter() - t0
+        times.append(elapsed)
+        successes += 1
+        print(f"  [{i+1:2d}/{N}] {elapsed:.3f}s OK  '{prompt[:40]}...' → '{token[:20]}'")
+    except Exception as e:
+        elapsed = time.perf_counter() - t0
+        failures += 1
+        print(f"  [{i+1:2d}/{N}] {elapsed:.3f}s ERR '{prompt[:40]}...' → {type(e).__name__}: {e}")
+
+total_time = time.perf_counter() - t_total
+
+print(f"\n{'='*60}")
+print(f"Results: {successes}/{N} succeeded, {failures}/{N} failed")
+print(f"Total:   {total_time:.2f}s")
+if times:
+    print(f"Latency: min={min(times):.3f}s, max={max(times):.3f}s, "
+          f"avg={sum(times)/len(times):.3f}s, median={sorted(times)[len(times)//2]:.3f}s")
+    print(f"Throughput: {N / total_time:.1f} req/s")

--- a/tests/test_backward_batching.py
+++ b/tests/test_backward_batching.py
@@ -1,0 +1,184 @@
+"""Tests for backward/gradient support with batched (multi-invoke) traces.
+
+These tests verify that `.grad` access works correctly when multiple input
+invokes are batched together.  The core issue is that `Batcher._narrow()`
+creates views that are not in the autograd forward path, so backward hooks
+on those views never fire.  The fix in `wrap_grad` registers hooks on the
+base tensor instead and narrows the gradient in the hook.
+
+A secondary fix in `Batcher._swap` prevents a segfault when a user assigns
+a narrow view back into its own base tensor (self-referential autograd).
+"""
+
+import pytest
+import torch
+from nnsight import LanguageModel
+
+
+@pytest.fixture(scope="module")
+def model():
+    return LanguageModel(
+        "openai-community/gpt2", device_map="cpu", dispatch=True
+    )
+
+
+class TestBackwardWithBatchedInvokes:
+    """Gradient access with two input invokes (needs_batching=True)."""
+
+    def test_grad_in_second_invoke(self, model):
+        """User's original attribution patching pattern: clean run + corrupted
+        run with backward in the second invoke."""
+        with model.trace() as tracer:
+            with tracer.invoke("Hello"):
+                clean = model.transformer.h[-1].output[0].save()
+            with tracer.invoke("World"):
+                x = model.transformer.h[-1].output[0]
+                x.requires_grad_(True)
+                logits = model.lm_head.output
+                with logits.sum().backward():
+                    grad = x.grad.save()
+
+        assert grad.shape[0] == 1
+        assert grad.shape[-1] == 768
+        assert (grad != 0).any()
+
+    def test_grad_in_first_invoke(self, model):
+        """Backward in the first invoke of two."""
+        with model.trace() as tracer:
+            with tracer.invoke("Hello"):
+                x = model.transformer.h[-1].output[0]
+                x.requires_grad_(True)
+                logits = model.lm_head.output
+                with logits.sum().backward():
+                    grad = x.grad.save()
+            with tracer.invoke("World"):
+                clean = model.transformer.h[-1].output[0].save()
+
+        assert grad.shape[0] == 1
+        assert (grad != 0).any()
+
+    def test_attribution_patching(self, model):
+        """Full attribution patching: logit-diff metric with gradient."""
+        paris = model.tokenizer.encode(" Paris")[0]
+        rome = model.tokenizer.encode(" Rome")[0]
+
+        with model.trace() as tracer:
+            with tracer.invoke("The Eiffel Tower is in"):
+                pass
+            with tracer.invoke("The Colosseum is in"):
+                hs = model.transformer.h[5].output[0]
+                hs.requires_grad_(True)
+                logits = model.lm_head.output[:, -1]
+                metric = logits[0, paris] - logits[0, rome]
+                with metric.backward():
+                    attr = hs.grad.save()
+
+        assert attr.shape[-1] == 768
+        assert (attr != 0).any()
+
+    def test_grad_deterministic(self, model):
+        """Same setup run twice produces identical gradients."""
+        grads = []
+        for _ in range(2):
+            with model.trace() as tracer:
+                with tracer.invoke("Hello"):
+                    pass
+                with tracer.invoke("World"):
+                    x = model.transformer.h[-1].output[0]
+                    x.requires_grad_(True)
+                    logits = model.lm_head.output
+                    with logits.sum().backward():
+                        grads.append(x.grad.save())
+
+        assert torch.allclose(grads[0], grads[1])
+
+    def test_grad_modification(self, model):
+        """User can read and modify gradients inside backward context."""
+        with model.trace() as tracer:
+            with tracer.invoke("Hello"):
+                pass
+            with tracer.invoke("World"):
+                x = model.transformer.h[-1].output[0]
+                x.requires_grad_(True)
+                logits = model.lm_head.output
+                with logits.sum().backward():
+                    orig = x.grad.clone().save()
+                    x.grad[:] = 0
+                    zeroed = x.grad.save()
+
+        assert (orig != 0).any()
+        assert (zeroed == 0).all()
+
+
+class TestBackwardRegressions:
+    """Ensure existing single-invoke and empty-invoke patterns still work."""
+
+    def test_single_invoke(self, model):
+        with model.trace("Hello"):
+            x = model.transformer.h[-1].output[0]
+            x.requires_grad_(True)
+            logits = model.lm_head.output
+            with logits.sum().backward():
+                grad = x.grad.save()
+
+        assert (grad != 0).any()
+
+    def test_input_plus_empty_invoke(self, model):
+        with model.trace() as tracer:
+            with tracer.invoke("Hello"):
+                x = model.transformer.h[-1].output[0]
+                x.requires_grad_(True)
+                logits = model.lm_head.output
+                with logits.sum().backward():
+                    grad = x.grad.save()
+            with tracer.invoke():
+                out = model.transformer.h[-1].output[0].save()
+
+        assert (grad != 0).any()
+
+    def test_retain_graph(self, model):
+        with model.trace("Hello"):
+            x = model.transformer.h[-1].output[0]
+            x.requires_grad_(True)
+            logits = model.lm_head.output
+            with logits.sum().backward(retain_graph=True):
+                g1 = x.grad.save()
+            modified = logits * 2
+            with modified.sum().backward():
+                g2 = x.grad.save()
+
+        assert torch.allclose(g2, g1 * 2, atol=1e-5)
+
+
+class TestSwapSelfReferentialGuard:
+    """Batcher._swap must use concat when swap_value is a view of
+    current_value, otherwise in-place assignment segfaults during backward."""
+
+    def test_pop_back_pattern(self, model):
+        """User reads output, sets requires_grad, assigns back — was segfault."""
+        with model.trace() as tracer:
+            with tracer.invoke("Hello"):
+                clean = model.transformer.h[-1].output[0].save()
+            with tracer.invoke("World"):
+                out = model.transformer.h[-1].output
+                x = out[0]
+                x.requires_grad_(True)
+                model.transformer.h[-1].output = (x,) + out[1:]
+                logits = model.lm_head.output
+                with logits.sum().backward():
+                    grad = x.grad.save()
+
+        assert (grad != 0).any()
+
+    def test_normal_swap_unaffected(self, model):
+        """Swapping a new tensor (not a view) still uses in-place path."""
+        with model.trace() as tracer:
+            with tracer.invoke("Hello"):
+                pass
+            with tracer.invoke("World"):
+                out = model.transformer.h[-1].output
+                modified = out[0] * 2
+                model.transformer.h[-1].output = (modified,) + out[1:]
+                logits = model.lm_head.output.save()
+
+        assert logits.shape[-1] == 50257

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1,0 +1,370 @@
+"""Tests for nnsight-vllm-serve client (serve= parameter).
+
+These tests MUST run against a pre-started nnsight-serve instance.
+They verify that requests go to the server, not local execution.
+
+Start the server:
+    CUDA_VISIBLE_DEVICES=1 conda run -n ndif-dev python -m nnsight.modeling.vllm.serve.cli \
+        Qwen/Qwen2.5-0.5B-Instruct --port 6679 --gpu-memory-utilization 0.3
+
+Run tests (on a DIFFERENT GPU):
+    CUDA_VISIBLE_DEVICES=2 conda run -n ndif-dev python -m pytest tests/test_serve.py -v -x -s
+"""
+
+import os
+import sys
+
+import pytest
+import torch
+
+# Force a GPU that is NOT used by the server.
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "2")
+
+try:
+    from nnsight.modeling.vllm import VLLM
+except Exception as e:
+    pytest.skip(f"Skipping serve tests (vllm import failed): {e}", allow_module_level=True)
+
+
+SERVE_URL = os.environ.get("NNSIGHT_SERVE_URL", "http://127.0.0.1:6679")
+MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
+N_LAYERS = 24
+HIDDEN_DIM = 896
+
+ET_PROMPT = "The Eiffel Tower is located in the city of"
+MSG_PROMPT = "Madison Square Garden is located in the city of"
+
+
+# =============================================================================
+# Server reachability check — skip ALL tests if server is down
+# =============================================================================
+
+def _server_is_reachable() -> bool:
+    """Check /health endpoint before running any tests."""
+    import httpx
+    try:
+        r = httpx.get(f"{SERVE_URL}/health", timeout=5.0)
+        return r.status_code == 200
+    except Exception:
+        return False
+
+if not _server_is_reachable():
+    pytest.skip(
+        f"nnsight-serve not reachable at {SERVE_URL}. Start the server first.",
+        allow_module_level=True,
+    )
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+@pytest.fixture(scope="module")
+def model():
+    """Meta-only VLLM model (no local engine, no dispatch)."""
+    m = VLLM(MODEL)
+    assert not m.dispatched, "Model should NOT be dispatched for serve tests"
+    return m
+
+
+@pytest.fixture(scope="module")
+def local_model():
+    """Locally-dispatched VLLM model for numerical comparison."""
+    return VLLM(MODEL, dispatch=True, gpu_memory_utilization=0.3)
+
+
+# =============================================================================
+# Helper: verify the model stayed meta after a serve trace
+# =============================================================================
+
+def _assert_not_dispatched(model):
+    """After a serve trace, the client model must still be meta (not dispatched)."""
+    assert not model.dispatched, (
+        "Model was dispatched locally during serve trace! "
+        "The serve= parameter is not being intercepted — requests are running locally."
+    )
+
+
+# =============================================================================
+# 1. Basic Inference
+# =============================================================================
+
+class TestBasicInference:
+    """Basic activation capture and logit access via serve=."""
+
+    def test_hidden_state_capture(self, model):
+        """Capture a single layer's output."""
+        with model.trace(ET_PROMPT, serve=SERVE_URL):
+            hidden = model.model.layers[5].output[0].save()
+
+        _assert_not_dispatched(model)
+        assert hidden.shape[-1] == HIDDEN_DIM
+        assert hidden.dtype == torch.bfloat16
+        assert not torch.all(hidden == 0)
+
+    def test_logit_prediction(self, model):
+        """Verify next-token prediction via logits."""
+        with model.trace(ET_PROMPT, temperature=0.0, top_p=1, serve=SERVE_URL):
+            logits = model.logits.output.save()
+
+        _assert_not_dispatched(model)
+        next_token = model.tokenizer.decode(logits.argmax(dim=-1))
+        assert "Paris" in next_token, f"Expected 'Paris', got '{next_token}'"
+
+    def test_multi_layer_capture(self, model):
+        """Capture outputs from multiple layers simultaneously."""
+        with model.trace(ET_PROMPT, serve=SERVE_URL):
+            h0 = model.model.layers[0].output[0].save()
+            h12 = model.model.layers[12].output[0].save()
+            h23 = model.model.layers[23].output[0].save()
+
+        _assert_not_dispatched(model)
+        assert h0.shape == h12.shape == h23.shape
+        assert not torch.equal(h0, h12)
+        assert not torch.equal(h12, h23)
+
+
+# =============================================================================
+# 2. Interventions
+# =============================================================================
+
+class TestInterventions:
+    """Activation modification via serve=."""
+
+    def test_zero_out_mlp(self, model):
+        """Zero out an MLP output and verify the prediction changes."""
+        # Get clean prediction first
+        with model.trace(ET_PROMPT, temperature=0.0, top_p=1, serve=SERVE_URL):
+            clean_logits = model.logits.output.save()
+        clean_token = model.tokenizer.decode(clean_logits.argmax(dim=-1))
+        assert "Paris" in clean_token
+
+        # Zero out MLP and check prediction changed
+        with model.trace(ET_PROMPT, temperature=0.0, top_p=1, serve=SERVE_URL):
+            model.model.layers[-2].mlp.output[:] = 0
+            logits = model.logits.output.save()
+
+        _assert_not_dispatched(model)
+        next_token = model.tokenizer.decode(logits.argmax(dim=-1))
+        assert "Paris" not in next_token
+
+    def test_swap_intervention(self, model):
+        """Swap an MLP output with zeros and verify the prediction changes."""
+        with model.trace(ET_PROMPT, temperature=0.0, top_p=1, serve=SERVE_URL):
+            model.model.layers[-2].mlp.output = torch.zeros_like(
+                model.model.layers[-2].mlp.output
+            )
+            logits = model.logits.output.save()
+
+        _assert_not_dispatched(model)
+        next_token = model.tokenizer.decode(logits.argmax(dim=-1))
+        assert "Paris" not in next_token
+
+
+# =============================================================================
+# 3. Batched Multi-Invoke
+# =============================================================================
+
+class TestBatching:
+    """Multiple prompts in a single trace via invoke()."""
+
+    def test_batched_clean_and_corrupted(self, model):
+        """Run clean and corrupted versions of the same prompt in one trace."""
+        with model.trace(temperature=0.0, top_p=1, serve=SERVE_URL) as tracer:
+            with tracer.invoke(ET_PROMPT):
+                clean_logits = model.logits.output.save()
+
+            with tracer.invoke(ET_PROMPT):
+                model.model.layers[-2].mlp.output[:] = 0
+                corrupted_logits = model.logits.output.save()
+
+        _assert_not_dispatched(model)
+
+        clean_token = model.tokenizer.decode(clean_logits.argmax(dim=-1))
+        corrupted_token = model.tokenizer.decode(corrupted_logits.argmax(dim=-1))
+        assert "Paris" in clean_token
+        assert "Paris" not in corrupted_token
+
+    def test_two_different_prompts(self, model):
+        """Capture logits from two different prompts in one trace."""
+        with model.trace(temperature=0.0, top_p=1, serve=SERVE_URL) as tracer:
+            with tracer.invoke(ET_PROMPT):
+                et_logits = model.logits.output.save()
+            with tracer.invoke(MSG_PROMPT):
+                msg_logits = model.logits.output.save()
+
+        _assert_not_dispatched(model)
+        et_token = model.tokenizer.decode(et_logits.argmax(dim=-1))
+        msg_token = model.tokenizer.decode(msg_logits.argmax(dim=-1))
+        assert "Paris" in et_token
+        assert "New" in msg_token
+
+
+# =============================================================================
+# 4. Cross-Invoke Shared State
+# =============================================================================
+
+class TestCrossInvokeSharedState:
+    """Shared Python objects across invokes in the same trace."""
+
+    def test_shared_list_across_invokes(self, model):
+        """Collect logits from multiple invokes into a shared list."""
+        prompts = [ET_PROMPT, MSG_PROMPT]
+
+        with model.trace(temperature=0.0, top_p=1, serve=SERVE_URL) as tracer:
+            out_ids = [list() for _ in range(len(prompts))].save()
+            for i, prompt in enumerate(prompts):
+                with tracer.invoke(prompt):
+                    out_ids[i].append(model.logits.output.argmax(dim=-1))
+
+        _assert_not_dispatched(model)
+        assert len(out_ids) == 2
+        assert len(out_ids[0]) == 1
+        assert len(out_ids[1]) == 1
+
+        et_token = model.tokenizer.decode(out_ids[0][0])
+        msg_token = model.tokenizer.decode(out_ids[1][0])
+        assert "Paris" in et_token
+        assert "New" in msg_token
+
+
+# =============================================================================
+# 5. Token ID Inputs
+# =============================================================================
+
+class TestTokenInputs:
+    """Non-string inputs: token ID lists and HF tokenizer dicts."""
+
+    def test_token_id_list(self, model):
+        """Pass token IDs directly instead of a string prompt."""
+        token_ids = model.tokenizer.encode(ET_PROMPT)
+
+        with model.trace(token_ids, temperature=0.0, top_p=1, serve=SERVE_URL):
+            logits = model.logits.output.save()
+
+        _assert_not_dispatched(model)
+        next_token = model.tokenizer.decode(logits.argmax(dim=-1))
+        assert "Paris" in next_token
+
+    def test_hf_tokenizer_dict(self, model):
+        """Pass a HuggingFace tokenizer output dict."""
+        hf_output = model.tokenizer(ET_PROMPT, return_tensors="pt")
+
+        with model.trace(dict(hf_output), temperature=0.0, top_p=1, serve=SERVE_URL):
+            logits = model.logits.output.save()
+
+        _assert_not_dispatched(model)
+        next_token = model.tokenizer.decode(logits.argmax(dim=-1))
+        assert "Paris" in next_token
+
+    def test_token_ids_in_invoker(self, model):
+        """Pass token IDs inside an invoker."""
+        token_ids = model.tokenizer.encode(ET_PROMPT)
+
+        with model.trace(temperature=0.0, top_p=1, serve=SERVE_URL) as tracer:
+            with tracer.invoke(token_ids):
+                logits = model.logits.output.save()
+
+        _assert_not_dispatched(model)
+        next_token = model.tokenizer.decode(logits.argmax(dim=-1))
+        assert "Paris" in next_token
+
+
+# =============================================================================
+# 6. Non-Blocking (Async) Mode
+# =============================================================================
+
+class TestNonBlocking:
+    """Non-blocking serve requests via blocking=False."""
+
+    def test_single_nonblocking(self, model):
+        """Single non-blocking request returns saves via .collect()."""
+        with model.trace(ET_PROMPT, temperature=0.0, top_p=1, serve=SERVE_URL, blocking=False) as t:
+            logits = model.logits.output.save()
+
+        _assert_not_dispatched(model)
+        saves = t.collect()
+        assert "logits" in saves, f"Expected 'logits' in saves, got keys: {list(saves.keys())}"
+        next_token = model.tokenizer.decode(saves["logits"].argmax(dim=-1))
+        assert "Paris" in next_token, f"Expected 'Paris', got '{next_token}'"
+
+    def test_concurrent_nonblocking(self, model):
+        """Two non-blocking requests should run concurrently in vLLM."""
+        import time
+
+        with model.trace(ET_PROMPT, temperature=0.0, top_p=1, serve=SERVE_URL, blocking=False) as t1:
+            logits1 = model.logits.output.save()
+        with model.trace(MSG_PROMPT, temperature=0.0, top_p=1, serve=SERVE_URL, blocking=False) as t2:
+            logits2 = model.logits.output.save()
+
+        _assert_not_dispatched(model)
+
+        # Both should be in-flight now. Collect results.
+        saves1 = t1.collect(timeout=30)
+        saves2 = t2.collect(timeout=30)
+
+        assert "logits1" in saves1 or "logits" in saves1, f"saves1 keys: {list(saves1.keys())}"
+        assert "logits2" in saves2 or "logits" in saves2, f"saves2 keys: {list(saves2.keys())}"
+
+    def test_nonblocking_hidden_states(self, model):
+        """Non-blocking capture of hidden states."""
+        with model.trace(ET_PROMPT, serve=SERVE_URL, blocking=False) as t:
+            hidden = model.model.layers[5].output[0].save()
+
+        _assert_not_dispatched(model)
+        saves = t.collect()
+        assert "hidden" in saves, f"Expected 'hidden' in saves, got keys: {list(saves.keys())}"
+        assert saves["hidden"].shape[-1] == HIDDEN_DIM
+
+
+# =============================================================================
+# 7. Numerical Comparison: serve vs local
+# =============================================================================
+
+class TestNumericalMatch:
+    """Verify serve= produces the same results as local execution."""
+
+    def test_hidden_states_match(self, model, local_model):
+        """Hidden states from serve and local should be bitwise identical."""
+        with model.trace(ET_PROMPT, serve=SERVE_URL):
+            serve_h = model.model.layers[5].output[0].save()
+
+        with local_model.trace(ET_PROMPT):
+            local_h = local_model.model.layers[5].output[0].save()
+
+        _assert_not_dispatched(model)
+        assert serve_h.shape == local_h.shape
+        assert torch.equal(serve_h.cpu(), local_h.cpu()), (
+            f"Max diff: {(serve_h.cpu().float() - local_h.cpu().float()).abs().max()}"
+        )
+
+    def test_logits_match(self, model, local_model):
+        """Logits from serve and local should be bitwise identical."""
+        with model.trace(ET_PROMPT, temperature=0.0, top_p=1, serve=SERVE_URL):
+            serve_logits = model.logits.output.save()
+
+        with local_model.trace(ET_PROMPT, temperature=0.0, top_p=1):
+            local_logits = local_model.logits.output.save()
+
+        _assert_not_dispatched(model)
+        assert torch.equal(serve_logits.cpu(), local_logits.cpu()), (
+            f"Max diff: {(serve_logits.cpu().float() - local_logits.cpu().float()).abs().max()}"
+        )
+
+    def test_intervention_results_match(self, model, local_model):
+        """Intervention results from serve and local should match."""
+        def run_trace(m, **kwargs):
+            with m.trace(ET_PROMPT, temperature=0.0, top_p=1, **kwargs):
+                m.model.layers[-2].mlp.output = torch.zeros_like(
+                    m.model.layers[-2].mlp.output
+                )
+                logits = m.logits.output.save()
+            return logits
+
+        serve_logits = run_trace(model, serve=SERVE_URL)
+        local_logits = run_trace(local_model)
+
+        _assert_not_dispatched(model)
+        assert torch.equal(serve_logits.cpu(), local_logits.cpu()), (
+            f"Max diff: {(serve_logits.cpu().float() - local_logits.cpu().float()).abs().max()}"
+        )

--- a/tests/test_serve_async.py
+++ b/tests/test_serve_async.py
@@ -1,0 +1,260 @@
+"""Thorough async/non-blocking tests for nnsight-serve.
+
+Tests:
+1. Timing overlap — are requests truly concurrent?
+2. Result isolation — same variable names across traces don't interfere
+3. Multi-process clients — separate processes hitting the same server
+4. Dependent requests — what happens (should not corrupt engine)
+
+Start the server first:
+    CUDA_VISIBLE_DEVICES=1 conda run -n ndif-dev --no-capture-output bash -c \
+        "python -m nnsight.modeling.vllm.serve.cli Qwen/Qwen2.5-0.5B-Instruct --port 6679 --gpu-memory-utilization 0.3"
+"""
+
+import os
+import sys
+import time
+import multiprocessing as mp
+
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "2")
+
+import pytest
+import torch
+
+try:
+    from nnsight.modeling.vllm import VLLM
+except Exception as e:
+    pytest.skip(f"vllm import failed: {e}", allow_module_level=True)
+
+import httpx
+
+SERVE_URL = os.environ.get("NNSIGHT_SERVE_URL", "http://127.0.0.1:6679")
+MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
+ET_PROMPT = "The Eiffel Tower is located in the city of"
+MSG_PROMPT = "Madison Square Garden is located in the city of"
+
+if not httpx.get(f"{SERVE_URL}/health", timeout=5.0).status_code == 200:
+    pytest.skip(f"Server not reachable at {SERVE_URL}", allow_module_level=True)
+
+
+@pytest.fixture(scope="module")
+def model():
+    m = VLLM(MODEL)
+    assert not m.dispatched
+    return m
+
+
+# =========================================================================
+# 1. Timing overlap: are non-blocking requests truly concurrent?
+# =========================================================================
+
+class TestTimingOverlap:
+    """Verify that non-blocking requests overlap in time."""
+
+    def test_concurrent_faster_than_sequential(self, model):
+        """4 non-blocking requests should take less than 4 * single_request_time.
+
+        If they were truly sequential, total time ≈ N * single.
+        If concurrent, total time ≈ single (+ batching overhead).
+        We use a loose check: concurrent < 0.8 * sequential estimate.
+        """
+        # Warmup
+        with model.trace(ET_PROMPT, serve=SERVE_URL):
+            model.logits.output.save()
+
+        # Measure single request time
+        t0 = time.perf_counter()
+        with model.trace(ET_PROMPT, serve=SERVE_URL):
+            model.logits.output.save()
+        single_time = time.perf_counter() - t0
+
+        # Fire 4 non-blocking requests concurrently.
+        # Each must use a proper `with` block (nnsight uses AST extraction).
+        t0 = time.perf_counter()
+
+        with model.trace(ET_PROMPT, temperature=0.0, top_p=1, serve=SERVE_URL, blocking=False) as t1:
+            model.logits.output.save()
+        with model.trace(ET_PROMPT, temperature=0.0, top_p=1, serve=SERVE_URL, blocking=False) as t2:
+            model.logits.output.save()
+        with model.trace(ET_PROMPT, temperature=0.0, top_p=1, serve=SERVE_URL, blocking=False) as t3:
+            model.logits.output.save()
+        with model.trace(ET_PROMPT, temperature=0.0, top_p=1, serve=SERVE_URL, blocking=False) as t4:
+            model.logits.output.save()
+
+        # Wait for all to complete
+        t1.collect(timeout=60)
+        t2.collect(timeout=60)
+        t3.collect(timeout=60)
+        t4.collect(timeout=60)
+        concurrent_time = time.perf_counter() - t0
+
+        N = 4
+        sequential_estimate = single_time * N
+        print(f"\nSingle: {single_time:.3f}s, Concurrent({N}): {concurrent_time:.3f}s, "
+              f"Sequential estimate: {sequential_estimate:.3f}s")
+
+        # Concurrent should be meaningfully faster than sequential
+        assert concurrent_time < sequential_estimate * 0.8, (
+            f"Concurrent ({concurrent_time:.3f}s) not faster than "
+            f"80% of sequential estimate ({sequential_estimate:.3f}s). "
+            f"Requests may not be truly concurrent."
+        )
+
+
+# =========================================================================
+# 2. Result isolation: same variable names across traces
+# =========================================================================
+
+class TestResultIsolation:
+    """Verify that concurrent traces with same variable names don't interfere."""
+
+    def test_same_varname_different_prompts(self, model):
+        """Two traces both save as 'logits' — each should get its own result."""
+        with model.trace(ET_PROMPT, temperature=0.0, top_p=1, serve=SERVE_URL, blocking=False) as t1:
+            logits = model.logits.output.save()
+
+        with model.trace(MSG_PROMPT, temperature=0.0, top_p=1, serve=SERVE_URL, blocking=False) as t2:
+            logits = model.logits.output.save()
+
+        saves1 = t1.collect(timeout=30)
+        saves2 = t2.collect(timeout=30)
+
+        # Both should have "logits" key
+        assert "logits" in saves1, f"saves1 keys: {list(saves1.keys())}"
+        assert "logits" in saves2, f"saves2 keys: {list(saves2.keys())}"
+
+        # But the values should be different (different prompts)
+        assert not torch.equal(saves1["logits"], saves2["logits"]), (
+            "Same variable name from different prompts returned identical tensors — "
+            "results are likely cross-contaminated"
+        )
+
+        # Verify correctness
+        et_token = model.tokenizer.decode(saves1["logits"].argmax(dim=-1))
+        msg_token = model.tokenizer.decode(saves2["logits"].argmax(dim=-1))
+        assert "Paris" in et_token, f"Expected 'Paris', got '{et_token}'"
+        assert "New" in msg_token, f"Expected 'New', got '{msg_token}'"
+
+    def test_same_varname_same_prompt(self, model):
+        """Two traces, same prompt, same varname — results should be identical."""
+        with model.trace(ET_PROMPT, temperature=0.0, top_p=1, serve=SERVE_URL, blocking=False) as t1:
+            logits = model.logits.output.save()
+
+        with model.trace(ET_PROMPT, temperature=0.0, top_p=1, serve=SERVE_URL, blocking=False) as t2:
+            logits = model.logits.output.save()
+
+        saves1 = t1.collect(timeout=30)
+        saves2 = t2.collect(timeout=30)
+
+        assert torch.equal(saves1["logits"], saves2["logits"]), (
+            f"Same prompt, same varname but different results. "
+            f"Max diff: {(saves1['logits'].float() - saves2['logits'].float()).abs().max()}"
+        )
+
+    def test_multiple_saves_isolation(self, model):
+        """Two traces saving multiple variables — all should be isolated."""
+        with model.trace(ET_PROMPT, serve=SERVE_URL, blocking=False) as t1:
+            h5 = model.model.layers[5].output[0].save()
+            h10 = model.model.layers[10].output[0].save()
+
+        with model.trace(MSG_PROMPT, serve=SERVE_URL, blocking=False) as t2:
+            h5 = model.model.layers[5].output[0].save()
+            h10 = model.model.layers[10].output[0].save()
+
+        saves1 = t1.collect(timeout=30)
+        saves2 = t2.collect(timeout=30)
+
+        # Each should have both keys
+        assert "h5" in saves1 and "h10" in saves1
+        assert "h5" in saves2 and "h10" in saves2
+
+        # Different prompts → different activations
+        assert not torch.equal(saves1["h5"], saves2["h5"])
+        assert not torch.equal(saves1["h10"], saves2["h10"])
+
+
+# =========================================================================
+# 3. Multi-process clients
+# =========================================================================
+
+def _worker_fn(prompt, serve_url, model_name, result_queue):
+    """Run a single serve trace in a separate process."""
+    os.environ["CUDA_VISIBLE_DEVICES"] = "2"
+    try:
+        from nnsight.modeling.vllm import VLLM
+        m = VLLM(model_name)
+        with m.trace(prompt, temperature=0.0, top_p=1, serve=serve_url):
+            logits = m.logits.output.save()
+        token = m.tokenizer.decode(logits.argmax(dim=-1))
+        result_queue.put(("ok", token))
+    except Exception as e:
+        result_queue.put(("error", str(e)))
+
+
+class TestMultiProcessClients:
+    """Multiple processes hitting the server concurrently."""
+
+    def test_two_processes(self, model):
+        """Two separate processes sending requests simultaneously."""
+        ctx = mp.get_context("spawn")
+        q1 = ctx.Queue()
+        q2 = ctx.Queue()
+
+        p1 = ctx.Process(target=_worker_fn, args=(ET_PROMPT, SERVE_URL, MODEL, q1))
+        p2 = ctx.Process(target=_worker_fn, args=(MSG_PROMPT, SERVE_URL, MODEL, q2))
+
+        t0 = time.perf_counter()
+        p1.start()
+        p2.start()
+
+        p1.join(timeout=300)
+        p2.join(timeout=300)
+        elapsed = time.perf_counter() - t0
+
+        if p1.is_alive() or p2.is_alive():
+            p1.kill()
+            p2.kill()
+            pytest.skip("Multi-process test timed out (likely HuggingFace network issue in spawned processes)")
+
+        status1, result1 = q1.get(timeout=5)
+        status2, result2 = q2.get(timeout=5)
+
+        assert status1 == "ok", f"Process 1 failed: {result1}"
+        assert status2 == "ok", f"Process 2 failed: {result2}"
+
+        assert "Paris" in result1, f"Process 1: expected 'Paris', got '{result1}'"
+        assert "New" in result2, f"Process 2: expected 'New', got '{result2}'"
+
+        print(f"\nTwo-process test completed in {elapsed:.1f}s")
+
+
+# =========================================================================
+# 4. Error handling for misuse
+# =========================================================================
+
+class TestErrorHandling:
+    """Verify that misuse produces clear errors, not silent corruption."""
+
+    def test_wrong_server_url(self, model):
+        """serve= pointing to wrong port should raise ConnectionError."""
+        with pytest.raises((ConnectionError, httpx.ConnectError)):
+            with model.trace(ET_PROMPT, serve="http://127.0.0.1:9999"):
+                model.logits.output.save()
+
+    def test_nonblocking_collect_before_fire(self, model):
+        """Calling collect() on a blocking trace should raise AttributeError."""
+        with model.trace(ET_PROMPT, serve=SERVE_URL) as t:
+            model.logits.output.save()
+
+        with pytest.raises(AttributeError, match="no pending serve request"):
+            t.collect()
+
+    def test_nonblocking_double_collect(self, model):
+        """Calling collect() twice should work (future.result() is idempotent)."""
+        with model.trace(ET_PROMPT, temperature=0.0, top_p=1, serve=SERVE_URL, blocking=False) as t:
+            logits = model.logits.output.save()
+
+        saves1 = t.collect(timeout=30)
+        saves2 = t.collect(timeout=30)  # Should not raise
+
+        assert saves1.keys() == saves2.keys()


### PR DESCRIPTION
## vLLM: serve mode, intervention gaps, gradient fix

Three independent features rebased into a clean 7-commit history on `dev`.

### nnsight-serve (commits 3–6)

Lightweight single-model server: vLLM does the heavy lifting, nnsight injects intervention hooks on top.

```bash
nnsight-serve Qwen/Qwen3-30B-A3B --port 6677 --gpu-memory-utilization 0.8
```

```python
model = VLLM("Qwen/Qwen3-30B-A3B")  # meta model, no GPU

with model.trace("The Eiffel Tower is in", serve="http://localhost:6677"):
    logits = model.logits.output.save()
```

- **Sync mode** (default): same UX as local -- `.save()` values available after the `with` block
- **Non-blocking mode**: `blocking=False` fires requests in background threads, `t.collect()` returns saves dict. 3.1x speedup with 4 concurrent requests verified.
- **Concurrency safety**: `Globals.saves`/`stack` refactored from class-level attributes to `contextvars` -- each async task gets isolated state. Required because nnsight-serve is the first context where `Globals.enter()/exit()` runs under async concurrency (FastAPI coroutines on the same event loop). Local execution and NDIF are unaffected (backward-compatible via metaclass properties).
- **pyproject.toml**: `nnsight[serve]` extra, `nnsight-serve` entry point, dropped stale `triton==3.5.0` pin

### vLLM intervention gaps (commits 1-2)

- **Deferred exceptions**: intervention errors no longer kill vLLM's engine process. Exceptions are stored per-mediator and surfaced at the trace boundary.
- **13 gaps documented** between vLLM and HF backends with per-gap test scripts and VLLM_GUIDE. Gap 1.1 (in-place mutation corrupts `.save()`) fixed via clone-on-save for inference-mode tensors.
- Semantic gaps (output tuple formats, merged projections, flat batch dims) kept as-is -- nnsight stays architecture-agnostic. Downstream tools like nnterp can bridge model-specific differences.

### Gradient fix (commit 7)

Fix `backward()` through batched narrow views. When multiple invokes are batched, `Batcher._narrow()` creates views not in the autograd forward path -- `register_hook` never fires. Now detects batch-dim views via `_base` and hooks the base tensor instead, narrowing the gradient to the invoke's slice.

### Tests

- `test_serve.py`: 17 tests (inference, interventions, batching, token inputs, non-blocking, numerical match)
- `test_serve_async.py`: 8 tests (timing overlap, result isolation, multi-process, error handling)
- `tests/serve_clients/`: 10 standalone scripts for manual testing with Qwen3-30B-A3B
- Intervention gap tests: 13 vLLM-vs-HF comparison scripts (`run_all.py`)
- `test_backward_batching.py`: gradient through batched invokes
- `test_tiny.py`: 18/18 pass (CPU + GPU), zero regressions

### Commits

```
823858b Fix backward/gradient through batched narrow views
ab0f5e2 Add serve tests, client scripts, and documentation
c420855 Fix serve concurrency and review issues
0550089 Add non-blocking serve mode with concurrent request support
734cd48 Add nnsight-serve: sync single-model server with vLLM backend
a4080d1 Add vLLM intervention gap report and clone-on-save fix
75b8cbf Defer exceptions in vLLM mode to prevent engine death
```