### PR TITLE
Split submit_request from handle_response; add async submit + get_response

### DIFF
--- a/src/nnsight/intervention/backends/remote.py
+++ b/src/nnsight/intervention/backends/remote.py
@@ -617,10 +617,36 @@ class RemoteBackend(Backend):
 
             local_tracer.execute(fn)
 
+    def _parse_submit_response(self, response: httpx.Response) -> ResponseModel:
+        """Parse an HTTP POST /request response into a ResponseModel.
+
+        Records ``self.job_id`` for subsequent status checks. Does not call
+        :meth:`handle_response` — callers decide when to dispatch status
+        updates so that async / streaming paths can yield the initial
+        response before any side effects run.
+        """
+        from ...schema.response import ResponseModel
+
+        if response.status_code != 200:
+            try:
+                msg = response.json()["detail"]
+            except Exception:
+                msg = response.reason_phrase
+            raise ConnectionError(msg)
+
+        response_model = ResponseModel(**response.json())
+        self.job_id = response_model.id
+        return response_model
+
     def submit_request(
         self, data: bytes, headers: Dict[str, Any]
-    ) -> Optional[ResponseModel]:
+    ) -> ResponseModel:
         """Submit the serialized request to the remote server via HTTP POST.
+
+        Returns the initial :class:`ResponseModel` (with the assigned job id
+        stored on ``self.job_id``). The returned response has *not* been
+        passed through :meth:`handle_response`; the caller is responsible
+        for dispatching it when ready.
 
         Args:
             data: Serialized request payload (potentially compressed).
@@ -633,10 +659,7 @@ class RemoteBackend(Backend):
             ConnectionError: If the server returns a non-200 status code.
             httpx.TimeoutException: If the request times out.
         """
-        from ...schema.response import ResponseModel
-
         headers["Content-Type"] = "application/octet-stream"
-
         timeout = httpx.Timeout(self.CONNECT_TIMEOUT, read=self.READ_TIMEOUT)
 
         with httpx.Client(timeout=timeout) as client:
@@ -646,22 +669,29 @@ class RemoteBackend(Backend):
                 headers=headers,
             )
 
-        if response.status_code == 200:
-            response_model = ResponseModel(**response.json())
+        return self._parse_submit_response(response)
 
-            # Store job ID for subsequent status checks
-            self.job_id = response_model.id
+    async def async_submit_request(
+        self, data: bytes, headers: Dict[str, Any]
+    ) -> ResponseModel:
+        """Async version of :meth:`submit_request`.
 
-            self.handle_response(response_model)
+        Uses :class:`httpx.AsyncClient` so that callers inside an event loop
+        don't block the thread.  See :meth:`submit_request` for the return
+        contract — the caller is responsible for invoking
+        :meth:`handle_response` on the returned model.
+        """
+        headers["Content-Type"] = "application/octet-stream"
+        timeout = httpx.Timeout(self.CONNECT_TIMEOUT, read=self.READ_TIMEOUT)
 
-            return response_model
-        else:
-            # Extract error message from response
-            try:
-                msg = response.json()["detail"]
-            except Exception:
-                msg = response.reason_phrase
-            raise ConnectionError(msg)
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.post(
+                f"{self.address}/request",
+                content=data,
+                headers=headers,
+            )
+
+        return self._parse_submit_response(response)
 
     def get_response(self) -> Optional[RESULT]:
         """Poll the server for the current job status (non-blocking mode).
@@ -682,6 +712,24 @@ class RemoteBackend(Backend):
 
         with httpx.Client(timeout=timeout) as client:
             response = client.get(
+                f"{self.address}/response/{self.job_id}",
+                headers={"ndif-api-key": self.api_key},
+            )
+
+        if response.status_code == 200:
+            response_model = ResponseModel(**response.json())
+            return self.handle_response(response_model)
+        else:
+            raise Exception(response.reason_phrase)
+
+    async def async_get_response(self) -> Optional[RESULT]:
+        """Async version of :meth:`get_response`."""
+        from ...schema.response import ResponseModel
+
+        timeout = httpx.Timeout(self.CONNECT_TIMEOUT, read=self.READ_TIMEOUT)
+
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.get(
                 f"{self.address}/response/{self.job_id}",
                 headers={"ndif-api-key": self.api_key},
             )
@@ -846,7 +894,8 @@ class RemoteBackend(Backend):
             # Prepare and submit the request
             data, headers = self.request(tracer)
             headers["ndif-session_id"] = sio.sid  # Link WebSocket to this request
-            self.submit_request(data, headers)
+            initial = self.submit_request(data, headers)
+            self.handle_response(initial)
 
             try:
                 # Register callback for streaming values back to server
@@ -891,7 +940,8 @@ class RemoteBackend(Backend):
 
             data, headers = self.request(tracer)
             headers["ndif-session_id"] = sio.sid
-            self.submit_request(data, headers)
+            initial = await self.async_submit_request(data, headers)
+            self.handle_response(initial)
 
             try:
                 LocalTracer.register(lambda data: self.stream_send(data, sio))
@@ -956,7 +1006,8 @@ class RemoteBackend(Backend):
         if self.job_id is None:
             # First call: submit the job
             data, headers = self.request(tracer)
-            self.submit_request(data, headers)
+            initial = self.submit_request(data, headers)
+            self.handle_response(initial)
             # job_id is set by submit_request
         else:
             # Subsequent calls: poll for result


### PR DESCRIPTION
## Summary

Refactor \`RemoteBackend\` so a subclass (or an async caller that wants streaming control) can submit a request without paying for \`handle_response\`'s side effects, and can use \`httpx.AsyncClient\` instead of the sync path.

Motivated by the workbench SSE endpoint flow: the FastAPI route wants to \`async yield\` the initial \`ResponseModel\` to the browser before anything touches the terminal-display logic or raises on error, and it wants to run the POST inside the event loop without a threadpool.

## Changes

- \`submit_request\` no longer calls \`handle_response\`. It's now a pure POST that returns the initial \`ResponseModel\` (still records \`self.job_id\` as natural bookkeeping). Callers are responsible for dispatching the response when they're ready.
- Add \`async_submit_request\` — mirrors \`submit_request\` via \`httpx.AsyncClient\`.
- Add \`async_get_response\` — mirrors \`get_response\` for symmetry in the non-blocking poll path.
- Factor the shared \`status_code\`/\`ResponseModel\` parsing into a small \`_parse_submit_response\` helper used by both submit variants.
- Update the three internal callers (\`blocking_request\`, \`async_request\`, \`non_blocking_request\`) to call \`handle_response\` explicitly on the initial response, preserving today's behaviour. \`async_request\` now also uses \`async_submit_request\` instead of the sync one.

## Test plan

- [ ] Unit / integration tests in nnsight pass on \`dev\`.
- [ ] Blocking remote trace (existing \`with model.trace(..., remote=True)\`) still shows the status display and completes.
- [ ] Async remote trace (\`tracer.asynchronous=True\`) still completes end-to-end; no thread blocking on the POST.
- [ ] Non-blocking submit + poll round-trip still works (submit → job_id → poll to COMPLETED).
- [ ] Workbench SSE endpoint (companion PR) exercises the new \`async_submit_request\` end-to-end against NDIF — verified locally against gpt2 on api.ndif.us.

## Companion

Workbench side: ndif-team/workbench#112 — its \`StreamingRemoteBackend\` now calls \`super().async_submit_request()\` instead of duplicating the POST.