### PR TITLE
Unpin vllm and triton

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,8 @@ diffusers = [
 
 
 vllm = [
-    "vllm==0.15.1",
-    "triton==3.5.0",
+    "vllm",
+    "triton",
 ]
 
 

--- a/src/nnsight/__init__.py
+++ b/src/nnsight/__init__.py
@@ -60,8 +60,6 @@ except NameError:
 
 __INTERACTIVE__ = (sys.flags.interactive or not sys.argv[0]) and not __IPYTHON__
 
-NNS_VLLM_VERSION = "0.15.1"
-
 
 from .intervention.envoy import Envoy
 from .modeling.base import NNsight

--- a/src/nnsight/modeling/vllm/vllm.py
+++ b/src/nnsight/modeling/vllm/vllm.py
@@ -1,17 +1,6 @@
-from ... import NNS_VLLM_VERSION
-
 import atexit
 import uuid
 import vllm
-
-# Check vLLM version compatibility
-_installed_version = getattr(vllm, "__version__", "unknown")
-if _installed_version != NNS_VLLM_VERSION:
-    raise ImportError(
-        f"nnsight requires vLLM version {NNS_VLLM_VERSION}, but found {_installed_version}. "
-        f"Please install the correct version:\n\n"
-        f"    pip install vllm=={NNS_VLLM_VERSION}\n"
-    )
 
 import torch
 
@@ -28,6 +17,7 @@ from vllm.distributed import (
     initialize_model_parallel,
 )
 from vllm.engine.arg_utils import EngineArgs
+from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.entrypoints.llm import LLM
 
 from ...intervention.envoy import Envoy
@@ -105,9 +95,10 @@ class VLLM(RemoteableMixin):
                 backend="gloo",
             )
 
-            initialize_model_parallel(
-                tensor_model_parallel_size=1, pipeline_model_parallel_size=1
-            )
+            with set_current_vllm_config(VllmConfig()):
+                initialize_model_parallel(
+                    tensor_model_parallel_size=1, pipeline_model_parallel_size=1
+                )
 
         atexit.register(VLLM._cleanup_distributed)
 


### PR DESCRIPTION
## Summary

Unpins `vllm` and `triton` from the `vllm` extra and drops the hard runtime version check, letting nnsight work with newer vLLM releases.

## Changes

- **`pyproject.toml`**: `vllm==0.15.1` → `vllm`, `triton==3.5.0` → `triton`.
- **`src/nnsight/__init__.py`**: remove the now-unused `NNS_VLLM_VERSION` constant.
- **`src/nnsight/modeling/vllm/vllm.py`**:
  - Remove the `ImportError` version check at import time.
  - Wrap `initialize_model_parallel(...)` in `set_current_vllm_config(VllmConfig())`. Since vLLM 0.19, `initialize_model_parallel` calls `get_current_vllm_config()` internally and asserts that a config context is active, so calling it bare raises `AssertionError: Current vLLM config is not set.` The wrapper provides a minimal default config so the call succeeds on both older and newer vLLM versions.

## Tested against

- `vllm==0.19.1` — `from nnsight.modeling.vllm import VLLM` imports cleanly, `VLLM(...)` constructs, and `model.trace(...)` completes end-to-end on a small chat-steering script.

## Test results

`pytest tests/test_vllm.py -v` against `vllm==0.19.1` (8x GPU host, 2m39s) passes fully.

## Extra Notes

- A `warning_once` from vLLM fires: `"Passing raw prompts to InputProcessor is deprecated and will be removed in v0.18. You should instead pass the outputs of Renderer.render_cmpl() or Renderer.render_chat()."` This is benign on 0.19 (they've extended the deprecation past the originally-stated v0.18) but worth following up on in a separate PR — nnsight's `_prepare_input` / `__call__` should ideally pre-render prompts via the Renderer before handing them to `generate()` / `add_request()`.