### PR TITLE
handle exceptions in converted functions

### DIFF
--- a/src/nnsight/intervention/source.py
+++ b/src/nnsight/intervention/source.py
@@ -80,6 +80,7 @@ from .hooks import (
     hooked_operation_output,
 )
 from .interleaver import IEnvoy, Interleaver
+from .tracing.globals import Globals
 
 if sys.version_info >= (3, 9):
     _ast_to_source = ast.unparse
@@ -191,7 +192,17 @@ def convert(fn: Callable, wrap: Callable, name: str):
     global_namespace.update(module_globals)
     global_namespace["wrap"] = wrap
 
-    filename = "<nnsight>"
+    metadata_key = hash((
+        fn.__code__.co_filename,
+        fn.__code__.co_firstlineno,
+        fn.__code__.co_name,
+    ))
+    filename = f"<nnsight {metadata_key}>"
+    Globals.converted_fn_files[filename] = (
+        fn.__code__.co_filename,
+        fn.__code__.co_firstlineno,
+        fn.__code__.co_name
+    )
 
     if isinstance(tree, ast.Module):
         code_obj = compile(tree, filename, "exec")

--- a/src/nnsight/intervention/tracing/globals.py
+++ b/src/nnsight/intervention/tracing/globals.py
@@ -96,6 +96,8 @@ class Globals:
 
     cache = TracingCache()
 
+    converted_fn_files = {}
+
     _mounted = False
 
     @staticmethod
@@ -114,4 +116,5 @@ class Globals:
     def clear():
         Globals.saves.clear()
         Globals.cache.clear()
+        Globals.converted_fn_files.clear()
         Globals.stack = 0

--- a/src/nnsight/intervention/tracing/util.py
+++ b/src/nnsight/intervention/tracing/util.py
@@ -8,6 +8,8 @@ from builtins import open
 from types import FrameType
 from typing import TYPE_CHECKING, Callable, Dict, List
 
+from .globals import Globals
+
 if TYPE_CHECKING:
     from .base import Tracer
 
@@ -200,18 +202,33 @@ class ExceptionWrapper(Exception):
             name = frame.f_code.co_name
 
             if fname.startswith("<nnsight"):
-                # Reconstruct to original user code location
-                real_fname = filename_mapping[fname]
-                start_line = start_lines[fname]
-                func_name = (
-                    co_names[fname]
-                    if "__nnsight_tracing_info__" in frame.f_locals
-                    else frame.f_code.co_name
-                )
-                source = source_lines[fname]
-                line_number = lineno - 1 + start_line + 1 + co_first_line
-                code_line = source[lineno - 1].strip()
-                frames.append((real_fname, line_number, func_name, code_line, False))
+                # Check if this is a tracer frame (in filename_mapping)
+                if fname in filename_mapping:
+                    real_fname = filename_mapping[fname]
+                    start_line = start_lines[fname]
+                    func_name = (
+                        co_names[fname]
+                        if "__nnsight_tracing_info__" in frame.f_locals
+                        else frame.f_code.co_name
+                    )
+                    source = source_lines[fname]
+                    line_number = lineno - 1 + start_line + 1 + co_first_line
+                    code_line = source[lineno - 1].strip()
+                    frames.append((real_fname, line_number, func_name, code_line, False))
+
+                # Check if this is a converted function frame (in Globals.converted_fn_files)
+                elif fname in Globals.converted_fn_files:
+                    co_filename, co_firstlineno, co_name = Globals.converted_fn_files[fname]
+                    line_number = co_firstlineno - 1 + lineno
+                    try:
+                        line = linecache.getline(co_filename, line_number).strip()
+                    except:
+                        line = ""
+                    frames.append((co_filename, line_number, co_name, line, False))
+
+                # Catch it all - unknown <nnsight ... > frame
+                else:
+                    frames.append((fname, lineno, name, "", False))
 
             elif "nnsight/" in fname:
                 # Internal nnsight code - only include in DEBUG mode


### PR DESCRIPTION
## The Problem

Exceptions in code compiled by `convert()` (which injects operation wrapping into forward methods using generic \<nnsight> filename) crashed `ExceptionWrapper._collect_frames()` with a `KeyError`. The exception handler only knew how to map `Tracer.Info` frames, not `convert()` frames.

## The Solution

Three files were modified:

### 1. `globals.py`
Added a metadata registry:
```python
class Globals:
    converted_fn_files = {}  # Maps <nnsight {metadata_key}> filenames to (co_filename, co_firstlineno, co_name)
```

### 2. `inject.py` 
Modified `convert()` to register metadata before compiling:
```python
metadata_key = hash((fn.__code__.co_filename, fn.__code__.co_firstlineno, fn.__code__.co_name))
filename = f"<nnsight {metadata_key}>"
Globals.converted_fn_files[filename] = (
    fn.__code__.co_filename,
    fn.__code__.co_firstlineno,
    fn.__code__.co_name
)
```

### 3. `util.py`
Updated `ExceptionWrapper._collect_frames()` to check both mappings:
```python
if fname in filename_mapping:
    # Handle Tracer.Info frames (existing logic)
    ...
if fname in Globals.converted_fn_files:
    # Handle convert() frames (new logic)
    co_filename, co_firstlineno, co_name = Globals.converted_fn_files[fname]
    line_number = co_firstlineno - 1 + lineno
    # Reconstruct original location
    ...
else:
    # Unknown frame - show as-is
    frames.append((fname, lineno, name, "", False))
```

## Result

- Exceptions in `convert()` compiled code no longer crash
- Tracebacks now show real file paths and correct line numbers
- Both `Tracer` and `convert()` frames are handled
