### PR TITLE
Envoy/diffusion fixes + CI test matrix expansion

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -29,4 +29,22 @@ jobs:
         pip install ./
     - name: Test with pytest
       run: |
-        pytest tests/test_lm.py tests/test_tiny.py tests/test_0516_features.py tests/test_debug.py tests/test_memory_cleanup.py tests/test_multiple_wrappers.py tests/test_source.py --device cpu
+        pytest \
+          tests/test_lm.py \
+          tests/test_tiny.py \
+          tests/test_0516_features.py \
+          tests/test_debug.py \
+          tests/test_memory_cleanup.py \
+          tests/test_multiple_wrappers.py \
+          tests/test_source.py \
+          tests/test_envoys.py \
+          tests/test_iter_edge_cases.py \
+          tests/test_transform.py \
+          tests/test_lambda_serialization.py \
+          tests/test_local_recursion.py \
+          tests/test_local_mutual_recursion.py \
+          tests/test_mutual_recursion.py \
+          tests/test_local_env.py \
+          tests/test_local_simulation.py \
+          tests/test_vlm.py \
+          --device cpu

--- a/src/nnsight/intervention/envoy.py
+++ b/src/nnsight/intervention/envoy.py
@@ -1042,6 +1042,10 @@ class Envoy(Batchable):
         If the value is a PyTorch module, it will be wrapped in an Envoy to enable
         intervention during execution.
 
+        Otherwise the write is mirrored to both the Envoy and the wrapped module
+        when applicable, so that reads via ``__dict__`` short-circuit and reads via
+        ``__getattr__`` (which falls through to ``_module``) stay consistent.
+
         Args:
             key: The attribute name
             value: The attribute value
@@ -1049,11 +1053,18 @@ class Envoy(Batchable):
 
         if key != "_module" and isinstance(value, torch.nn.Module):
             self._add_envoy(value, key)
-        else:
-            if "_module" in self.__dict__ and hasattr(self._module, key):
-                return setattr(self._module, key, value)
-            else:
-                super().__setattr__(key, value)
+            return
+
+        on_module = "_module" in self.__dict__ and hasattr(self._module, key)
+
+        # Set on the Envoy if it already owns the key, or if there's no _module
+        # to fall through to.
+        if key in self.__dict__ or not on_module:
+            super().__setattr__(key, value)
+
+        # Mirror to _module so the wrapped model stays in sync with the wrapper.
+        if on_module:
+            setattr(self._module, key, value)
 
     def __getstate__(self):
 

--- a/src/nnsight/modeling/diffusion.py
+++ b/src/nnsight/modeling/diffusion.py
@@ -273,7 +273,10 @@ class DiffusionModel(HuggingFaceModel):
             else getattr(pipelines, automodel)
         )
 
-        self.config = None
+        # Use __dict__ directly so we don't mirror this onto the (possibly
+        # already-loaded) underlying module via Envoy.__setattr__ — we're
+        # caching the config on the wrapper, not mutating the model's own.
+        self.__dict__["config"] = None
         self._model: Diffuser = None
 
         super().__init__(*args, **kwargs)
@@ -294,7 +297,7 @@ class DiffusionModel(HuggingFaceModel):
             revision: Git revision of the repository.
         """
         if self.config is None:
-            self.config = self.automodel.load_config(repo_id, revision=revision)
+            self.__dict__["config"] = self.automodel.load_config(repo_id, revision=revision)
 
     def _load_meta(self, repo_id: str, revision: Optional[str] = None, **kwargs):
         """Load a meta (placeholder) version of the diffusion model.

--- a/src/nnsight/modeling/diffusion.py
+++ b/src/nnsight/modeling/diffusion.py
@@ -342,8 +342,6 @@ class DiffusionModel(HuggingFaceModel):
         """
         self._load_config(repo_id, revision=revision)
 
-        device_map = "balanced" if device_map == "auto" or device_map is None else device_map
-
         model = Diffuser(
             self.automodel, repo_id, revision=revision, device_map=device_map, config=self.config, **kwargs
         )

--- a/src/nnsight/modeling/transformers.py
+++ b/src/nnsight/modeling/transformers.py
@@ -35,8 +35,11 @@ class TransformersModel(HuggingFaceModel):
 
     def __init__(self, *args, config_model: Type[PretrainedConfig] = None, automodel: Type[AutoModel] = AutoModel, **kwargs):
 
-        self.config: PretrainedConfig = config_model
-        
+        # Use __dict__ directly so we don't mirror this onto the (possibly
+        # already-loaded) underlying module via Envoy.__setattr__ — we're
+        # caching the config on the wrapper, not mutating the model's own.
+        self.__dict__["config"] = config_model
+
         self.automodel = (
             automodel
             if not isinstance(automodel, str)
@@ -49,7 +52,7 @@ class TransformersModel(HuggingFaceModel):
 
         if self.config is None:
 
-            self.config = AutoConfig.from_pretrained(
+            self.__dict__["config"] = AutoConfig.from_pretrained(
                 repo_id, revision=revision, **kwargs
             )
 
@@ -64,7 +67,7 @@ class TransformersModel(HuggingFaceModel):
 
         model = self.automodel.from_config(self.config, trust_remote_code=True)
 
-        self.config = model.config
+        self.__dict__["config"] = model.config
 
         return model
 
@@ -79,6 +82,6 @@ class TransformersModel(HuggingFaceModel):
 
         model = self.automodel.from_pretrained(repo_id, revision=revision, **kwargs)
 
-        self.config = model.config
+        self.__dict__["config"] = model.config
 
         return model

--- a/tests/test_diffusion.py
+++ b/tests/test_diffusion.py
@@ -160,16 +160,16 @@ class TestDiffusionBatching:
         ) as tracer:
 
             with tracer.invoke(cat_prompt):
-                encoder_out_1 = tiny_sd.text_encoder.text_model.encoder.layers[-1].output.save()
+                encoder_out_1 = tiny_sd.text_encoder.encoder.layers[-1].output.save()
 
             with tracer.invoke([panda_prompt, birthday_cake_prompt]):
-                encoder_out_2 = tiny_sd.text_encoder.text_model.encoder.layers[-1].output.save()
+                encoder_out_2 = tiny_sd.text_encoder.encoder.layers[-1].output.save()
 
             with tracer.invoke(wave_prompt):
-                encoder_out_3 = tiny_sd.text_encoder.text_model.encoder.layers[-1].output.save()
+                encoder_out_3 = tiny_sd.text_encoder.encoder.layers[-1].output.save()
 
             with tracer.invoke():
-                encoder_out_all = tiny_sd.text_encoder.text_model.encoder.layers[-1].output.save()
+                encoder_out_all = tiny_sd.text_encoder.encoder.layers[-1].output.save()
 
         assert encoder_out_all.shape[0] == encoder_out_1.shape[0] + encoder_out_2.shape[0] + encoder_out_3.shape[0]
         assert encoder_out_1.shape[0] == 1
@@ -300,7 +300,7 @@ class TestDiffusionBatching:
         birthday_cake_prompt,
         wave_prompt
     ):
-        module = tiny_sd.text_encoder.text_model.encoder.layers[-1]
+        module = tiny_sd.text_encoder.encoder.layers[-1]
 
         with tiny_sd.generate(
             num_inference_steps=20,


### PR DESCRIPTION
## Summary

Four focused improvements stacked on top of `vllm-serve`:

- **`fix(envoy)`** — make `Envoy.__setattr__` symmetric with attribute lookup so writes for keys the wrapper has pre-claimed (e.g. `LanguageModel.config`) don't silently divert to `_module` while reads return stale `__dict__` values.
- **`fix(diffusion)`** — stop rewriting the caller's `device_map`. The old code force-promoted `None` and `\"auto\"` to `\"balanced\"`, which on multi-GPU hosts splits the pipeline across every GPU and dies with cross-device tensor errors during forward.
- **`test(diffusion)`** — drop the now-removed `CLIPTextModel.text_model` segment from text-encoder paths (transformers 5.x flattening).
- **`ci`** — add 10 CPU-only test files to `python-app.yml` (255 / 0 / 2 skip, ~39s on CPU; was 180 / 0 / 2 skip).

## Background

The Envoy fix fell out of investigating why circuit-tracer's `NNSightReplacementModel.from_config` (which does `model = LanguageModel(hf_model); model.config = config`) returned `model.config is None` on every nnsight ≥ v0.6.2. Root cause is commit dedc7e5 (\"handle setting existing module and attributes on an envoy\"): `__setattr__` started routing writes to `_module` whenever `_module` had the attribute, but `__getattr__` only fires when normal lookup fails — so any attribute the wrapper had pre-claimed in `__init__` (`config`, `automodel`, ...) had its writes silently sent to `_module` while reads continued returning the original stale `__dict__` value. circuit-tracer 0.4.1 monkey-patches around this; this PR fixes it at the source.

The diffusion fixes came out of running `tests/test_diffusion.py` on a multi-GPU box: 27 / 30 failed because of the unwanted device-map remap, plus 2 more from a transformers 5.x API change that flattened `CLIPTextModel.text_model` into `CLIPTextModel`.

The CI expansion adds the test files that are already CPU-runnable, fast, and currently green on this branch — pure additive coverage.

## Per-file change summary

| File | Change |
|---|---|
| `src/nnsight/intervention/envoy.py` | `__setattr__`: write goes to whichever side already owns the key, mirrors to `_module` if it has the attribute (dual-write keeps reads consistent regardless of which lookup path Python takes) |
| `src/nnsight/modeling/transformers.py` | Internal `self.config = ...` writes converted to `self.__dict__[\"config\"] = ...` so we cache on the wrapper without redundantly rewriting the underlying HF model's `config` |
| `src/nnsight/modeling/diffusion.py` | Same `self.__dict__[\"config\"]` change in `DiffusionModel`, plus removal of the `device_map = \"balanced\" if device_map == \"auto\" or device_map is None else device_map` line so we pass the caller's choice through unchanged |
| `tests/test_diffusion.py` | 5 occurrences of `tiny_sd.text_encoder.text_model.encoder.layers[-1]` → `tiny_sd.text_encoder.encoder.layers[-1]` |
| `.github/workflows/python-app.yml` | Add 10 CPU-only test files to the pytest invocation |

## CI matrix added (CPU-safe, all currently passing)

```
test_envoys.py
test_iter_edge_cases.py
test_transform.py
test_lambda_serialization.py
test_local_recursion.py
test_local_mutual_recursion.py
test_mutual_recursion.py
test_local_env.py
test_local_simulation.py
test_vlm.py
```

`test_vlm.py` works on CPU as-is — its fixture already plumbs `device_map=device`. The LLaVA-Interleave-Qwen-0.5B model fits in RAM and runs in seconds for these cases.

## Not added in this PR

- `test_dataclass_serialization.py` — held back per discussion.
- `test_serialization_edge_cases.py`, `test_whitelist_serialization.py` — both fail on a missing `SERVER_MODULES_WHITELIST` import after the recent serialization-whitelist refactor; same root fix would unblock both.
- `test_diffusion.py`, `test_vllm*.py`, `test_serve*.py`, `test_tp_stream_fix.py`, `test_remote.py` — need GPU / vLLM / running serve / NDIF; better as separate workflows.

## Test plan

- [x] nnsight CI suite (post-expansion): 255 passed, 2 skipped, 1 xpassed on `nn6` env, `--device cpu`
- [x] Diffusion suite on CUDA: 30 passed (was 27 failed before the device-map and `text_model` fixes)
- [x] circuit-tracer's small/large dummy-weight nnsight tests (9 tests) pass with the Envoy fix and **without** the local monkey-patch they previously needed
- [x] `Envoy.__setattr__` semantic check: brand-new attrs land on Envoy only; `_module`-only attrs route to `_module`; attrs that exist on both stay in sync (write visible on both sides, reset propagates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)