### PR TITLE
perf: lazy-load model classes to cut import nnsight from 7.6s to 1.6s

### DIFF
--- a/src/nnsight/__init__.py
+++ b/src/nnsight/__init__.py
@@ -65,25 +65,39 @@ __INTERACTIVE__ = (sys.flags.interactive or not sys.argv[0]) and not __IPYTHON__
 
 from .intervention.envoy import Envoy
 from .modeling.base import NNsight
-from .modeling.language import LanguageModel
-from .modeling.vlm import VisionLanguageModel
+
+# Public names whose modules are expensive to import (transformers ~3s,
+# diffusers ~1.5s) but only relevant when those classes are actually used.
+# Map: public name -> submodule (relative to this package) defining it.
+_LAZY_IMPORTS = {
+    "LanguageModel":       ".modeling.language",
+    "VisionLanguageModel": ".modeling.vlm",
+    "DiffusionModel":      ".modeling.diffusion",
+}
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    # Static-analyzer view (Pyright/Pylance/mypy/PyCharm). Dead at runtime.
+    from .modeling.language import LanguageModel
+    from .modeling.vlm import VisionLanguageModel
+    from .modeling.diffusion import DiffusionModel
 
 
 def __getattr__(name):
-    # Lazy-load DiffusionModel: importing diffusers costs ~1.5s and most
-    # users never touch it. Import only on first attribute access, then
-    # cache on the module so subsequent accesses skip this hook.
-    if name == "DiffusionModel":
-        try:
-            from .modeling.diffusion import DiffusionModel as _DiffusionModel
-        except ImportError as e:
-            raise AttributeError(
-                "DiffusionModel is unavailable: install the 'diffusers' package "
-                f"to use it ({e})."
-            ) from e
-        globals()["DiffusionModel"] = _DiffusionModel
-        return _DiffusionModel
-    raise AttributeError(f"module 'nnsight' has no attribute {name!r}")
+    target = _LAZY_IMPORTS.get(name)
+    if target is None:
+        raise AttributeError(f"module 'nnsight' has no attribute {name!r}")
+    import importlib
+    try:
+        module = importlib.import_module(target, __name__)
+    except ImportError as e:
+        raise AttributeError(
+            f"{name} is unavailable ({e}). Install the missing optional "
+            "dependency to use it."
+        ) from e
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
 
 
 from .intervention.tracing.base import Tracer

--- a/src/nnsight/__init__.py
+++ b/src/nnsight/__init__.py
@@ -203,6 +203,15 @@ DEFAULT_PATCHER.add(Patch(Tensor, wrap_backward(Tensor.backward), "backward"))
 
 DEFAULT_PATCHER.__enter__()
 
+# `from nnsight import *` consults __all__ (or globals() if absent), but PEP 562
+# module-level __getattr__ is not consulted by star-imports. Without naming the
+# lazy entries here, `LanguageModel` / `VisionLanguageModel` / `DiffusionModel`
+# would silently drop from `*`. Build __all__ from the currently-public globals
+# plus the lazy names to preserve prior star-import behavior end-to-end.
+__all__ = sorted(
+    {name for name in globals() if not name.startswith("_")} | set(_LAZY_IMPORTS)
+)
+
 if __INTERACTIVE__:
     from code import InteractiveConsole
     import readline

--- a/src/nnsight/__init__.py
+++ b/src/nnsight/__init__.py
@@ -1,8 +1,3 @@
-# Apply engineio SSL race condition fix before any socketio imports.
-# This fixes a ~30-55% connection failure rate over TLS.
-# See: https://github.com/miguelgrinberg/python-socketio/issues/1568
-from . import _engineio_patch  # noqa: F401
-
 # This section ensures that the source code for both the main script and the file where `nnsight` is imported
 # is cached in Python's `linecache` module. This is important for robust stack trace and debugging support,
 # especially in interactive or dynamic environments where files may change after import.
@@ -57,11 +52,12 @@ except PackageNotFoundError:
 from .intervention.tracing.globals import save
 from .ndif import *
 
-from IPython import get_ipython
-
+# Detect IPython without importing it — if IPython isn't already in sys.modules,
+# we are not running under IPython and there's no need to pay its import cost.
+_ipy_mod = sys.modules.get("IPython")
 try:
-    __IPYTHON__ = get_ipython() is not None
-except NameError:
+    __IPYTHON__ = _ipy_mod is not None and _ipy_mod.get_ipython() is not None
+except Exception:
     __IPYTHON__ = False
 
 __INTERACTIVE__ = (sys.flags.interactive or not sys.argv[0]) and not __IPYTHON__
@@ -72,10 +68,24 @@ from .modeling.base import NNsight
 from .modeling.language import LanguageModel
 from .modeling.vlm import VisionLanguageModel
 
-try:
-    from .modeling.diffusion import DiffusionModel
-except ImportError:
-    pass
+
+def __getattr__(name):
+    # Lazy-load DiffusionModel: importing diffusers costs ~1.5s and most
+    # users never touch it. Import only on first attribute access, then
+    # cache on the module so subsequent accesses skip this hook.
+    if name == "DiffusionModel":
+        try:
+            from .modeling.diffusion import DiffusionModel as _DiffusionModel
+        except ImportError as e:
+            raise AttributeError(
+                "DiffusionModel is unavailable: install the 'diffusers' package "
+                f"to use it ({e})."
+            ) from e
+        globals()["DiffusionModel"] = _DiffusionModel
+        return _DiffusionModel
+    raise AttributeError(f"module 'nnsight' has no attribute {name!r}")
+
+
 from .intervention.tracing.base import Tracer
 from .intervention.tracing.util import ExceptionWrapper
 
@@ -98,7 +108,7 @@ sys.excepthook = _nnsight_excepthook
 
 # Also handle IPython if available
 try:
-    _ipython = get_ipython()
+    _ipython = _ipy_mod.get_ipython() if _ipy_mod is not None else None
     if _ipython is not None:
 
         def _nnsight_ipython_exception_handler(self, etype, evalue, tb, tb_offset=None):

--- a/src/nnsight/_engineio_patch.py
+++ b/src/nnsight/_engineio_patch.py
@@ -205,7 +205,3 @@ def apply_patch():
     # Apply the patch
     engineio.client.Client._connect_websocket = _patched_connect_websocket
     _patched = True
-
-
-# Auto-apply patch on import
-apply_patch()

--- a/src/nnsight/intervention/backends/remote.py
+++ b/src/nnsight/intervention/backends/remote.py
@@ -884,6 +884,8 @@ class RemoteBackend(Backend):
             RemoteException: If the job fails on the server.
         """
         # Establish WebSocket connection for real-time updates
+        from ..._engineio_patch import apply_patch
+        apply_patch()
         with socketio.SimpleClient(reconnection_attempts=10) as sio:
             sio.connect(
                 self.ws_address,
@@ -931,6 +933,8 @@ class RemoteBackend(Backend):
     async def async_request(self, tracer: Tracer) -> Optional[RESULT]:
         """Async version of blocking_request(). See blocking_request() for full documentation."""
         # Establish async WebSocket connection
+        from ..._engineio_patch import apply_patch
+        apply_patch()
         async with socketio.AsyncSimpleClient(reconnection_attempts=10) as sio:
             await sio.connect(
                 self.ws_address,

--- a/src/nnsight/modeling/mixins/remoteable.py
+++ b/src/nnsight/modeling/mixins/remoteable.py
@@ -6,12 +6,14 @@ from typing import Any, Callable, Dict, Union
 from typing_extensions import Self
 
 from ...intervention.backends import Backend
-from ...intervention.backends.remote import RemoteBackend
-from ...intervention.backends.local_simulation import LocalSimulationBackend
 from ...intervention.serialization import load, save
 from ...intervention.tracing.tracer import InterleavingTracer, Tracer
 from ...util import from_import_path, to_import_path
 from .meta import MetaMixin
+
+# RemoteBackend / LocalSimulationBackend are imported lazily inside trace()/session():
+# RemoteBackend pulls in socketio + engineio + tornado (~250ms) and is only needed
+# when a user actually requests remote=True / remote='local'.
 
 
 class RemoteableMixin(MetaMixin):
@@ -58,11 +60,14 @@ class RemoteableMixin(MetaMixin):
         if backend is not None:
             pass
         elif remote == 'local':
+            from ...intervention.backends.local_simulation import LocalSimulationBackend
             backend = LocalSimulationBackend(self)
         elif remote:
+            from ...intervention.backends.remote import RemoteBackend
             backend = RemoteBackend(self.to_model_key(), blocking=blocking)
         # If backend is a string, assume RemoteBackend url.
         elif isinstance(backend, str):
+            from ...intervention.backends.remote import RemoteBackend
             backend = RemoteBackend(
                 self.to_model_key(), host=backend, blocking=blocking
             )
@@ -96,9 +101,11 @@ class RemoteableMixin(MetaMixin):
         if backend is not None:
             pass
         elif remote:
+            from ...intervention.backends.remote import RemoteBackend
             backend = RemoteBackend(self.to_model_key(), blocking=blocking)
         # If backend is a string, assume RemoteBackend url.
         elif isinstance(backend, str):
+            from ...intervention.backends.remote import RemoteBackend
             backend = RemoteBackend(
                 self.to_model_key(), host=backend, blocking=blocking
             )


### PR DESCRIPTION
## Summary

Cold-start cost of `import nnsight` was ~7.6s. After this PR it's ~1.6s when no HuggingFace-backed model classes are used. Achieved by deferring three classes of imports that are only conditionally needed.

| Scenario | Before | After |
|---|---|---|
| `import nnsight` (no other access) | 7.6s | **1.6s** (-79%) |
| `umm.py` end-to-end (VLM remote trace) | 11.4s | **9.5s** (-17%) |
| `from nnsight import LanguageModel` | 7.6s | ~5s (transformers loads on access) |
| `from nnsight import NNsight` only | 7.6s | **~1.6s** |

## What's deferred

### 1. `_engineio_patch` — engineio + tornado + aiohttp (~250ms)
The patch monkey-patches `engineio.client.Client._connect_websocket` to fix an SSL race; nothing local-only ever needs it. `apply_patch()` is now called lazily inside `RemoteBackend.blocking_request` / `async_request`, immediately before each `sio.connect(...)`. The function is already idempotent so subsequent calls are free.

### 2. IPython (~210ms)
`from IPython import get_ipython` was loading IPython just to compute `__IPYTHON__`. Replaced with `sys.modules.get("IPython")` — if IPython isn't already in `sys.modules`, the process isn't running under IPython by definition. Same gating used for the IPython exception hook.

### 3. `RemoteBackend` / `LocalSimulationBackend` in `modeling/mixins/remoteable.py`
These were the path re-introducing socketio at top-level (since they're imported from `LanguageModel` -> mixins). Moved into `trace()` / `session()` so they only load when `remote=True` / `remote='local'` is actually requested.

### 4. `LanguageModel`, `VisionLanguageModel`, `DiffusionModel` (3s + 1.5s)
Generalised lazy-import via a `_LAZY_IMPORTS` registry and module-level `__getattr__`. Each entry resolves on first attribute access and caches on the module so subsequent accesses skip the hook.

```python
_LAZY_IMPORTS = {
    "LanguageModel":       ".modeling.language",
    "VisionLanguageModel": ".modeling.vlm",
    "DiffusionModel":      ".modeling.diffusion",
}
```

A parallel `if TYPE_CHECKING:` block declares the same names with their real imports, so Pyright / Pylance / mypy / PyCharm still get autocomplete, go-to-definition, and type-checking on `from nnsight import LanguageModel`. The block is dead at runtime.

## Test plan

- [x] CI suite (15 test files, `--device cpu`): **232 passed, 2 skipped, 1 xpassed**
- [x] End-to-end remote trace via `umm.py` against a live NDIF server returns the expected `Gemma3CausalLMOutputWithPast`
- [x] After `import nnsight`: `IPython`, `transformers`, `diffusers`, `socketio`, `engineio` are all NOT in `sys.modules`
- [x] `nnsight.LanguageModel` / `nnsight.VisionLanguageModel` / `nnsight.DiffusionModel` resolve correctly on first access; second access hits the cached attribute (no `__getattr__` re-entry)
- [x] `nnsight.__IPYTHON__` is `False` in plain `python`

## IDE / type-checker behaviour

`from nnsight import LanguageModel` works the same as before for static analysers — the `TYPE_CHECKING` block exposes the real types. Verified that the previous bare-`__getattr__` approach (used in the first commit for `DiffusionModel`) loses IDE support, which is why the `TYPE_CHECKING` block is the standard idiom (used by pandas, transformers, huggingface_hub, etc.).

## Files changed

- `src/nnsight/__init__.py` — `_LAZY_IMPORTS` registry + `TYPE_CHECKING` block + generic `__getattr__`; sys.modules-based IPython detection; removed eager `_engineio_patch` import and eager `LanguageModel` / `VisionLanguageModel` / `DiffusionModel` imports
- `src/nnsight/_engineio_patch.py` — removed auto-apply at module load
- `src/nnsight/intervention/backends/remote.py` — `apply_patch()` before each `sio.connect(...)`
- `src/nnsight/modeling/mixins/remoteable.py` — `RemoteBackend` / `LocalSimulationBackend` imports moved into `trace()` / `session()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)