### PR TITLE
Add nnsight login command and notebook helper (#506)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ vllm = [
 
 all = ["nnsight[test,diffusers,vllm]"]
 
+[project.scripts]
+nnsight = "nnsight.login:main"
+
 [project.urls]
 Homepage = "https://github.com/ndif-team/nnsight"
 Website = "https://nnsight.net/"

--- a/src/nnsight/__init__.py
+++ b/src/nnsight/__init__.py
@@ -56,6 +56,7 @@ except PackageNotFoundError:
 
 from .intervention.tracing.globals import save
 from .ndif import *
+from .login import login
 
 from IPython import get_ipython
 

--- a/src/nnsight/login.py
+++ b/src/nnsight/login.py
@@ -1,0 +1,70 @@
+"""Login helpers for storing your NDIF API key.
+
+This module exposes two entry points:
+
+- ``nnsight.login()`` for use in a notebook or interactive session. It prompts
+  for the API key with ``getpass`` so the key is never echoed to the screen and
+  saves it through the existing config machinery.
+- ``main()`` for the ``nnsight login`` console command, which does the same thing
+  from a terminal.
+
+Both persist the key by calling ``CONFIG.set_default_api_key``, which writes it
+to ``config.yaml`` so future sessions pick it up automatically.
+"""
+
+from getpass import getpass
+from typing import Optional
+
+
+def login(api_key: Optional[str] = None) -> None:
+    """Store your NDIF API key so future sessions can use it.
+
+    Args:
+        api_key: The NDIF API key. If not given, you will be prompted for it.
+            The prompt uses ``getpass`` so the key is not echoed.
+
+    Examples:
+        >>> from nnsight import login
+        >>> login()
+        Enter your NDIF API key:
+        NDIF API key saved.
+    """
+
+    from . import CONFIG
+
+    if api_key is None:
+        api_key = getpass("Enter your NDIF API key: ")
+
+    api_key = api_key.strip()
+
+    if not api_key:
+        print("No API key provided. Nothing was saved.")
+        return
+
+    CONFIG.set_default_api_key(api_key)
+
+    print("NDIF API key saved.")
+
+
+def main() -> None:
+    """Console entry point for the ``nnsight login`` command."""
+
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="nnsight",
+        description="Command line tools for nnsight.",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+    subparsers.add_parser("login", help="Store your NDIF API key.")
+
+    args = parser.parse_args()
+
+    if args.command == "login":
+        login()
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

This resolves #506 by adding a way to store your NDIF API key from the command line or from a notebook, in the same spirit as the HuggingFace login flow.

You can now run `nnsight login` in a terminal and get prompted for your key, or call `from nnsight import login` and run `login()` in a notebook.

## How it works

The new `src/nnsight/login.py` holds a small `login` helper. When called with no argument it prompts for the key with `getpass`, so the key is never echoed to the screen. It then persists the key through the existing `CONFIG.set_default_api_key`, which already writes `config.yaml`, so future sessions pick the key up automatically. Passing the key directly as `login("my-key")` skips the prompt, and empty input is a safe no-op that saves nothing.

The same module exposes a `main` function that backs a new `nnsight` console command with a `login` subcommand, built with `argparse` to match the style of the existing `nnsight-serve` CLI.

Three edits make this work. The helper lives in `src/nnsight/login.py`. The package exports it with one new line in `src/nnsight/__init__.py` so `from nnsight import login` resolves. A new `[project.scripts]` section in `pyproject.toml` registers `nnsight = "nnsight.login:main"`, which is the first console script for this package.

## Verification

I installed the package editable in a clean virtual environment and confirmed the following against the real install. The import `from nnsight import login` works. Calling `login()` with `getpass` patched to a dummy key updates `CONFIG.API.APIKEY` and writes that key into `config.yaml`. Passing the key explicitly persists it too, and whitespace only input leaves the stored key untouched. The console script is registered as a `console_scripts` entry point, and `nnsight --help` lists the `login` subcommand while `nnsight login` prompts for the key. The change is minimal and the new module is clean under both black and isort.

## Usage

```
$ nnsight login
Enter your NDIF API key:
NDIF API key saved.
```

```python
from nnsight import login
login()
```

Closes #506
