### PR TITLE
Fix MissedProviderError in .backward() with multiple invokers (#664)

### DIFF
--- a/src/nnsight/intervention/batching.py
+++ b/src/nnsight/intervention/batching.py
@@ -272,7 +272,13 @@ class Batcher:
         batch_start, batch_size = batch_group
 
         if acts.shape[0] == self.total_batch_size:
-            return acts.narrow(0, batch_start, batch_size)
+            view = acts.narrow(0, batch_start, batch_size)
+            # Tag the view so a backward hook registered on it can be redirected
+            # to the full-batch parent tensor, which is the tensor actually in
+            # the loss graph. Without this, gradients for batched invokes are
+            # never computed for the view (see wrap_grad in tracing/backwards.py).
+            view._nnsight_batch_group = (batch_start, batch_size)
+            return view
 
         return acts
 

--- a/src/nnsight/intervention/tracing/backwards.py
+++ b/src/nnsight/intervention/tracing/backwards.py
@@ -17,9 +17,15 @@ def wrap_grad(interleaver: Interleaver):
 
     def wrap(tensor: torch.Tensor):
 
-        # Only wrap the tensor once
-        if tensor._backward_hooks:
-            return
+        # When two or more invokes share an input, the Batcher delivers each
+        # invoke a storage-sharing view (`tensor.narrow(0, start, size)`) of the
+        # full-batch activation. That view is never an input to any op producing
+        # the loss, so a hook on it never fires. The Batcher tags such views with
+        # their batch slice; redirect the hook to the full-batch parent and
+        # narrow the gradient to this invoke's slice. The parent IS in the loss
+        # graph, so its hook fires. (See Batcher._narrow in ../batching.py.)
+        batch_group = getattr(tensor, "_nnsight_batch_group", None)
+        redirect = batch_group is not None and tensor._base is not None
 
         # We are providing the grad of the tensor
         provider = id(tensor)
@@ -27,22 +33,62 @@ def wrap_grad(interleaver: Interleaver):
         # Well need to remove the hook
         hook = None
 
-        # On backwards for this tensor
-        def inner(grad: torch.Tensor):
+        if redirect:
 
-            # Inject the grad value
-            # Possibly editing it in the process
-            try:
-                grad = interleaver.handle(f"{provider}.grad", grad)
-            finally:
-                hook.remove()
+            # Only wrap the view once.
+            if getattr(tensor, "_nnsight_grad_wrapped", False):
+                return
 
-            return grad
+            target = tensor._base
+
+            # The parent gradient has the same shape and (contiguous) layout as
+            # the parent tensor, so this invoke's slice is recovered by re-applying
+            # the view's own geometry. This is general: the parent may be the
+            # flattened (batch*seq, hidden) activation, not (batch, seq, hidden).
+            shape, stride, offset = tensor.shape, tensor.stride(), tensor.storage_offset()
+
+            # On backwards for the parent tensor
+            def inner(grad: torch.Tensor):
+
+                # Slice out this invoke's gradient, let the user read/edit it,
+                # and splice any edit back into the parent gradient.
+                try:
+                    sliced = grad.as_strided(shape, stride, offset)
+                    new_sliced = interleaver.handle(f"{provider}.grad", sliced)
+                    if new_sliced is not sliced:
+                        grad = grad.clone()
+                        grad.as_strided(shape, stride, offset).copy_(new_sliced)
+                finally:
+                    hook.remove()
+
+                return grad
+
+        else:
+
+            # Only wrap the tensor once
+            if tensor._backward_hooks:
+                return
+
+            target = tensor
+
+            # On backwards for this tensor
+            def inner(grad: torch.Tensor):
+
+                # Inject the grad value
+                # Possibly editing it in the process
+                try:
+                    grad = interleaver.handle(f"{provider}.grad", grad)
+                finally:
+                    hook.remove()
+
+                return grad
 
         # Register the hook and track it on the owning mediator so
         # Interleaver.cancel can clean it up if the worker thread dies
         # before the hook fires.
-        hook = tensor.register_hook(inner)
+        hook = target.register_hook(inner)
+        if redirect:
+            tensor._nnsight_grad_wrapped = True
         mediator = interleaver.current
         if mediator is not None:
             mediator.hooks.append(hook)

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -277,6 +277,51 @@ class TestGradients:
 
         assert not torch.all(hidden_states_grad1.eq(hidden_states_grad2))
 
+    def test_backward_with_multiple_invokers(self, gpt2: nnsight.LanguageModel):
+        """Regression for #664: a gradient requested inside a batched invoke.
+
+        With two or more invokes sharing an input, each invoke's module output
+        is a storage-sharing view of the full batch; a backward hook on that view
+        never fires, raising MissedProviderError. The grad must (a) be provided
+        and (b) match the gradient computed for the same input in a single invoke.
+        """
+        prompt = "The quick brown fox jumps"
+
+        # Reference: single invoke, no batching.
+        with gpt2.trace() as tracer:
+            with tracer.invoke(prompt):
+                ref_x = gpt2.transformer.h[5].attn.c_proj.output
+                with gpt2.lm_head.output.sum().backward():
+                    ref_grad = ref_x.grad.save()
+
+        # Two invokes share the input -> batching views in invoke 2.
+        with gpt2.trace() as tracer:
+            with tracer.invoke(prompt):
+                gpt2.lm_head.output.save()
+            with tracer.invoke(prompt):
+                batched_x = gpt2.transformer.h[5].attn.c_proj.output
+                with gpt2.lm_head.output.sum().backward():
+                    batched_grad = batched_x.grad.save()
+            _test_serialize(tracer)
+
+        assert batched_grad is not None
+        assert torch.allclose(ref_grad, batched_grad, atol=1e-5)
+
+    def test_grad_edit_with_multiple_invokers(self, gpt2: nnsight.LanguageModel):
+        """Editing a gradient inside a batched invoke must be applied (#664)."""
+        prompt = "The quick brown fox jumps"
+        with gpt2.trace() as tracer:
+            with tracer.invoke(prompt):
+                gpt2.lm_head.output.save()
+            with tracer.invoke(prompt):
+                x = gpt2.transformer.h[5].attn.c_proj.output
+                with gpt2.lm_head.output.sum().backward():
+                    grad_before = x.grad.clone().save()
+                    x.grad = x.grad * 3.0
+                    grad_after = x.grad.save()
+
+        assert torch.allclose(grad_after, grad_before * 3.0, atol=1e-5)
+
     def test_external_tensors(self, gpt2: nnsight.LanguageModel):
         """Test using external tensors in trace."""
         device = next(gpt2.parameters())


### PR DESCRIPTION
## Summary

Fixes #664 — `MissedProviderError` when accessing `.grad` inside a `.backward()` block in an invoke when **two or more invokes share an input**.

## Root cause

With a single invoke, `Batcher.narrow()` returns the module-output tensor unchanged, and that tensor is in the loss graph, so the backward hook fires. With **two or more invokes**, `needs_batching` becomes true and `Batcher._narrow()` returns a storage-sharing view (`acts.narrow(0, start, size)`) for slice delivery. That view is **never an input to any op producing the loss** — the loss flows through the full-batch parent — so PyTorch never runs a grad node for the view and the hook registered on it never fires.

## Fix

- `Batcher._narrow` tags each batch-slice view it creates with `_nnsight_batch_group`.
- `wrap_grad.wrap` detects a tagged view and registers the hook on the **parent** (`tensor._base`), which *is* in the loss graph. When the hook fires it recovers this invoke's slice from the parent gradient with `grad.as_strided(view.shape, view.stride(), view.storage_offset())`, hands it to the mediator, and — if the user edited the gradient (a swap) — splices the edit back into the parent gradient.

Using the view's own `as_strided` geometry (rather than `narrow(0, …)`) is necessary because the parent is the **flattened** `(batch*seq, hidden)` activation, not `(batch, seq, hidden)` — so a naive dim-0 narrow selects the wrong rows.

The redirect is gated on the Batcher's tag, so it applies **only** to batcher-created views. User-constructed views keep the previous behaviour (hook on the tensor directly), which sidesteps the ambiguity raised in the issue's "open question" about user-built views that participate in the loss directly.

## Testing

Added two regression tests to `TestGradients` in `tests/test_lm.py`, run on CPU:

- `test_backward_with_multiple_invokers` — reproduces the issue scenario and asserts the batched-invoke gradient (a) is provided and (b) **numerically equals** the single-invoke gradient for the same input.
- `test_grad_edit_with_multiple_invokers` — assigning `x.grad = x.grad * 3` inside a batched invoke is applied.

```
pytest tests/test_lm.py::TestGradients tests/test_lm.py::TestInvokerBatching --device cpu
# 10 passed
```

All existing gradient and invoker-batching tests continue to pass (no regression).
