### PR TITLE
fix(language): derive position_ids from the mask for left-padded batches

### DIFF
--- a/src/nnsight/modeling/language.py
+++ b/src/nnsight/modeling/language.py
@@ -279,6 +279,33 @@ class LanguageModel(TransformersModel):
         "verbose",
     }
 
+    def _supply_left_pad_position_ids(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+        """Supply mask-derived ``position_ids`` for a left-padded batch.
+
+        When the tokenizer left-pads a multi-row batch, a bare ``forward`` defaults ``position_ids``
+        to a mask-blind ``arange``, so a padded (shorter) row's real tokens are assigned absolute
+        positions shifted by the pad count. Models with learned absolute position embeddings (the
+        GPT-2 family) then read the wrong position vector and silently mispredict every prompt
+        shorter than the longest one in the batch. Deriving ``position_ids`` from the attention mask
+        — exactly what ``generate`` does — keeps each real token at its true 0-based position.
+        Relative-position models (RoPE/ALiBi) are unaffected by the shift, and correct
+        ``position_ids`` are a harmless no-op for them.
+
+        No-op unless the tokenizer pads on the left, ``position_ids`` was not already supplied, and
+        an ``attention_mask`` with actual padding is present.
+        """
+        if self.tokenizer.padding_side != "left":
+            return kwargs
+        if kwargs.get("position_ids", None) is not None:
+            return kwargs
+        mask = kwargs.get("attention_mask", None)
+        if not isinstance(mask, torch.Tensor) or mask.dim() != 2 or bool(mask.all()):
+            return kwargs
+        position_ids = mask.long().cumsum(-1) - 1
+        position_ids.masked_fill_(mask == 0, 0)
+        kwargs["position_ids"] = position_ids
+        return kwargs
+
     def _prepare_input(
         self,
         *inputs: Union[
@@ -351,11 +378,10 @@ class LanguageModel(TransformersModel):
                 "Pass a non-empty prompt or non-empty `input_ids`."
             )
 
-        return (
-            tuple(),
-            {**inputs, "labels": labels, **remaining_kwargs},
-            len(inputs["input_ids"]),
+        kwargs = self._supply_left_pad_position_ids(
+            {**inputs, "labels": labels, **remaining_kwargs}
         )
+        return (tuple(), kwargs, len(inputs["input_ids"]))
 
     def _batch(
         self,
@@ -417,11 +443,13 @@ class LanguageModel(TransformersModel):
 
         batched_inputs.pop("input_ids", None)
         batched_inputs.pop("attention_mask", None)
+        # drop any stale per-invoke position_ids; recompute below from the final combined mask
+        batched_inputs.pop("position_ids", None)
 
-        return (
-            tuple(),
-            {**new_batched_inputs, **batched_inputs, "labels": batched_labels},
+        kwargs = self._supply_left_pad_position_ids(
+            {**new_batched_inputs, **batched_inputs, "labels": batched_labels}
         )
+        return tuple(), kwargs
 
     def _remoteable_model_key(self) -> str:
         return super()._remoteable_model_key()

--- a/src/nnsight/modeling/language.py
+++ b/src/nnsight/modeling/language.py
@@ -75,11 +75,6 @@ class LanguageModel(TransformersModel):
 
         self.tokenizer: PreTrainedTokenizer = tokenizer
 
-        # The exact tensor `_supply_left_pad_position_ids` last injected. `__nnsight_generate__`
-        # strips the left-pad correction by identity against this, so an explicit user-supplied
-        # `position_ids` is never silently dropped on the generate path.
-        self._injected_position_ids: Optional[torch.Tensor] = None
-
         super().__init__(*args, automodel=automodel, **kwargs)
 
         self.generator: Envoy = LanguageModel.Generator()
@@ -198,17 +193,31 @@ class LanguageModel(TransformersModel):
 
         streamer = kwargs.pop("streamer", self.generator.streamer._module)
 
-        # The left-padded-batch position_ids correction (`_supply_left_pad_position_ids`) is for the
-        # bare-forward/trace path only. `generate` derives and advances `position_ids` itself across
-        # decode steps; a static tensor passed in would freeze the padded rows' positions and corrupt
-        # their continuation. Strip the correction — but only the exact tensor nnsight injected
-        # (matched by identity): a user-supplied `position_ids`, or a batched merge containing one,
-        # passes through to `generate` untouched.
-        if (
-            self._injected_position_ids is not None
-            and kwargs.get("position_ids", None) is self._injected_position_ids
-        ):
-            kwargs.pop("position_ids")
+        # `generate` derives and advances `position_ids` itself across decode steps, so a
+        # user-supplied `position_ids` is not supported here — reject it rather than freeze the
+        # padded rows' positions and corrupt their continuation. nnsight's own left-pad correction
+        # (added by `_supply_left_pad_position_ids`) must still be stripped so `generate` manages
+        # positions on its own. That correction is exactly the mask-derived left-pad position_ids,
+        # so strip a value that matches it (nnsight's own — or a user value identical to it, which
+        # `generate` would recompute anyway) and reject anything else. Matching by value (not object
+        # identity) survives the `.to(device)` copy applied before this runs, and a model that never
+        # injects (e.g. a VLM, which overrides input prep) rejects every user value rather than
+        # silently dropping it.
+        position_ids = kwargs.get("position_ids", None)
+        if position_ids is not None:
+            mask = kwargs.get("attention_mask", None)
+            injected = (
+                self._mask_derived_position_ids(mask)
+                if isinstance(mask, torch.Tensor) and mask.dim() == 2
+                else None
+            )
+            if injected is not None and torch.equal(position_ids, injected):
+                kwargs.pop("position_ids")
+            else:
+                raise ValueError(
+                    "Custom `position_ids` is not supported with `.generate()`: generate derives "
+                    "and advances position_ids itself across decode steps. Omit `position_ids`."
+                )
         output = self._model.generate(*args, streamer=streamer, **kwargs)
 
         if self.interleaver is not None:
@@ -308,25 +317,54 @@ class LanguageModel(TransformersModel):
         ``position_ids`` are a harmless no-op for them.
 
         This corrects the bare-forward (trace) path. ``generate`` manages ``position_ids`` itself
-        across decode steps, so ``__nnsight_generate__`` strips exactly the tensor injected here
-        (tracked via ``self._injected_position_ids``) before calling it; a user-supplied
-        ``position_ids`` is left alone on every path.
+        across decode steps, so ``__nnsight_generate__`` strips this correction (identified by
+        value, via :meth:`_mask_derived_position_ids`) before calling it.
 
         No-op unless the tokenizer pads on the left, ``position_ids`` was not already supplied, and
-        an ``attention_mask`` with actual padding is present.
+        a multi-row ``attention_mask`` with actual padding is present. Only multi-row batches are
+        corrected: a single sequence is never padded against others, and restricting injection to
+        multi-row batches lets the batched path treat any single-row ``position_ids`` as
+        unambiguously user-supplied (see :meth:`_is_user_position_ids`).
         """
         if self.tokenizer.padding_side != "left":
             return kwargs
         if kwargs.get("position_ids", None) is not None:
             return kwargs
         mask = kwargs.get("attention_mask", None)
-        if not isinstance(mask, torch.Tensor) or mask.dim() != 2 or bool(mask.all()):
+        if (
+            not isinstance(mask, torch.Tensor)
+            or mask.dim() != 2
+            or mask.shape[0] <= 1
+            or bool(mask.all())
+        ):
             return kwargs
-        position_ids = mask.long().cumsum(-1) - 1
-        position_ids.masked_fill_(mask == 0, 0)
-        kwargs["position_ids"] = position_ids
-        self._injected_position_ids = position_ids
+        kwargs["position_ids"] = self._mask_derived_position_ids(mask)
         return kwargs
+
+    @staticmethod
+    def _mask_derived_position_ids(mask: torch.Tensor) -> torch.Tensor:
+        """The left-padding ``position_ids`` for a 2D attention ``mask``.
+
+        Each real token gets its true 0-based position (``cumsum`` of the mask minus one); padded
+        slots are set to 0. This is the standard left-padding correction and the exact tensor
+        :meth:`_supply_left_pad_position_ids` injects, so ``__nnsight_generate__`` can recognize
+        nnsight's own correction by value.
+        """
+        position_ids = mask.long().cumsum(-1) - 1
+        return position_ids.masked_fill(mask == 0, 0)
+
+    @staticmethod
+    def _is_user_position_ids(position_ids: Optional[torch.Tensor]) -> bool:
+        """Whether a ``position_ids`` reaching the batched (:meth:`_batch`) path is user-supplied.
+
+        :meth:`_supply_left_pad_position_ids` only ever injects its correction for a multi-row
+        batch, and a multi-row user-supplied ``position_ids`` is already rejected up front in
+        :meth:`_prepare_input`. So any single-row ``position_ids`` arriving here is necessarily the
+        user's. (This is :meth:`_batch`-only — it is sound because that path is reached only by
+        :class:`LanguageModel`, which is the model that injects; ``__nnsight_generate__`` is shared
+        with models that never inject, so it instead matches the correction by value.)
+        """
+        return position_ids is not None and position_ids.shape[0] == 1
 
     def _prepare_input(
         self,
@@ -400,10 +438,23 @@ class LanguageModel(TransformersModel):
                 "Pass a non-empty prompt or non-empty `input_ids`."
             )
 
-        kwargs = self._supply_left_pad_position_ids(
-            {**inputs, "labels": labels, **remaining_kwargs}
-        )
-        return (tuple(), kwargs, len(inputs["input_ids"]))
+        batch_size = len(inputs["input_ids"])
+
+        kwargs = {**inputs, "labels": labels, **remaining_kwargs}
+
+        # A user-supplied `position_ids` can only be honored for a single, unpadded prompt: once a
+        # batch is left-padded, a per-prompt `position_ids` cannot be safely placed into it. Reject
+        # it here for multi-prompt invokes rather than silently dropping or mis-aligning it.
+        if kwargs.get("position_ids", None) is not None and batch_size > 1:
+            raise ValueError(
+                "Custom `position_ids` is not supported for a multi-prompt (batched) input. "
+                "nnsight left-pads the batch and derives position_ids from the attention mask; a "
+                "per-prompt position_ids cannot be safely aligned. Run each prompt in its own "
+                "trace, or omit `position_ids`."
+            )
+
+        kwargs = self._supply_left_pad_position_ids(kwargs)
+        return (tuple(), kwargs, batch_size)
 
     def _batch(
         self,
@@ -466,49 +517,28 @@ class LanguageModel(TransformersModel):
         batched_inputs.pop("input_ids", None)
         batched_inputs.pop("attention_mask", None)
 
-        # Per-invoke `position_ids` tensors can't survive re-padding as-is: their width is the
-        # old batch's, not the combined one (stale they would crash on shape mismatch, or worse,
-        # silently broadcast one invoke's positions across the whole batch). Two cases:
-        #   - every `position_ids` seen so far was nnsight's own left-pad correction, or none
-        #     existed: drop and recompute from the final combined mask.
-        #   - an invoke explicitly supplied `position_ids`: re-align each source's rows into the
-        #     combined width with the same left/right-aligned placement used for the mask above,
-        #     deriving rows without explicit ids from the combined mask. The merged tensor counts
-        #     as user-supplied — it is not stripped before `generate`.
+        # A per-invoke `position_ids` can't survive re-padding into the combined batch: its width is
+        # the source invoke's, not the combined one. nnsight's own left-pad correction (only ever
+        # injected for a multi-row batch) is meant to be dropped here and recomputed from the
+        # combined mask below. A single-row `position_ids` is therefore user-supplied (a multi-row
+        # user value is already rejected in `_prepare_input`) — reject it rather than silently drop
+        # it or mis-align it across the batch.
         old_position_ids = batched_inputs.pop("position_ids", None)
         new_position_ids = prepared_kwargs.get("position_ids", None)
 
-        purely_injected = new_position_ids is None and (
-            old_position_ids is None
-            or old_position_ids is self._injected_position_ids
+        if self._is_user_position_ids(old_position_ids) or self._is_user_position_ids(
+            new_position_ids
+        ):
+            raise ValueError(
+                "Custom `position_ids` is not supported when batching multiple invokes. nnsight "
+                "re-pads the combined batch and derives position_ids from the attention mask; a "
+                "per-invoke position_ids cannot be safely aligned. Run the prompt in its own "
+                "trace, or omit `position_ids`."
+            )
+
+        kwargs = self._supply_left_pad_position_ids(
+            {**new_batched_inputs, **batched_inputs, "labels": batched_labels}
         )
-
-        kwargs = {**new_batched_inputs, **batched_inputs, "labels": batched_labels}
-
-        if purely_injected:
-            kwargs = self._supply_left_pad_position_ids(kwargs)
-        else:
-            combined_position_ids = combined_mask.long().cumsum(-1) - 1
-            combined_position_ids.masked_fill_(combined_mask == 0, 0)
-
-            for row_start, position_ids in [
-                (0, old_position_ids),
-                (n_old, new_position_ids),
-            ]:
-                if position_ids is not None:
-                    position_ids = position_ids.to(combined_position_ids)
-                    if left:
-                        combined_position_ids[
-                            row_start : row_start + position_ids.shape[0],
-                            -position_ids.shape[1] :,
-                        ] = position_ids
-                    else:
-                        combined_position_ids[
-                            row_start : row_start + position_ids.shape[0],
-                            : position_ids.shape[1],
-                        ] = position_ids
-
-            kwargs["position_ids"] = combined_position_ids
 
         return tuple(), kwargs
 

--- a/src/nnsight/modeling/language.py
+++ b/src/nnsight/modeling/language.py
@@ -75,6 +75,11 @@ class LanguageModel(TransformersModel):
 
         self.tokenizer: PreTrainedTokenizer = tokenizer
 
+        # The exact tensor `_supply_left_pad_position_ids` last injected. `__nnsight_generate__`
+        # strips the left-pad correction by identity against this, so an explicit user-supplied
+        # `position_ids` is never silently dropped on the generate path.
+        self._injected_position_ids: Optional[torch.Tensor] = None
+
         super().__init__(*args, automodel=automodel, **kwargs)
 
         self.generator: Envoy = LanguageModel.Generator()
@@ -196,8 +201,14 @@ class LanguageModel(TransformersModel):
         # The left-padded-batch position_ids correction (`_supply_left_pad_position_ids`) is for the
         # bare-forward/trace path only. `generate` derives and advances `position_ids` itself across
         # decode steps; a static tensor passed in would freeze the padded rows' positions and corrupt
-        # their continuation, so drop it here and let `generate` handle left-padding as it already does.
-        kwargs.pop("position_ids", None)
+        # their continuation. Strip the correction — but only the exact tensor nnsight injected
+        # (matched by identity): a user-supplied `position_ids`, or a batched merge containing one,
+        # passes through to `generate` untouched.
+        if (
+            self._injected_position_ids is not None
+            and kwargs.get("position_ids", None) is self._injected_position_ids
+        ):
+            kwargs.pop("position_ids")
         output = self._model.generate(*args, streamer=streamer, **kwargs)
 
         if self.interleaver is not None:
@@ -297,7 +308,9 @@ class LanguageModel(TransformersModel):
         ``position_ids`` are a harmless no-op for them.
 
         This corrects the bare-forward (trace) path. ``generate`` manages ``position_ids`` itself
-        across decode steps, so ``__nnsight_generate__`` strips this value before calling it.
+        across decode steps, so ``__nnsight_generate__`` strips exactly the tensor injected here
+        (tracked via ``self._injected_position_ids``) before calling it; a user-supplied
+        ``position_ids`` is left alone on every path.
 
         No-op unless the tokenizer pads on the left, ``position_ids`` was not already supplied, and
         an ``attention_mask`` with actual padding is present.
@@ -312,6 +325,7 @@ class LanguageModel(TransformersModel):
         position_ids = mask.long().cumsum(-1) - 1
         position_ids.masked_fill_(mask == 0, 0)
         kwargs["position_ids"] = position_ids
+        self._injected_position_ids = position_ids
         return kwargs
 
     def _prepare_input(
@@ -451,12 +465,51 @@ class LanguageModel(TransformersModel):
 
         batched_inputs.pop("input_ids", None)
         batched_inputs.pop("attention_mask", None)
-        # drop any stale per-invoke position_ids; recompute below from the final combined mask
-        batched_inputs.pop("position_ids", None)
 
-        kwargs = self._supply_left_pad_position_ids(
-            {**new_batched_inputs, **batched_inputs, "labels": batched_labels}
+        # Per-invoke `position_ids` tensors can't survive re-padding as-is: their width is the
+        # old batch's, not the combined one (stale they would crash on shape mismatch, or worse,
+        # silently broadcast one invoke's positions across the whole batch). Two cases:
+        #   - every `position_ids` seen so far was nnsight's own left-pad correction, or none
+        #     existed: drop and recompute from the final combined mask.
+        #   - an invoke explicitly supplied `position_ids`: re-align each source's rows into the
+        #     combined width with the same left/right-aligned placement used for the mask above,
+        #     deriving rows without explicit ids from the combined mask. The merged tensor counts
+        #     as user-supplied — it is not stripped before `generate`.
+        old_position_ids = batched_inputs.pop("position_ids", None)
+        new_position_ids = prepared_kwargs.get("position_ids", None)
+
+        purely_injected = new_position_ids is None and (
+            old_position_ids is None
+            or old_position_ids is self._injected_position_ids
         )
+
+        kwargs = {**new_batched_inputs, **batched_inputs, "labels": batched_labels}
+
+        if purely_injected:
+            kwargs = self._supply_left_pad_position_ids(kwargs)
+        else:
+            combined_position_ids = combined_mask.long().cumsum(-1) - 1
+            combined_position_ids.masked_fill_(combined_mask == 0, 0)
+
+            for row_start, position_ids in [
+                (0, old_position_ids),
+                (n_old, new_position_ids),
+            ]:
+                if position_ids is not None:
+                    position_ids = position_ids.to(combined_position_ids)
+                    if left:
+                        combined_position_ids[
+                            row_start : row_start + position_ids.shape[0],
+                            -position_ids.shape[1] :,
+                        ] = position_ids
+                    else:
+                        combined_position_ids[
+                            row_start : row_start + position_ids.shape[0],
+                            : position_ids.shape[1],
+                        ] = position_ids
+
+            kwargs["position_ids"] = combined_position_ids
+
         return tuple(), kwargs
 
     def _remoteable_model_key(self) -> str:

--- a/src/nnsight/modeling/language.py
+++ b/src/nnsight/modeling/language.py
@@ -193,6 +193,11 @@ class LanguageModel(TransformersModel):
 
         streamer = kwargs.pop("streamer", self.generator.streamer._module)
 
+        # The left-padded-batch position_ids correction (`_supply_left_pad_position_ids`) is for the
+        # bare-forward/trace path only. `generate` derives and advances `position_ids` itself across
+        # decode steps; a static tensor passed in would freeze the padded rows' positions and corrupt
+        # their continuation, so drop it here and let `generate` handle left-padding as it already does.
+        kwargs.pop("position_ids", None)
         output = self._model.generate(*args, streamer=streamer, **kwargs)
 
         if self.interleaver is not None:
@@ -287,9 +292,12 @@ class LanguageModel(TransformersModel):
         positions shifted by the pad count. Models with learned absolute position embeddings (the
         GPT-2 family) then read the wrong position vector and silently mispredict every prompt
         shorter than the longest one in the batch. Deriving ``position_ids`` from the attention mask
-        — exactly what ``generate`` does — keeps each real token at its true 0-based position.
+        (the standard left-padding correction) keeps each real token at its true 0-based position.
         Relative-position models (RoPE/ALiBi) are unaffected by the shift, and correct
         ``position_ids`` are a harmless no-op for them.
+
+        This corrects the bare-forward (trace) path. ``generate`` manages ``position_ids`` itself
+        across decode steps, so ``__nnsight_generate__`` strips this value before calling it.
 
         No-op unless the tokenizer pads on the left, ``position_ids`` was not already supplied, and
         an ``attention_mask`` with actual padding is present.

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -610,64 +610,59 @@ class TestInvokerBatching:
         assert torch.equal(used.cpu(), custom)
 
     @torch.no_grad()
-    def test_user_position_ids_survive_invoker_batching(
+    def test_user_position_ids_rejected_when_batching(
         self, gpt2: nnsight.LanguageModel, ET_prompt: str
     ):
-        """Per-invoke user-supplied ``position_ids`` must survive batching with other invokes.
+        """A user-supplied ``position_ids`` is rejected for a multi-prompt / batched input.
 
-        ``_batch`` re-pads all rows to a common width, so each invoke's position_ids must be
-        re-aligned into the combined batch (placed over the row's real tokens, like the
-        attention mask), not dropped and recomputed. An invoke that did NOT supply ids gets
-        mask-derived values. Constant fill values are used so a silent fallback to the
-        mask-derived cumsum (consecutive integers) cannot masquerade as a pass.
+        Custom position_ids are only honored for a single, unpadded prompt. When batching, nnsight
+        left-pads the combined batch and re-derives position_ids from the attention mask, so a
+        per-prompt position_ids cannot be safely aligned — passing one must raise rather than be
+        silently dropped or mis-aligned across the batch. Both shapes of batching are covered: a
+        single invoke holding multiple prompts, and multiple single-prompt invokes one of which
+        supplies position_ids.
         """
-        short = "Hello world"            # fewer tokens -> left-padded in the batch
+        short = "Hello world"
         long = ET_prompt
         n_short = gpt2.tokenizer(short, return_tensors="pt")["input_ids"].shape[1]
         n_long = gpt2.tokenizer(long, return_tensors="pt")["input_ids"].shape[1]
-        custom_short = torch.full((1, n_short), 7, dtype=torch.long)
-        custom_long = torch.full((1, n_long), 9, dtype=torch.long)
 
-        # both invokes supply ids: each row carries its values, right-aligned over real tokens
-        with gpt2.trace() as tracer:
-            with tracer.invoke(short, position_ids=custom_short):
-                used_short = gpt2.transformer.wpe.input.save()
-            with tracer.invoke(long, position_ids=custom_long):
-                used_long = gpt2.transformer.wpe.input.save()
+        # one invoke holding two prompts, with position_ids for the (left-padded) batch
+        with pytest.raises(ValueError):
+            with gpt2.trace(
+                [short, long], position_ids=torch.zeros(2, n_long, dtype=torch.long)
+            ):
+                gpt2.lm_head.output.save()
 
-        pad = n_long - n_short
-        expected_short = torch.cat(
-            [torch.zeros(pad, dtype=torch.long), custom_short[0]]
-        ).unsqueeze(0)
-        assert torch.equal(used_short.cpu(), expected_short)
-        assert torch.equal(used_long.cpu(), custom_long)
-
-        # only one invoke supplies ids: the other row falls back to mask-derived positions
-        with gpt2.trace() as tracer:
-            with tracer.invoke(short, position_ids=custom_short):
-                used_short = gpt2.transformer.wpe.input.save()
-            with tracer.invoke(long):
-                used_long = gpt2.transformer.wpe.input.save()
-
-        assert torch.equal(used_short.cpu(), expected_short)
-        assert torch.equal(used_long.cpu(), torch.arange(n_long).unsqueeze(0))
+        # two single-prompt invokes, one supplying position_ids, batched together
+        with pytest.raises(ValueError):
+            with gpt2.trace() as tracer:
+                with tracer.invoke(
+                    short, position_ids=torch.zeros(1, n_short, dtype=torch.long)
+                ):
+                    gpt2.lm_head.output.save()
+                with tracer.invoke(long):
+                    gpt2.lm_head.output.save()
 
     @torch.no_grad()
-    def test_user_position_ids_reach_generate(self, gpt2: nnsight.LanguageModel):
-        """A user-supplied ``position_ids`` must pass through to ``generate``.
+    def test_user_position_ids_rejected_in_generate(self, gpt2: nnsight.LanguageModel):
+        """A user-supplied ``position_ids`` is rejected on the ``generate`` path.
 
-        ``__nnsight_generate__`` strips the auto-injected left-pad correction (a static tensor
-        would freeze decode positions), but it must strip only the exact tensor nnsight injected —
-        identity-matched — never an explicit user value.
+        ``generate`` derives and advances position_ids itself across decode steps, so a static
+        user tensor would freeze the decode positions. Passing one must raise rather than be
+        honored or silently dropped. (nnsight's own left-pad correction, injected only for a
+        multi-row batch, is still stripped here — that path is exercised by
+        ``test_batched_generation_matches_single_prompt``.)
         """
         prompt = "Hello world"
         n = gpt2.tokenizer(prompt, return_tensors="pt")["input_ids"].shape[1]
         custom = torch.full((1, n), 5, dtype=torch.long)
 
-        with gpt2.generate(prompt, position_ids=custom, max_new_tokens=1, do_sample=False):
-            used = gpt2.transformer.wpe.input.save()
-
-        assert torch.equal(used.cpu(), custom)
+        with pytest.raises(ValueError):
+            with gpt2.generate(
+                prompt, position_ids=custom, max_new_tokens=1, do_sample=False
+            ):
+                gpt2.generator.output.save()
 
     @torch.no_grad()
     def test_invoker_input_ids(self, gpt2: nnsight.LanguageModel):

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -567,6 +567,32 @@ class TestInvokerBatching:
         assert torch.equal(batched[1].argmax(-1), long_alone[0].argmax(-1))
 
     @torch.no_grad()
+    def test_batched_generation_matches_single_prompt(
+        self, gpt2: nnsight.LanguageModel, ET_prompt: str
+    ):
+        """Mixed-length batched generation must produce the same continuation for a prompt as
+        generating it alone.
+
+        The left-padded-batch ``position_ids`` correction is for the bare-forward (trace) path only.
+        ``generate`` derives and advances ``position_ids`` itself across decode steps, so if the
+        correction leaks into ``generate`` the padded row's positions freeze and its decode diverges.
+        This guards that the correction is stripped before ``generate`` (the trace fix must not break
+        generation)."""
+        short = "Hello world"           # fewer tokens -> left-padded in the batch
+        long = ET_prompt
+
+        with gpt2.generate(max_new_tokens=8, do_sample=False) as tracer:
+            with tracer.invoke([short, long]):
+                batched = gpt2.generator.output.save()
+        with gpt2.generate(max_new_tokens=8, do_sample=False) as tracer:
+            with tracer.invoke(short):
+                single = gpt2.generator.output.save()
+
+        # the last 8 columns are the newly generated tokens; the padded (short) row must match
+        # the standalone run token-for-token.
+        assert torch.equal(batched[0, -8:], single[0, -8:])
+
+    @torch.no_grad()
     def test_invoker_input_ids(self, gpt2: nnsight.LanguageModel):
         """Test that input IDs are copied when batching."""
         with gpt2.trace() as tracer:

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -537,6 +537,36 @@ class TestInvokerBatching:
         assert torch.allclose(list_logits3, invoke_logits3, atol=1e-5)
 
     @torch.no_grad()
+    def test_batched_positions_match_single_prompt(
+        self, gpt2: nnsight.LanguageModel, ET_prompt: str
+    ):
+        """A prompt's next-token logits in a mixed-length batch must match running it alone.
+
+        The batch is left-padded, so a shorter prompt's real tokens land at shifted positions unless
+        ``position_ids`` are derived from the attention mask. Without that, GPT-2's learned absolute
+        position embeddings make the padded row's logits diverge from the single-prompt result — a
+        silent per-prompt error. This is a stronger check than ``test_invoke_list_attention_mask``,
+        which compares batched paths to each other: both share the same padding, so they agree even
+        when both are wrong. The single-prompt run is the real ground truth.
+        """
+        short = "Hello world"            # fewer tokens -> left-padded in the batch
+        long = ET_prompt
+
+        with gpt2.trace([short, long]):
+            batched = gpt2.lm_head.output[:, -1].save()        # [2, vocab]
+        with gpt2.trace(short):
+            short_alone = gpt2.lm_head.output[:, -1].save()    # [1, vocab]
+        with gpt2.trace(long):
+            long_alone = gpt2.lm_head.output[:, -1].save()
+
+        # the padded (shorter) row is the one the position shift corrupts
+        assert (batched[0] - short_alone[0]).abs().max() < 1e-1
+        assert torch.equal(batched[0].argmax(-1), short_alone[0].argmax(-1))
+        # the longest (unpadded) row is unaffected either way; check it stays correct
+        assert (batched[1] - long_alone[0]).abs().max() < 1e-1
+        assert torch.equal(batched[1].argmax(-1), long_alone[0].argmax(-1))
+
+    @torch.no_grad()
     def test_invoker_input_ids(self, gpt2: nnsight.LanguageModel):
         """Test that input IDs are copied when batching."""
         with gpt2.trace() as tracer:

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -593,6 +593,83 @@ class TestInvokerBatching:
         assert torch.equal(batched[0, -8:], single[0, -8:])
 
     @torch.no_grad()
+    def test_user_position_ids_respected_in_trace(self, gpt2: nnsight.LanguageModel):
+        """An explicitly user-supplied ``position_ids`` must reach the model unchanged.
+
+        The left-pad correction only fills in *missing* position_ids; a researcher passing
+        their own (e.g. to probe position sensitivity) must see exactly those values at the
+        position-embedding lookup (``wpe`` receives the position_ids tensor as its input).
+        """
+        prompt = "Hello world"
+        n = gpt2.tokenizer(prompt, return_tensors="pt")["input_ids"].shape[1]
+        custom = torch.full((1, n), 5, dtype=torch.long)
+
+        with gpt2.trace(prompt, position_ids=custom):
+            used = gpt2.transformer.wpe.input.save()
+
+        assert torch.equal(used.cpu(), custom)
+
+    @torch.no_grad()
+    def test_user_position_ids_survive_invoker_batching(
+        self, gpt2: nnsight.LanguageModel, ET_prompt: str
+    ):
+        """Per-invoke user-supplied ``position_ids`` must survive batching with other invokes.
+
+        ``_batch`` re-pads all rows to a common width, so each invoke's position_ids must be
+        re-aligned into the combined batch (placed over the row's real tokens, like the
+        attention mask), not dropped and recomputed. An invoke that did NOT supply ids gets
+        mask-derived values. Constant fill values are used so a silent fallback to the
+        mask-derived cumsum (consecutive integers) cannot masquerade as a pass.
+        """
+        short = "Hello world"            # fewer tokens -> left-padded in the batch
+        long = ET_prompt
+        n_short = gpt2.tokenizer(short, return_tensors="pt")["input_ids"].shape[1]
+        n_long = gpt2.tokenizer(long, return_tensors="pt")["input_ids"].shape[1]
+        custom_short = torch.full((1, n_short), 7, dtype=torch.long)
+        custom_long = torch.full((1, n_long), 9, dtype=torch.long)
+
+        # both invokes supply ids: each row carries its values, right-aligned over real tokens
+        with gpt2.trace() as tracer:
+            with tracer.invoke(short, position_ids=custom_short):
+                used_short = gpt2.transformer.wpe.input.save()
+            with tracer.invoke(long, position_ids=custom_long):
+                used_long = gpt2.transformer.wpe.input.save()
+
+        pad = n_long - n_short
+        expected_short = torch.cat(
+            [torch.zeros(pad, dtype=torch.long), custom_short[0]]
+        ).unsqueeze(0)
+        assert torch.equal(used_short.cpu(), expected_short)
+        assert torch.equal(used_long.cpu(), custom_long)
+
+        # only one invoke supplies ids: the other row falls back to mask-derived positions
+        with gpt2.trace() as tracer:
+            with tracer.invoke(short, position_ids=custom_short):
+                used_short = gpt2.transformer.wpe.input.save()
+            with tracer.invoke(long):
+                used_long = gpt2.transformer.wpe.input.save()
+
+        assert torch.equal(used_short.cpu(), expected_short)
+        assert torch.equal(used_long.cpu(), torch.arange(n_long).unsqueeze(0))
+
+    @torch.no_grad()
+    def test_user_position_ids_reach_generate(self, gpt2: nnsight.LanguageModel):
+        """A user-supplied ``position_ids`` must pass through to ``generate``.
+
+        ``__nnsight_generate__`` strips the auto-injected left-pad correction (a static tensor
+        would freeze decode positions), but it must strip only the exact tensor nnsight injected —
+        identity-matched — never an explicit user value.
+        """
+        prompt = "Hello world"
+        n = gpt2.tokenizer(prompt, return_tensors="pt")["input_ids"].shape[1]
+        custom = torch.full((1, n), 5, dtype=torch.long)
+
+        with gpt2.generate(prompt, position_ids=custom, max_new_tokens=1, do_sample=False):
+            used = gpt2.transformer.wpe.input.save()
+
+        assert torch.equal(used.cpu(), custom)
+
+    @torch.no_grad()
     def test_invoker_input_ids(self, gpt2: nnsight.LanguageModel):
         """Test that input IDs are copied when batching."""
         with gpt2.trace() as tracer:


### PR DESCRIPTION
Base: dev
Branch: fix/batched-position-ids
Closes: #672 

---

`LanguageModel` left-pads multi-prompt batches but never supplies `position_ids`, so models with learned absolute position embeddings (GPT-2 family) read shifted position embeddings for the padded rows and **silently mispredict every prompt shorter than the longest** in the batch. No error is raised. (Details, severity measurements, and scope are in the linked issue.)

## Change

Adds `LanguageModel._supply_left_pad_position_ids`, called from `_prepare_input` and `_batch`, which derives `position_ids` from the attention mask (`cumsum(-1) - 1`, padded positions → 0) — the same correction `generate()` applies via `prepare_inputs_for_generation`.

Conservative by design — it is a no-op unless:
- the tokenizer pads on the **left**,
- `position_ids` was **not** already supplied, and
- an `attention_mask` with **actual padding** is present (relative-position models are unaffected by the shift, but correct `position_ids` are a harmless no-op for them).

`_batch` additionally drops any stale per-invoke `position_ids` and recomputes from the final combined mask. `VisionLanguageModel` overrides both `_prepare_input` and `_batch`, so its mrope / image-token handling is untouched.

## Test

`tests/test_lm.py::TestInvokerBatching::test_batched_positions_match_single_prompt` — a prompt's next-token logits in a mixed-length batch must match running it alone.

This is a stronger check than the existing `test_invoke_list_attention_mask`, which only compares batched paths to each other: both share the same left-padding, so they agree even when both are wrong. The single-prompt run is the real ground truth.

## Notes

- Scoped to text-only `LanguageModel`; VLM is untouched (it overrides the two methods).
- Affects only mixed-length batches on absolute-position models; single-prompt traces, `.generate()`, RoPE/ALiBi models, and the vLLM backend are unchanged.