### PR TITLE
Clarify logit lens heatmap token labels

### DIFF
--- a/docs/patterns/logit-lens.md
+++ b/docs/patterns/logit-lens.md
@@ -87,6 +87,35 @@ for i, p in enumerate(target_probs):
     print(f"layer {i:2d}: P({target!r}) = {p.item():.3f}")
 ```
 
+### Token labels for heatmaps
+
+If you plot per-token logit lens values, tokenize the prompt outside the trace to
+build x-axis labels. This keeps the plotting code independent of trace internals:
+
+```python
+token_ids = model.tokenizer(prompt, return_tensors="pt")["input_ids"][0]
+token_labels = [model.tokenizer.decode([int(token_id)]) for token_id in token_ids]
+```
+
+Assume `layer_token_scores` is a `[layers, sequence]` array of values to plot.
+Use numeric x positions for Plotly heatmaps, then display the token strings as
+tick labels. That keeps repeated tokens in separate columns:
+
+```python
+import plotly.express as px
+
+x_positions = list(range(len(token_labels)))
+
+fig = px.imshow(
+    layer_token_scores,
+    x=x_positions,
+    y=list(range(layer_token_scores.shape[0])),
+    labels={"x": "input token", "y": "layer", "color": "score"},
+)
+fig.update_xaxes(tickmode="array", tickvals=x_positions, ticktext=token_labels)
+fig.show()
+```
+
 ### Tuned lens (use a learned linear map per layer)
 
 If you have a tuned-lens checkpoint with one affine map `A_L` per layer, replace `model.transformer.ln_f(hs)` with `A_L(hs)`:


### PR DESCRIPTION
Summary
- Build token labels by tokenizing the prompt outside the trace
- Use numeric Plotly x positions with token text labels so duplicate tokens stay separate

Verification
- /Users/joyyang/Projects/open-source/.venv/nnsight/bin/python -m pytest tests/test_tiny.py --device cpu -x
- Markdown code fence count is balanced

Addresses #448
Addresses #462