### PR TITLE
Fix cache navigation through collapsing/re-mount renames

### DIFF
--- a/src/nnsight/intervention/tracing/tracer.py
+++ b/src/nnsight/intervention/tracing/tracer.py
@@ -99,30 +99,45 @@ class Cache:
             # (e.g. translating root key ``"model"`` → ``"transformer"``,
             # which is not in storage).
             super().__init__()
-            if data:
+            # Use the raw dict length, not the ``_path``-scoped ``__len__``:
+            # an alias-space sub-view (from a collapsing/re-mount rename) has a
+            # scoped length of 0 because no real key lives under its alias path,
+            # yet its full storage must still propagate to deeper children.
+            if dict.__len__(data):
                 for k in dict.__iter__(data):
                     dict.__setitem__(self, k, dict.__getitem__(data, k))
+
+        def _resolved_path(self):
+            """Resolve ``_path`` to a real storage key.
+
+            When navigation lands on an aliased path produced by a
+            collapsing/re-mount rename (e.g. ``"model.layers.0"`` from
+            ``rename={"model.layers": "layers"}``), the underlying storage key
+            is the un-renamed path (``"model.transformer.h.0"``). ``_alias_paths``
+            maps the former to the latter; real paths pass through unchanged.
+            """
+            return self._alias_paths.get(self._path, self._path)
 
         @property
         def output(self):
             """
             Returns the output attribute from the Cache.Entry at the current path.
             """
-            return dict.__getitem__(self, self._path).output
+            return dict.__getitem__(self, self._resolved_path()).output
 
         @property
         def inputs(self):
             """
             Returns the inputs attribute from the Cache.Entry at the current path.
             """
-            return dict.__getitem__(self, self._path).inputs
+            return dict.__getitem__(self, self._resolved_path()).inputs
 
         @property
         def input(self):
             """
             Returns the input property from the Cache.Entry at the current path.
             """
-            return dict.__getitem__(self, self._path).input
+            return dict.__getitem__(self, self._resolved_path()).input
 
         def _scoped_iter(self):
             """Iterate keys visible at the current ``_path`` scope.
@@ -183,13 +198,48 @@ class Cache:
             )
             return f"{{{body}}}"
 
+        def _child(self, path):
+            """Build a sub-view CacheDict scoped at ``path``."""
+            return Cache.CacheDict(
+                self,
+                path,
+                rename=self._rename,
+                alias=self._alias,
+                alias_paths=self._alias_paths,
+            )
+
+        def _alias_path_prefix(self, path):
+            """True if ``path`` is an alias path or a prefix of one.
+
+            Lets attribute/index navigation walk the authoritative
+            ``_alias_paths`` keyspace segment by segment, which is required for
+            collapsing/re-mount renames whose alias path (``"model.layers.0"``)
+            is not a prefix of any real storage key (``"model.transformer.h.0"``).
+            """
+            return any(
+                key == path or key.startswith(path + ".") for key in self._alias_paths
+            )
+
         def _add_alias_path(self, module_path):
             if self._rename:
-                alias_path = str(module_path)
+                # The root component (``cache.model``) is the fixed cache root
+                # and is never renamed in access space, so protect it from the
+                # substring replacements below. Without this a rename like
+                # ``{"model": "foo"}`` would also rewrite the root segment
+                # (``model.model.layers.0`` -> ``foo.foo.layers.0``) and the
+                # user-facing ``cache.model.foo.layers[0]`` would never match.
+                root, _, rest = str(module_path).partition(".")
+
+                if rest == "":
+                    return
+
+                alias_rest = rest
 
                 for path, alias in self._rename.items():
                     path = path.removeprefix(".")
-                    alias_path = alias_path.replace(path, alias)
+                    alias_rest = alias_rest.replace(path, alias)
+
+                alias_path = root + "." + alias_rest
 
                 if alias_path != module_path:
                     self._alias_paths[alias_path] = module_path
@@ -213,14 +263,10 @@ class Cache:
             if isinstance(name, int):
                 path = self._path + "." + f"{name}"
 
-                if any(key.startswith(path) for key in self):
-                    return Cache.CacheDict(
-                        self,
-                        path,
-                        rename=self._rename,
-                        alias=self._alias,
-                        alias_paths=self._alias_paths,
-                    )
+                if any(key.startswith(path) for key in self) or self._alias_path_prefix(
+                    path
+                ):
+                    return self._child(path)
                 elif any(
                     key.startswith(self._path + ".")
                     and len(key) >= len(self._path) + 1
@@ -236,22 +282,31 @@ class Cache:
         def __getattr__(self, attr: str):
             path = self._path + "." + attr if self._path != "" else attr
 
+            # (1) Direct route: ``path`` prefixes a real storage key.
             if any(key.startswith(path) for key in self):
-                return Cache.CacheDict(
-                    self,
-                    path,
-                    rename=self._rename,
-                    alias=self._alias,
-                    alias_paths=self._alias_paths,
-                )
-            elif self._alias and attr in self._alias:
-                name = self._alias[attr]
-                name = name.removeprefix(".")
-                return self.__getattr__(name)
-            else:
-                raise AttributeError(
-                    f"'{attr}' module path was never cached. '{self.__class__.__name__}' has no matching attribute."
-                )
+                return self._child(path)
+
+            # (2) Leaf-alias route: translate the aliased segment to its
+            #     underlying name and keep navigating in real-path space. If
+            #     that dead-ends (e.g. the alias value is a re-mount rooted
+            #     elsewhere, as with collapsing renames), fall through to the
+            #     alias-path route rather than raising.
+            if self._alias and attr in self._alias:
+                name = self._alias[attr].removeprefix(".")
+                try:
+                    return self.__getattr__(name)
+                except AttributeError:
+                    pass
+
+            # (3) Alias-path route: ``path`` prefixes an authoritative alias
+            #     path. Handles collapsing/re-mount renames whose alias path is
+            #     absent from the real storage keys.
+            if self._alias_path_prefix(path):
+                return self._child(path)
+
+            raise AttributeError(
+                f"'{attr}' module path was never cached. '{self.__class__.__name__}' has no matching attribute."
+            )
 
         def __getstate__(self):
             return self.__dict__.copy()

--- a/src/nnsight/intervention/tracing/tracer.py
+++ b/src/nnsight/intervention/tracing/tracer.py
@@ -262,16 +262,22 @@ class Cache:
 
             if isinstance(name, int):
                 path = self._path + "." + f"{name}"
+                prefix = self._path + "."
 
                 if any(key.startswith(path) for key in self) or self._alias_path_prefix(
                     path
                 ):
                     return self._child(path)
+                # Out-of-bounds on a modulelist: a sibling numeric index exists
+                # under ``_path`` but ``name`` isn't one of them. Check both the
+                # real keys and the alias-path keyspace so renamed/collapsed
+                # modulelists raise ``IndexError`` rather than leaking a
+                # ``KeyError`` from the ``dict.__getitem__`` fallback below.
                 elif any(
-                    key.startswith(self._path + ".")
-                    and len(key) >= len(self._path) + 1
-                    and key[len(self._path) + 1].isdigit()
-                    for key in self
+                    key.startswith(prefix)
+                    and len(key) > len(prefix)
+                    and key[len(prefix)].isdigit()
+                    for key in (*self, *self._alias_paths)
                 ):
                     raise IndexError(
                         f"Index {key} is out of bounds for modulelist or module does not allow indexing."

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -1294,6 +1294,52 @@ class TestCache:
             cache.model.model.h["second_layer"].output,
         )
 
+    @torch.no_grad()
+    def test_cache_collapsing_rename(self, MSG_prompt: str):
+        """Attribute access through a collapsing / re-mount rename (issue #535).
+
+        A rename whose key is a dotted path (e.g. ``"model.layers": "layers"``)
+        re-mounts a nested module at the root. The renamed access path
+        (``cache.model.layers[i]``) is not a prefix of any real storage key, so
+        it must resolve through the alias-path map rather than the real keys.
+        """
+        gpt2 = nnsight.LanguageModel(
+            "openai-community/gpt2",
+            rename={"transformer": "model", "h": "layers", "model.layers": "layers"},
+        )
+
+        with gpt2.trace(MSG_prompt) as tracer:
+            cache = tracer.cache(modules=[l for l in gpt2.layers[::2]]).save()
+
+        for i in range(0, 12, 2):
+            # dict-style (real key) and attribute-style (renamed) must agree.
+            assert torch.equal(
+                cache[f"model.transformer.h.{i}"].output,
+                cache.model.layers[i].output,
+            )
+
+    @torch.no_grad()
+    def test_cache_rename_preserves_root(self, MSG_prompt: str):
+        """A rename matching the root component name must not corrupt the root.
+
+        With ``rename={"model": "foo"}`` the real key ``model.model.layers.0``
+        must alias to ``model.foo.layers.0`` (renaming only the nested
+        ``model``), not ``foo.foo.layers.0`` — the ``cache.model`` root is fixed
+        (issue #535, original example).
+        """
+        lm = nnsight.LanguageModel(
+            "yujiepan/llama-3.2-tiny-random",
+            rename={"model": "foo", "model.language_model": "foo"},
+        )
+
+        with lm.trace(MSG_prompt) as tracer:
+            cache = tracer.cache(modules=[lm.foo.layers[0]]).save()
+
+        assert torch.equal(
+            cache["model.model.layers.0"].output[0],
+            cache.model.foo.layers[0].output[0],
+        )
+
 
 # =============================================================================
 # Module Renaming

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -1308,8 +1308,12 @@ class TestCache:
             rename={"transformer": "model", "h": "layers", "model.layers": "layers"},
         )
 
+        # Explicit subset (strided) with inputs, exercising ``.output``,
+        # ``.input`` and out-of-bounds indexing through the renamed path.
         with gpt2.trace(MSG_prompt) as tracer:
-            cache = tracer.cache(modules=[l for l in gpt2.layers[::2]]).save()
+            cache = tracer.cache(
+                modules=[l for l in gpt2.layers[::2]], include_inputs=True
+            ).save()
 
         for i in range(0, 12, 2):
             # dict-style (real key) and attribute-style (renamed) must agree.
@@ -1317,6 +1321,25 @@ class TestCache:
                 cache[f"model.transformer.h.{i}"].output,
                 cache.model.layers[i].output,
             )
+            assert torch.equal(
+                cache[f"model.transformer.h.{i}"].input,
+                cache.model.layers[i].input,
+            )
+
+        # Out-of-bounds on the renamed modulelist must raise IndexError, not
+        # leak a KeyError from the underlying dict.
+        with pytest.raises(IndexError):
+            cache.model.layers[999]
+
+        # Full cache (no ``modules=``): navigating into a submodule of a
+        # re-mounted block must resolve through the alias path too.
+        with gpt2.trace(MSG_prompt) as tracer:
+            cache = tracer.cache().save()
+
+        assert torch.equal(
+            cache["model.transformer.h.0.attn"].output[0],
+            cache.model.layers[0].attn.output[0],
+        )
 
     @torch.no_grad()
     def test_cache_rename_preserves_root(self, MSG_prompt: str):


### PR DESCRIPTION
## Summary

Fixes cache attribute/index navigation when using collapsing or re-mount renames (e.g., `rename={"model.layers": "layers"}`). These renames re-mount nested modules at the root, creating alias paths that don't exist in real storage keys. The cache navigator now resolves these paths correctly through an alias-path map.

## Key Changes

- **Added `_resolved_path()` method**: Translates aliased paths (from collapsing renames) back to their real storage keys using the `_alias_paths` map.

- **Updated property accessors** (`.output`, `.inputs`, `.input`): Now use `_resolved_path()` to look up cache entries, enabling access through renamed paths.

- **Added `_alias_path_prefix()` helper**: Checks if a path is an alias path or a prefix of one, allowing segment-by-segment navigation through the alias-path keyspace.

- **Refactored `_add_alias_path()`**: Protects the root cache component from substring replacements. A rename like `{"model": "foo"}` now correctly produces `model.foo.layers.0` (not `foo.foo.layers.0`), since `cache.model` is the fixed root.

- **Enhanced `__getitem__()` (integer indexing)**: Now checks both real keys and alias-path prefixes when validating numeric indices, raising `IndexError` instead of leaking `KeyError` for out-of-bounds access on renamed module lists.

- **Refactored `__getattr__()` (attribute access)**: Implements a three-route resolution strategy:
  1. Direct route: path prefixes a real storage key
  2. Leaf-alias route: translate aliased segment and continue in real-path space
  3. Alias-path route: path prefixes an authoritative alias path (handles collapsing renames)

- **Added `_child()` helper**: Centralizes sub-view creation to reduce duplication.

## Tests

Added two new test cases:
- `test_cache_collapsing_rename`: Validates attribute/index access through collapsing renames, including `.output`, `.input`, and out-of-bounds indexing.
- `test_cache_rename_preserves_root`: Ensures renames matching the root component name don't corrupt the fixed `cache.model` root.

## Implementation Details

The core issue: when a rename like `{"model.layers": "layers"}` is applied, the user-facing access path `cache.model.layers[0]` doesn't match any real storage key (which is `model.transformer.h.0`). The fix maintains an `_alias_paths` map that records these mappings and uses it during navigation to resolve paths correctly. The three-route resolution in `__getattr__()` ensures both simple renames and complex collapsing renames work seamlessly.

https://claude.ai/code/session_01CGecSNRudbfxSX14gsBco5