### PR TITLE
Robustify activation caching: rename navigation, hook lifecycle, membership semantics

### DIFF
--- a/docs/usage/rename-modules.md
+++ b/docs/usage/rename-modules.md
@@ -106,11 +106,11 @@ model._update_alias({"new_name": "transformer.h"})
 
 Cache storage keys are always the **real** module paths, but navigation
 understands the rename. At cache creation, `tracer.cache(...)`
-(`src/nnsight/intervention/tracing/tracer.py`) asks the envoy tree for every
-module's user-facing path (`Envoy._aliased_paths`,
-`src/nnsight/intervention/envoy.py`) — the same `Aliaser` state that resolves
-`model.layers` — and `Cache.CacheDict` uses that map to translate renamed
-access paths back to real storage keys:
+(`src/nnsight/intervention/tracing/tracer.py`) snapshots the envoy tree as a
+weights-free skeleton (`Envoy._skeleton`,
+`src/nnsight/intervention/envoy.py`) whose nodes carry children and aliases —
+resolved from the same `Aliaser` state that answers `model.layers` — and
+`Cache.CacheDict` navigates that skeleton to reach real storage keys:
 
 ```python
 with model.trace("Hello") as tracer:

--- a/docs/usage/rename-modules.md
+++ b/docs/usage/rename-modules.md
@@ -104,15 +104,25 @@ model._update_alias({"new_name": "transformer.h"})
 
 ## Cache keys honor the rename
 
-`tracer.cache(...)` (`src/nnsight/intervention/tracing/tracer.py:465`) passes `rename` and the inverted alias map into `Cache.CacheDict`, so:
+Cache storage keys are always the **real** module paths, but navigation
+understands the rename. At cache creation, `tracer.cache(...)`
+(`src/nnsight/intervention/tracing/tracer.py`) asks the envoy tree for every
+module's user-facing path (`Envoy._aliased_paths`,
+`src/nnsight/intervention/envoy.py`) — the same `Aliaser` state that resolves
+`model.layers` — and `Cache.CacheDict` uses that map to translate renamed
+access paths back to real storage keys:
 
 ```python
 with model.trace("Hello") as tracer:
     cache = tracer.cache()
 
-cache["model.layers.0"].output    # works via alias
-cache.layers[0].output            # also works
+cache["model.transformer.h.0"].output   # real storage key
+cache["model.layers.0"].output          # renamed key, translated for you
+cache.model.layers[0].output            # attribute-style through the rename
 ```
+
+Real keys are authoritative: if a renamed path collides with a genuinely
+cached module's real path, the real module wins.
 
 ## Gotchas
 

--- a/src/nnsight/intervention/envoy.py
+++ b/src/nnsight/intervention/envoy.py
@@ -751,16 +751,16 @@ class Envoy(Batchable):
         root = build(self)
 
         # Second pass, once every node exists: link aliases to their target
-        # nodes. ``fetch_attr`` resolves dotted names through the aliasers
-        # themselves, so chained renames compose exactly as attribute access
-        # does.
+        # nodes through ``Aliaser.resolve`` — the same call envoy attribute
+        # access makes, so cache navigation cannot disagree with it (and
+        # chained renames compose exactly as attribute access does).
         def link(envoy: Envoy):
             aliaser = envoy._alias
             if aliaser is not None:
                 node = nodes[envoy.path]
-                for alias, name in aliaser.alias_to_name.items():
+                for alias in aliaser.alias_to_name:
                     try:
-                        target = util.fetch_attr(envoy, name)
+                        target = aliaser.resolve(envoy, alias)
                     except Exception:
                         continue
                     if isinstance(target, Envoy) and target.path in nodes:
@@ -1057,7 +1057,7 @@ class Envoy(Batchable):
         """
 
         if self._alias is not None and name in self._alias.alias_to_name:
-            return util.fetch_attr(self, self._alias.alias_to_name[name])
+            return self._alias.resolve(self, name)
 
         if hasattr(self._module, name):
             value = getattr(self._module, name)
@@ -1174,6 +1174,17 @@ class Aliaser:
         self.alias_to_name = {}
         self.name_to_aliases = {}
         self.extras = {}
+
+    def resolve(self, envoy: Envoy, alias: str) -> Any:
+        """Resolve ``alias`` to its target, starting from ``envoy``.
+
+        The single source of truth for what an alias means: both
+        :meth:`Envoy.__getattr__` (live attribute access like
+        ``model.layers``) and :meth:`Envoy._skeleton` (the cache's
+        navigation snapshot) route through here, so the two can never
+        disagree. Raises if ``alias`` is unknown or its target is missing.
+        """
+        return util.fetch_attr(envoy, self.alias_to_name[alias])
 
     def build(self, envoy: Envoy):
 

--- a/src/nnsight/intervention/envoy.py
+++ b/src/nnsight/intervention/envoy.py
@@ -736,7 +736,9 @@ class Envoy(Batchable):
 
         Returns a super-root node (``path == ""``) whose single child is this
         envoy, so navigation and cache storage keys share the same first
-        segment (``cache.model...``).
+        segment (``cache.model...``). Intended for the root envoy: paths are
+        absolute, so a skeleton built from a sub-envoy is not navigable from
+        its super-root.
         """
         nodes: Dict[str, PathNode] = {}
 
@@ -764,7 +766,7 @@ class Envoy(Batchable):
                     except Exception:
                         continue
                     if isinstance(target, Envoy) and target.path in nodes:
-                        node.aliases[alias.removeprefix(".")] = nodes[target.path]
+                        node.aliases[alias] = nodes[target.path]
             for child in envoy._children:
                 link(child)
 
@@ -1207,4 +1209,7 @@ class Aliaser:
             self.name_to_aliases[name] = aliases
 
             for alias in aliases:
-                self.alias_to_name[alias] = name
+                # Normalize dot-prefixed alias values (``{".transformer.h":
+                # ".layers"}`` is documented) the same way names are, so
+                # lookup by attribute name finds them.
+                self.alias_to_name[alias.removeprefix(".")] = name

--- a/src/nnsight/intervention/envoy.py
+++ b/src/nnsight/intervention/envoy.py
@@ -717,6 +717,61 @@ class Envoy(Batchable):
                 return True
         return False
 
+    def _aliased_paths(self) -> Dict[str, str]:
+        """Map every descendant envoy's real path to its user-facing path.
+
+        The user-facing path is derived from the envoy tree itself — the same
+        per-envoy :class:`Aliaser` state and ``fetch_attr`` resolution that
+        answer aliased attribute access like ``model.layers`` — so consumers
+        (e.g. the activation cache) inherit rename semantics from one source
+        of truth instead of re-deriving them from the rename dict.
+
+        Two rename kinds contribute:
+
+        - Single-name renames (``{"h": "layers"}``): a child's segment is
+          replaced by its first alias at the envoy level where the alias is
+          registered.
+        - Dotted-path renames (``{"model.layers": "layers"}``, kept in
+          ``Aliaser.extras``): the target module is re-mounted — its
+          user-facing path becomes the declaring envoy's path plus the alias,
+          and its descendants chain off that re-mounted path.
+
+        Paths equal to their real path are included as identity entries.
+        """
+        facing = {self.path: self.path}
+        remounts = {}
+
+        def walk(envoy: Envoy):
+            base = facing[envoy.path]
+            aliaser = envoy._alias
+
+            if aliaser is not None:
+                for dotted, aliases in aliaser.extras.items():
+                    try:
+                        target = util.fetch_attr(envoy, dotted)
+                    except Exception:
+                        continue
+                    if isinstance(target, Envoy) and aliases:
+                        remounts[target.path] = (
+                            base + "." + aliases[0].removeprefix(".")
+                        )
+
+            for child in envoy._children:
+                name = child.path.rsplit(".", 1)[-1]
+                face = remounts.get(child.path)
+                if face is None:
+                    if aliaser is not None:
+                        aliases = aliaser.name_to_aliases.get(name)
+                        if aliases:
+                            name = aliases[0].removeprefix(".")
+                    face = base + "." + name
+                facing[child.path] = face
+                walk(child)
+
+        walk(self)
+
+        return facing
+
     def _add_envoy(self, module: torch.nn.Module, name: str) -> Envoy:
         """
         Adds a new Envoy for a given torch module under this Envoy.

--- a/src/nnsight/intervention/envoy.py
+++ b/src/nnsight/intervention/envoy.py
@@ -33,7 +33,7 @@ from .tracing.base import Tracer, WithBlockNotFoundError
 from .tracing.editing import EditingTracer
 from .tracing.globals import Object
 from .tracing.iterator import IteratorProxy, register_counters_for_active_iters
-from .tracing.tracer import InterleavingTracer, ScanningTracer
+from .tracing.tracer import InterleavingTracer, PathNode, ScanningTracer
 from .interleaver import Interleaver, Mediator, IEnvoy, eproperty
 from .hooks import (
     hooked_input,
@@ -717,60 +717,62 @@ class Envoy(Batchable):
                 return True
         return False
 
-    def _aliased_paths(self) -> Dict[str, str]:
-        """Map every descendant envoy's real path to its user-facing path.
+    def _skeleton(self) -> PathNode:
+        """Snapshot this envoy tree as a weights-free :class:`PathNode` tree.
 
-        The user-facing path is derived from the envoy tree itself — the same
-        per-envoy :class:`Aliaser` state and ``fetch_attr`` resolution that
-        answer aliased attribute access like ``model.layers`` — so consumers
-        (e.g. the activation cache) inherit rename semantics from one source
-        of truth instead of re-deriving them from the rename dict.
+        Each envoy becomes a node carrying only its path, its children by
+        real name, and its aliases — where every alias is resolved to its
+        target node using the same per-envoy :class:`Aliaser` state and
+        ``fetch_attr`` resolution that answer attribute access like
+        ``model.layers``. Consumers (the activation cache) navigate this
+        skeleton instead of re-deriving rename semantics, so they cannot
+        disagree with the envoy tree; and since nodes hold no modules, the
+        skeleton is picklable and keeps no weights alive.
 
-        Two rename kinds contribute:
+        An alias may point at a direct child (``{"h": "layers"}``) or at any
+        descendant (a dotted re-mount, ``{"model.layers": "layers"}``); both
+        become plain node references. Every alias of a module is linked, not
+        just the first one.
 
-        - Single-name renames (``{"h": "layers"}``): a child's segment is
-          replaced by its first alias at the envoy level where the alias is
-          registered.
-        - Dotted-path renames (``{"model.layers": "layers"}``, kept in
-          ``Aliaser.extras``): the target module is re-mounted — its
-          user-facing path becomes the declaring envoy's path plus the alias,
-          and its descendants chain off that re-mounted path.
-
-        Paths equal to their real path are included as identity entries.
+        Returns a super-root node (``path == ""``) whose single child is this
+        envoy, so navigation and cache storage keys share the same first
+        segment (``cache.model...``).
         """
-        facing = {self.path: self.path}
-        remounts = {}
+        nodes: Dict[str, PathNode] = {}
 
-        def walk(envoy: Envoy):
-            base = facing[envoy.path]
-            aliaser = envoy._alias
-
-            if aliaser is not None:
-                for dotted, aliases in aliaser.extras.items():
-                    try:
-                        target = util.fetch_attr(envoy, dotted)
-                    except Exception:
-                        continue
-                    if isinstance(target, Envoy) and aliases:
-                        remounts[target.path] = (
-                            base + "." + aliases[0].removeprefix(".")
-                        )
-
+        def build(envoy: Envoy) -> PathNode:
+            node = PathNode(path=envoy.path)
+            nodes[envoy.path] = node
             for child in envoy._children:
                 name = child.path.rsplit(".", 1)[-1]
-                face = remounts.get(child.path)
-                if face is None:
-                    if aliaser is not None:
-                        aliases = aliaser.name_to_aliases.get(name)
-                        if aliases:
-                            name = aliases[0].removeprefix(".")
-                    face = base + "." + name
-                facing[child.path] = face
-                walk(child)
+                node.children[name] = build(child)
+            return node
 
-        walk(self)
+        root = build(self)
 
-        return facing
+        # Second pass, once every node exists: link aliases to their target
+        # nodes. ``fetch_attr`` resolves dotted names through the aliasers
+        # themselves, so chained renames compose exactly as attribute access
+        # does.
+        def link(envoy: Envoy):
+            aliaser = envoy._alias
+            if aliaser is not None:
+                node = nodes[envoy.path]
+                for alias, name in aliaser.alias_to_name.items():
+                    try:
+                        target = util.fetch_attr(envoy, name)
+                    except Exception:
+                        continue
+                    if isinstance(target, Envoy) and target.path in nodes:
+                        node.aliases[alias.removeprefix(".")] = nodes[target.path]
+            for child in envoy._children:
+                link(child)
+
+        link(self)
+
+        super_root = PathNode(path="")
+        super_root.children[root.path] = root
+        return super_root
 
     def _add_envoy(self, module: torch.nn.Module, name: str) -> Envoy:
         """

--- a/src/nnsight/intervention/interleaver.py
+++ b/src/nnsight/intervention/interleaver.py
@@ -463,6 +463,14 @@ class Interleaver:
 
         self.current: Mediator = None
 
+        # Hook handles of mediators dropped from ``self.mediators`` before
+        # ``cancel()`` runs (dead-mediator pruning in ``__exit__``, the
+        # clear in ``check_dangling_mediators``). Persistent hooks (cache,
+        # iter trackers) must keep firing until the trace ends, so they are
+        # retired here and removed in ``cancel()`` — otherwise they leak
+        # onto the module and corrupt caches on the next trace.
+        self.retired_hooks: List[Any] = []
+
     def cancel(self):
         """Cancel all mediators / intervention threads.
 
@@ -476,6 +484,10 @@ class Interleaver:
         for mediator in self.mediators:
             mediator.cancel()
             mediator.remove_hooks()
+
+        for handle in self.retired_hooks:
+            handle.remove()
+        self.retired_hooks = []
 
         self.mediators = []
         self.tracer = None
@@ -641,8 +653,18 @@ class Interleaver:
         # Clear the interleaving flag on exit.
         self._interleaving = False
 
-        # Clear the mediators that are no longer alive.
-        self.mediators = [mediator for mediator in self.mediators if mediator.alive]
+        # Clear the mediators that are no longer alive, retiring their hook
+        # handles so ``cancel()`` can still remove them at the end of the
+        # trace (vLLM re-enters this context per engine step, so removal
+        # here would be premature for persistent cache/iter hooks).
+        alive = []
+        for mediator in self.mediators:
+            if mediator.alive:
+                alive.append(mediator)
+            else:
+                self.retired_hooks.extend(mediator.hooks)
+                mediator.hooks.clear()
+        self.mediators = alive
 
         # Swallow internal control-flow exceptions so they don't escape the
         # ``with self.interleaver:`` block in server worker paths and kill
@@ -733,6 +755,10 @@ class Interleaver:
                         warnings.warn(msg)
                 else:
                     mediator.handle()
+
+        for mediator in self.mediators:
+            self.retired_hooks.extend(mediator.hooks)
+            mediator.hooks.clear()
 
         self.mediators = []
 

--- a/src/nnsight/intervention/tracing/tracer.py
+++ b/src/nnsight/intervention/tracing/tracer.py
@@ -4,7 +4,7 @@ import inspect
 from dataclasses import dataclass, field
 
 
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 import torch
 from torch._subclasses.fake_tensor import FakeCopyMode, FakeTensorMode
@@ -149,27 +149,27 @@ class Cache:
                     dict.__setitem__(self, k, dict.__getitem__(data, k))
 
         @property
-        def output(self) -> Any:
+        def output(self):
             """
             Returns the output attribute from the Cache.Entry at the current path.
             """
             return dict.__getitem__(self, self._path).output
 
         @property
-        def inputs(self) -> Any:
+        def inputs(self):
             """
             Returns the inputs attribute from the Cache.Entry at the current path.
             """
             return dict.__getitem__(self, self._path).inputs
 
         @property
-        def input(self) -> Any:
+        def input(self):
             """
             Returns the input property from the Cache.Entry at the current path.
             """
             return dict.__getitem__(self, self._path).input
 
-        def _scoped_iter(self) -> Iterator[str]:
+        def _scoped_iter(self):
             """Iterate keys visible at the current ``_path`` scope.
 
             For the root view (``_path == ""``) this is every key. For a

--- a/src/nnsight/intervention/tracing/tracer.py
+++ b/src/nnsight/intervention/tracing/tracer.py
@@ -99,30 +99,45 @@ class Cache:
             # (e.g. translating root key ``"model"`` → ``"transformer"``,
             # which is not in storage).
             super().__init__()
-            if data:
+            # Use the raw dict length, not the ``_path``-scoped ``__len__``:
+            # an alias-space sub-view (from a collapsing/re-mount rename) has a
+            # scoped length of 0 because no real key lives under its alias path,
+            # yet its full storage must still propagate to deeper children.
+            if dict.__len__(data):
                 for k in dict.__iter__(data):
                     dict.__setitem__(self, k, dict.__getitem__(data, k))
+
+        def _resolved_path(self):
+            """Resolve ``_path`` to a real storage key.
+
+            When navigation lands on an aliased path produced by a
+            collapsing/re-mount rename (e.g. ``"model.layers.0"`` from
+            ``rename={"model.layers": "layers"}``), the underlying storage key
+            is the un-renamed path (``"model.transformer.h.0"``). ``_alias_paths``
+            maps the former to the latter; real paths pass through unchanged.
+            """
+            return self._alias_paths.get(self._path, self._path)
 
         @property
         def output(self):
             """
             Returns the output attribute from the Cache.Entry at the current path.
             """
-            return dict.__getitem__(self, self._path).output
+            return dict.__getitem__(self, self._resolved_path()).output
 
         @property
         def inputs(self):
             """
             Returns the inputs attribute from the Cache.Entry at the current path.
             """
-            return dict.__getitem__(self, self._path).inputs
+            return dict.__getitem__(self, self._resolved_path()).inputs
 
         @property
         def input(self):
             """
             Returns the input property from the Cache.Entry at the current path.
             """
-            return dict.__getitem__(self, self._path).input
+            return dict.__getitem__(self, self._resolved_path()).input
 
         def _scoped_iter(self):
             """Iterate keys visible at the current ``_path`` scope.
@@ -183,13 +198,48 @@ class Cache:
             )
             return f"{{{body}}}"
 
+        def _child(self, path):
+            """Build a sub-view CacheDict scoped at ``path``."""
+            return Cache.CacheDict(
+                self,
+                path,
+                rename=self._rename,
+                alias=self._alias,
+                alias_paths=self._alias_paths,
+            )
+
+        def _alias_path_prefix(self, path):
+            """True if ``path`` is an alias path or a prefix of one.
+
+            Lets attribute/index navigation walk the authoritative
+            ``_alias_paths`` keyspace segment by segment, which is required for
+            collapsing/re-mount renames whose alias path (``"model.layers.0"``)
+            is not a prefix of any real storage key (``"model.transformer.h.0"``).
+            """
+            return any(
+                key == path or key.startswith(path + ".") for key in self._alias_paths
+            )
+
         def _add_alias_path(self, module_path):
             if self._rename:
-                alias_path = str(module_path)
+                # The root component (``cache.model``) is the fixed cache root
+                # and is never renamed in access space, so protect it from the
+                # substring replacements below. Without this a rename like
+                # ``{"model": "foo"}`` would also rewrite the root segment
+                # (``model.model.layers.0`` -> ``foo.foo.layers.0``) and the
+                # user-facing ``cache.model.foo.layers[0]`` would never match.
+                root, _, rest = str(module_path).partition(".")
+
+                if rest == "":
+                    return
+
+                alias_rest = rest
 
                 for path, alias in self._rename.items():
                     path = path.removeprefix(".")
-                    alias_path = alias_path.replace(path, alias)
+                    alias_rest = alias_rest.replace(path, alias)
+
+                alias_path = root + "." + alias_rest
 
                 if alias_path != module_path:
                     self._alias_paths[alias_path] = module_path
@@ -213,14 +263,10 @@ class Cache:
             if isinstance(name, int):
                 path = self._path + "." + f"{name}"
 
-                if any(key.startswith(path) for key in self):
-                    return Cache.CacheDict(
-                        self,
-                        path,
-                        rename=self._rename,
-                        alias=self._alias,
-                        alias_paths=self._alias_paths,
-                    )
+                if any(key.startswith(path) for key in self) or self._alias_path_prefix(
+                    path
+                ):
+                    return self._child(path)
                 elif any(
                     key.startswith(self._path + ".")
                     and len(key) >= len(self._path) + 1
@@ -236,22 +282,31 @@ class Cache:
         def __getattr__(self, attr: str):
             path = self._path + "." + attr if self._path != "" else attr
 
+            # (1) Direct route: ``path`` prefixes a real storage key.
             if any(key.startswith(path) for key in self):
-                return Cache.CacheDict(
-                    self,
-                    path,
-                    rename=self._rename,
-                    alias=self._alias,
-                    alias_paths=self._alias_paths,
-                )
-            elif self._alias and attr in self._alias:
-                name = self._alias[attr]
-                name = name.removeprefix(".")
-                return self.__getattr__(name)
-            else:
-                raise AttributeError(
-                    f"'{attr}' module path was never cached. '{self.__class__.__name__}' has no matching attribute."
-                )
+                return self._child(path)
+
+            # (2) Leaf-alias route: translate the aliased segment to its
+            #     underlying name and keep navigating in real-path space. If
+            #     that dead-ends (e.g. the alias value is a re-mount rooted
+            #     elsewhere, as with collapsing renames), fall through to the
+            #     alias-path route rather than raising.
+            if self._alias and attr in self._alias:
+                name = self._alias[attr].removeprefix(".")
+                try:
+                    return self.__getattr__(name)
+                except AttributeError:
+                    pass
+
+            # (3) Alias-path route: ``path`` prefixes an authoritative alias
+            #     path. Handles collapsing/re-mount renames whose alias path is
+            #     absent from the real storage keys.
+            if self._alias_path_prefix(path):
+                return self._child(path)
+
+            raise AttributeError(
+                f"'{attr}' module path was never cached. '{self.__class__.__name__}' has no matching attribute."
+            )
 
         def __getstate__(self):
             return self.__dict__.copy()

--- a/src/nnsight/intervention/tracing/tracer.py
+++ b/src/nnsight/intervention/tracing/tracer.py
@@ -82,14 +82,17 @@ class Cache:
             self,
             data: "Union[Cache.CacheDict, Dict[str, Cache.Entry]]",
             path: str = "",
-            alias: Dict[str, str] = dict(),
-            rename: Dict[str, str] = dict(),
-            alias_paths: Dict[str, str] = dict(),
+            alias: Optional[Dict[str, str]] = None,
+            rename: Optional[Dict[str, str]] = None,
+            alias_paths: Optional[Dict[str, str]] = None,
         ):
             self._path = path
-            self._alias = alias
-            self._rename = rename
-            self._alias_paths = alias_paths
+            # ``None`` defaults instead of ``dict()``: a mutable default would
+            # be shared by every CacheDict in the process, so alias paths
+            # registered by one cache would leak into navigation of all others.
+            self._alias = alias if alias is not None else {}
+            self._rename = rename if rename is not None else {}
+            self._alias_paths = alias_paths if alias_paths is not None else {}
 
             # Copy underlying storage directly, bypassing any CacheDict
             # overrides (``__getitem__``, ``__iter__``, ``keys``) on
@@ -114,8 +117,12 @@ class Cache:
             collapsing/re-mount rename (e.g. ``"model.layers.0"`` from
             ``rename={"model.layers": "layers"}``), the underlying storage key
             is the un-renamed path (``"model.transformer.h.0"``). ``_alias_paths``
-            maps the former to the latter; real paths pass through unchanged.
+            maps the former to the latter. Real storage keys are authoritative:
+            a path present in storage is never rerouted through the alias map,
+            so an alias can't shadow a genuinely cached module of the same name.
             """
+            if dict.__contains__(self, self._path):
+                return self._path
             return self._alias_paths.get(self._path, self._path)
 
         @property
@@ -220,53 +227,104 @@ class Cache:
                 key == path or key.startswith(path + ".") for key in self._alias_paths
             )
 
+        @staticmethod
+        def _replace_segments(segments, pattern, replacement):
+            """Replace each non-overlapping occurrence of ``pattern`` (a
+            contiguous run of path segments) in ``segments`` with
+            ``replacement``. Matching is whole-segment, so a rename like
+            ``{"h": "layers"}`` rewrites the ``h`` component without
+            corrupting ``lm_head`` the way substring replacement would.
+            """
+            if not pattern or len(pattern) > len(segments):
+                return segments
+            out = []
+            i = 0
+            while i < len(segments):
+                if segments[i : i + len(pattern)] == pattern:
+                    out.extend(replacement)
+                    i += len(pattern)
+                else:
+                    out.append(segments[i])
+                    i += 1
+            return out
+
         def _add_alias_path(self, module_path):
-            if self._rename:
-                # The root component (``cache.model``) is the fixed cache root
-                # and is never renamed in access space, so protect it from the
-                # substring replacements below. Without this a rename like
-                # ``{"model": "foo"}`` would also rewrite the root segment
-                # (``model.model.layers.0`` -> ``foo.foo.layers.0``) and the
-                # user-facing ``cache.model.foo.layers[0]`` would never match.
-                root, _, rest = str(module_path).partition(".")
+            if not self._rename:
+                return
 
-                if rest == "":
-                    return
+            # The root component (``cache.model``) is the fixed cache root
+            # and is never renamed in access space, so protect it from the
+            # replacements below. Without this a rename like ``{"model":
+            # "foo"}`` would also rewrite the root segment
+            # (``model.model.layers.0`` -> ``foo.foo.layers.0``) and the
+            # user-facing ``cache.model.foo.layers[0]`` would never match.
+            root, _, rest = str(module_path).partition(".")
 
-                alias_rest = rest
+            if rest == "":
+                return
 
-                for path, alias in self._rename.items():
-                    path = path.removeprefix(".")
-                    alias_rest = alias_rest.replace(path, alias)
+            segments = rest.split(".")
 
-                alias_path = root + "." + alias_rest
+            for path, aliases in self._rename.items():
+                pattern = path.removeprefix(".").split(".")
+                if isinstance(aliases, str):
+                    aliases = [aliases]
+                # With multiple aliases for one module the first one names the
+                # alias path; the others stay reachable through the leaf-alias
+                # route in ``__getattr__``.
+                replacement = [
+                    s for s in aliases[0].removeprefix(".").split(".") if s
+                ]
+                segments = self._replace_segments(segments, pattern, replacement)
 
-                if alias_path != module_path:
-                    self._alias_paths[alias_path] = module_path
+            if not segments:
+                return
+
+            alias_path = ".".join([root, *segments])
+
+            if alias_path != module_path:
+                self._alias_paths[alias_path] = module_path
 
         def __getitem__(self, key):
+            # Real storage keys are authoritative: check them before any alias
+            # translation so a rename can never shadow a genuinely cached
+            # module of the same name (e.g. ``rename={"a": "b", "b": "a"}``).
+            # This also keeps IPython pretty-printers (which call ``obj[k]``
+            # for each ``k`` in ``keys()``) from getting a double-prefixed key
+            # like ``"model.transformer.h.0.model.transformer.h.0"``.
+            if isinstance(key, str) and dict.__contains__(self, key):
+                return dict.__getitem__(self, key)
+
             name = self._alias.get(key, key)
 
             if isinstance(name, str):
-                name = self._alias_paths.get(name, name)
-
-                # Absolute key: already a full path present in the underlying
-                # storage. Return it directly so IPython pretty-printers (which
-                # call ``obj[k]`` for each ``k`` in ``keys()``) don't get a
-                # double-prefixed key like ``"model.transformer.h.0.model.transformer.h.0"``.
                 if dict.__contains__(self, name):
                     return dict.__getitem__(self, name)
 
+                if name in self._alias_paths:
+                    return dict.__getitem__(self, self._alias_paths[name])
+
                 path = self._path + "." + name if self._path != "" else name
+
+                # A key relative to this sub-view may itself be an aliased
+                # path (e.g. ``cache.model["layers.0"]`` under
+                # ``rename={"model.layers": "layers"}``); resolve the composed
+                # path through the alias map when it isn't in real storage.
+                if not dict.__contains__(self, path):
+                    path = self._alias_paths.get(path, path)
+
                 return dict.__getitem__(self, path)
 
             if isinstance(name, int):
                 path = self._path + "." + f"{name}"
                 prefix = self._path + "."
 
-                if any(key.startswith(path) for key in self) or self._alias_path_prefix(
-                    path
-                ):
+                # Whole-segment matching (``== path`` / ``path + "."``): a bare
+                # ``startswith(path)`` would let index 1 match ``...h.10`` and
+                # hand back a bogus sub-view that later raises ``KeyError``.
+                if any(
+                    key == path or key.startswith(path + ".") for key in self
+                ) or self._alias_path_prefix(path):
                     return self._child(path)
                 # Out-of-bounds on a modulelist: a sibling numeric index exists
                 # under ``_path`` but ``name`` isn't one of them. Check both the
@@ -288,8 +346,10 @@ class Cache:
         def __getattr__(self, attr: str):
             path = self._path + "." + attr if self._path != "" else attr
 
-            # (1) Direct route: ``path`` prefixes a real storage key.
-            if any(key.startswith(path) for key in self):
+            # (1) Direct route: ``path`` is a real storage key or a
+            #     whole-segment prefix of one (``.ln`` must not match a key
+            #     ``...ln_f`` the way a bare ``startswith`` would).
+            if any(key == path or key.startswith(path + ".") for key in self):
                 return self._child(path)
 
             # (2) Leaf-alias route: translate the aliased segment to its
@@ -637,7 +697,14 @@ class InterleavingTracer(Tracer):
         rename_dict = (
             self.model._alias.rename if self.model._alias is not None else dict()
         )
-        alias_dict = {value: key for key, value in rename_dict.items()}
+        # Rename values may be a list of aliases (e.g. ``{"transformer":
+        # ["model", "mdl"]}``); map every alias back to its module name.
+        alias_dict = {}
+        for name, aliases in rename_dict.items():
+            if isinstance(aliases, str):
+                aliases = [aliases]
+            for alias in aliases:
+                alias_dict[alias] = name
 
         if not self.model.interleaving:
             raise ValueError("Cannot create a cache outside an invoker.")

--- a/src/nnsight/intervention/tracing/tracer.py
+++ b/src/nnsight/intervention/tracing/tracer.py
@@ -198,13 +198,13 @@ class Cache:
         def __contains__(self, key):
             if not isinstance(key, str):
                 return False
-            if dict.__contains__(self, key):
-                if self._path == "":
-                    return True
-                return key == self._path or key.startswith(self._path + ".")
-            if self._path != "":
-                return dict.__contains__(self, self._path + "." + key)
-            return False
+            # Membership is defined as "lookup succeeds", so ``in`` and
+            # ``[]`` share one resolution semantics — renamed keys included.
+            try:
+                self[key]
+            except KeyError:
+                return False
+            return True
 
         def keys(self, alias: bool = False):
             if alias:

--- a/src/nnsight/intervention/tracing/tracer.py
+++ b/src/nnsight/intervention/tracing/tracer.py
@@ -1,7 +1,7 @@
 import copy
 import inspect
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Set, Tuple, Union
@@ -23,6 +23,44 @@ if TYPE_CHECKING:
     from ..envoy import Envoy
 else:
     Envoy = Any
+
+
+@dataclass
+class PathNode:
+    """One node of a weights-free skeleton of the envoy tree.
+
+    Built by :meth:`Envoy._skeleton` when a cache is created and carried by
+    :class:`Cache.CacheDict` so navigation (``cache.model.layers[0]``) can be
+    resolved structurally — child by child, alias by alias — instead of by
+    string matching over flat storage keys. Nodes hold only names, paths and
+    references to other nodes: no modules, no tensors, so the skeleton is
+    cheap to pickle and keeps no model weights alive.
+
+    ``aliases`` mirrors the envoy-level :class:`Aliaser` resolution: a value
+    may be a direct child (single-name rename, ``{"h": "layers"}``) or any
+    descendant (dotted re-mount rename, ``{"model.layers": "layers"}``).
+    """
+
+    path: str
+    children: "Dict[str, PathNode]" = field(default_factory=dict)
+    aliases: "Dict[str, PathNode]" = field(default_factory=dict)
+
+    def resolve(self, name: str) -> "Optional[PathNode]":
+        """Resolve one path segment. Real children are authoritative: an
+        alias can never shadow a genuine sibling of the same name."""
+        child = self.children.get(name)
+        if child is not None:
+            return child
+        return self.aliases.get(name)
+
+    def navigate(self, dotted: str) -> "Optional[PathNode]":
+        """Resolve a dotted path relative to this node, or ``None``."""
+        node = self
+        for segment in dotted.split("."):
+            node = node.resolve(segment)
+            if node is None:
+                return None
+        return node
 
 
 class Cache:
@@ -82,67 +120,54 @@ class Cache:
             self,
             data: "Union[Cache.CacheDict, Dict[str, Cache.Entry]]",
             path: str = "",
-            alias: Optional[Dict[str, str]] = None,
-            alias_paths: Optional[Dict[str, str]] = None,
+            node: Optional[PathNode] = None,
+            tree: Optional[PathNode] = None,
         ):
+            """
+            Args:
+                data: Storage to copy — flat ``{real path: Entry}``.
+                path: Real path of this view ("" for the root view).
+                node: Skeleton node this view is scoped at. The root view's
+                    node is ``tree`` itself.
+                tree: Super-root of the model skeleton
+                    (:meth:`Envoy._skeleton`). When absent, a bare tree is
+                    derived from the storage keys on first navigation —
+                    real paths stay navigable, aliases don't exist.
+            """
             self._path = path
-            # ``None`` defaults instead of ``dict()``: a mutable default would
-            # be shared by every CacheDict in the process, so alias paths
-            # registered by one cache would leak into navigation of all others.
-            self._alias = alias if alias is not None else {}
-            self._alias_paths = alias_paths if alias_paths is not None else {}
+            self._node = node if node is not None else tree
+            self._tree = tree
 
             # Copy underlying storage directly, bypassing any CacheDict
             # overrides (``__getitem__``, ``__iter__``, ``keys``) on
             # ``data``. Overriding ``__iter__`` forces CPython's
             # ``dict.__init__`` slow path to call ``data.__getitem__``,
-            # which would apply alias translation and break the copy
-            # (e.g. translating root key ``"model"`` → ``"transformer"``,
-            # which is not in storage).
+            # which would apply alias resolution and break the copy.
             super().__init__()
-            # Use the raw dict length, not the ``_path``-scoped ``__len__``:
-            # an alias-space sub-view (from a collapsing/re-mount rename) has a
-            # scoped length of 0 because no real key lives under its alias path,
-            # yet its full storage must still propagate to deeper children.
             if dict.__len__(data):
                 for k in dict.__iter__(data):
                     dict.__setitem__(self, k, dict.__getitem__(data, k))
-
-        def _resolved_path(self) -> str:
-            """Resolve ``_path`` to a real storage key.
-
-            When navigation lands on an aliased path produced by a
-            collapsing/re-mount rename (e.g. ``"model.layers.0"`` from
-            ``rename={"model.layers": "layers"}``), the underlying storage key
-            is the un-renamed path (``"model.transformer.h.0"``). ``_alias_paths``
-            maps the former to the latter. Real storage keys are authoritative:
-            a path present in storage is never rerouted through the alias map,
-            so an alias can't shadow a genuinely cached module of the same name.
-            """
-            if dict.__contains__(self, self._path):
-                return self._path
-            return self._alias_paths.get(self._path, self._path)
 
         @property
         def output(self) -> Any:
             """
             Returns the output attribute from the Cache.Entry at the current path.
             """
-            return dict.__getitem__(self, self._resolved_path()).output
+            return dict.__getitem__(self, self._path).output
 
         @property
         def inputs(self) -> Any:
             """
             Returns the inputs attribute from the Cache.Entry at the current path.
             """
-            return dict.__getitem__(self, self._resolved_path()).inputs
+            return dict.__getitem__(self, self._path).inputs
 
         @property
         def input(self) -> Any:
             """
             Returns the input property from the Cache.Entry at the current path.
             """
-            return dict.__getitem__(self, self._resolved_path()).input
+            return dict.__getitem__(self, self._path).input
 
         def _scoped_iter(self) -> Iterator[str]:
             """Iterate keys visible at the current ``_path`` scope.
@@ -182,7 +207,12 @@ class Cache:
 
         def keys(self, alias: bool = False):
             if alias:
-                return self._alias_paths.keys()
+                facing = self._facing_paths()
+                return [
+                    facing[k]
+                    for k in self._scoped_iter()
+                    if facing.get(k, k) != k
+                ]
 
             if self._path == "":
                 return super().keys()
@@ -203,80 +233,124 @@ class Cache:
             )
             return f"{{{body}}}"
 
-        def _child(self, path: str) -> "Cache.CacheDict":
-            """Build a sub-view CacheDict scoped at ``path``."""
+        def _child(self, node: PathNode) -> "Cache.CacheDict":
+            """Build a sub-view CacheDict scoped at ``node``."""
             return Cache.CacheDict(
                 self,
-                path,
-                alias=self._alias,
-                alias_paths=self._alias_paths,
+                node.path,
+                node=node,
+                tree=self._tree,
             )
 
-        def _alias_path_prefix(self, path: str) -> bool:
-            """True if ``path`` is an alias path or a prefix of one.
-
-            Lets attribute/index navigation walk the authoritative
-            ``_alias_paths`` keyspace segment by segment, which is required for
-            collapsing/re-mount renames whose alias path (``"model.layers.0"``)
-            is not a prefix of any real storage key (``"model.transformer.h.0"``).
+        def _ensure_node(self) -> Optional[PathNode]:
+            """This view's skeleton node, deriving a bare tree from the
+            storage keys if none was provided (direct construction without a
+            model). The derived tree navigates real paths only — no aliases.
             """
+            if self._node is None:
+                root = PathNode(path="")
+                for key in dict.__iter__(self):
+                    node = root
+                    prefix = ""
+                    for segment in key.split("."):
+                        prefix = segment if prefix == "" else prefix + "." + segment
+                        nxt = node.children.get(segment)
+                        if nxt is None:
+                            nxt = PathNode(path=prefix)
+                            node.children[segment] = nxt
+                        node = nxt
+                self._tree = root
+                self._node = root if self._path == "" else root.navigate(self._path)
+            return self._node
+
+        def _cached_under(self, node: PathNode) -> bool:
+            """Whether anything was recorded at or below ``node``.
+
+            The skeleton knows the whole model; the cache only what was
+            cached. Navigation refuses to descend into empty subtrees so
+            ``cache.model.transformer.h[0].mlp`` raises when only ``h[0]``
+            itself was cached.
+            """
+            prefix = node.path + "."
             return any(
-                key == path or key.startswith(path + ".") for key in self._alias_paths
+                k == node.path or k.startswith(prefix)
+                for k in dict.__iter__(self)
             )
+
+        def _facing_paths(self) -> Dict[str, str]:
+            """Real path → canonical user-facing path, from the skeleton.
+
+            The canonical spelling uses, at each step, the first alias
+            registered for the child (or its real name), with re-mount
+            aliases overriding the whole subtree they re-mount.
+            """
+            facing: Dict[str, str] = {}
+            remounts: Dict[str, str] = {}
+
+            tree = self._tree
+            if tree is None:
+                return facing
+
+            def walk(node: PathNode, base: str):
+                children = {id(child) for child in node.children.values()}
+                for alias, target in node.aliases.items():
+                    if id(target) not in children:
+                        remounts[target.path] = (
+                            base + "." + alias if base else alias
+                        )
+                for name, child in node.children.items():
+                    face = remounts.get(child.path)
+                    if face is None:
+                        label = next(
+                            (a for a, t in node.aliases.items() if t is child),
+                            name,
+                        )
+                        face = base + "." + label if base else label
+                    facing[child.path] = face
+                    walk(child, face)
+
+            walk(tree, "")
+
+            return facing
 
         def __getitem__(
             self, key: Union[str, int]
         ) -> "Union[Cache.CacheDict, Cache.Entry, List[Cache.Entry]]":
-            # Real storage keys are authoritative: check them before any alias
-            # translation so a rename can never shadow a genuinely cached
-            # module of the same name (e.g. ``rename={"a": "b", "b": "a"}``).
-            # This also keeps IPython pretty-printers (which call ``obj[k]``
-            # for each ``k`` in ``keys()``) from getting a double-prefixed key
-            # like ``"model.transformer.h.0.model.transformer.h.0"``.
-            if isinstance(key, str) and dict.__contains__(self, key):
+            if isinstance(key, str):
+                # Real storage keys are authoritative: check them before any
+                # alias resolution so a rename can never shadow a genuinely
+                # cached module of the same name. This also keeps IPython
+                # pretty-printers (which call ``obj[k]`` for each ``k`` in
+                # ``keys()``) from re-resolving absolute keys.
+                if dict.__contains__(self, key):
+                    return dict.__getitem__(self, key)
+
+                node = self._ensure_node()
+
+                # Resolve the (possibly dotted, possibly aliased) key against
+                # the skeleton — relative to this view first, then as an
+                # absolute path from the root.
+                target = node.navigate(key) if node is not None else None
+                if target is None and self._tree is not None:
+                    target = self._tree.navigate(key)
+                if target is not None:
+                    return dict.__getitem__(self, target.path)
+
                 return dict.__getitem__(self, key)
 
-            name = self._alias.get(key, key)
+            if isinstance(key, int):
+                node = self._ensure_node()
+                target = node.resolve(str(key)) if node is not None else None
 
-            if isinstance(name, str):
-                if dict.__contains__(self, name):
-                    return dict.__getitem__(self, name)
+                if target is not None and self._cached_under(target):
+                    return self._child(target)
 
-                if name in self._alias_paths:
-                    return dict.__getitem__(self, self._alias_paths[name])
-
-                path = self._path + "." + name if self._path != "" else name
-
-                # A key relative to this sub-view may itself be an aliased
-                # path (e.g. ``cache.model["layers.0"]`` under
-                # ``rename={"model.layers": "layers"}``); resolve the composed
-                # path through the alias map when it isn't in real storage.
-                if not dict.__contains__(self, path):
-                    path = self._alias_paths.get(path, path)
-
-                return dict.__getitem__(self, path)
-
-            if isinstance(name, int):
-                path = self._path + "." + f"{name}"
-                prefix = self._path + "."
-
-                # Whole-segment matching (``== path`` / ``path + "."``): a bare
-                # ``startswith(path)`` would let index 1 match ``...h.10`` and
-                # hand back a bogus sub-view that later raises ``KeyError``.
-                if any(
-                    key == path or key.startswith(path + ".") for key in self
-                ) or self._alias_path_prefix(path):
-                    return self._child(path)
-                # Out-of-bounds on a modulelist: a sibling numeric index exists
-                # under ``_path`` but ``name`` isn't one of them. Check both the
-                # real keys and the alias-path keyspace so renamed/collapsed
-                # modulelists raise ``IndexError`` rather than leaking a
-                # ``KeyError`` from the ``dict.__getitem__`` fallback below.
-                elif any(
-                    key.startswith(prefix)
-                    and len(key) > len(prefix)
-                    and key[len(prefix)].isdigit()
-                    for key in (*self, *self._alias_paths)
+                # The index names no cached module, but numeric siblings
+                # exist: this is a modulelist and the index is out of bounds
+                # (or points at an uncached element) — IndexError, not a
+                # KeyError leak from the fallback below.
+                if node is not None and any(
+                    name.isdigit() for name in node.children
                 ):
                     raise IndexError(
                         f"Index {key} is out of bounds for modulelist or module does not allow indexing."
@@ -285,31 +359,22 @@ class Cache:
             return dict.__getitem__(self, key)
 
         def __getattr__(self, attr: str) -> "Cache.CacheDict":
-            path = self._path + "." + attr if self._path != "" else attr
+            # Guard the fields this method itself relies on: during
+            # unpickling ``__getattr__`` can fire before ``__setstate__``
+            # restores them, and falling through would recurse.
+            if attr in ("_path", "_node", "_tree"):
+                raise AttributeError(attr)
 
-            # (1) Direct route: ``path`` is a real storage key or a
-            #     whole-segment prefix of one (``.ln`` must not match a key
-            #     ``...ln_f`` the way a bare ``startswith`` would).
-            if any(key == path or key.startswith(path + ".") for key in self):
-                return self._child(path)
+            node = self._ensure_node()
+            target = node.resolve(attr) if node is not None else None
 
-            # (2) Leaf-alias route: translate the aliased segment to its
-            #     underlying name and keep navigating in real-path space. If
-            #     that dead-ends (e.g. the alias value is a re-mount rooted
-            #     elsewhere, as with collapsing renames), fall through to the
-            #     alias-path route rather than raising.
-            if self._alias and attr in self._alias:
-                name = self._alias[attr].removeprefix(".")
-                try:
-                    return self.__getattr__(name)
-                except AttributeError:
-                    pass
-
-            # (3) Alias-path route: ``path`` prefixes an authoritative alias
-            #     path. Handles collapsing/re-mount renames whose alias path is
-            #     absent from the real storage keys.
-            if self._alias_path_prefix(path):
-                return self._child(path)
+            if target is not None:
+                if self._cached_under(target):
+                    return self._child(target)
+                raise AttributeError(
+                    f"'{attr}' exists on the model but was never cached. "
+                    f"'{self.__class__.__name__}' has no matching attribute."
+                )
 
             raise AttributeError(
                 f"'{attr}' module path was never cached. '{self.__class__.__name__}' has no matching attribute."
@@ -329,8 +394,7 @@ class Cache:
         detach: Optional[bool] = True,
         include_output: bool = True,
         include_inputs: bool = False,
-        aliased_paths: Optional[Dict[str, str]] = None,
-        alias: Optional[Dict[str, str]] = None,
+        tree: Optional[PathNode] = None,
     ):
         """Initialize a Cache with optional transformation parameters.
 
@@ -342,11 +406,9 @@ class Cache:
             detach: Whether to detach tensors from the computation graph.
             include_output: Whether to cache module outputs.
             include_inputs: Whether to cache module inputs.
-            aliased_paths: Real path → user-facing path for every module, as
-                computed from the envoy tree (:meth:`Envoy._aliased_paths`).
-                Renamed paths of cached modules are registered in the
-                ``CacheDict``'s alias-path map as values arrive.
-            alias: Alias mapping for ``CacheDict`` attribute access.
+            tree: Weights-free skeleton of the model
+                (:meth:`Envoy._skeleton`) that ``CacheDict`` navigation
+                resolves attribute/index access against, including renames.
         """
         self.device = device
         self.dtype = dtype
@@ -354,12 +416,11 @@ class Cache:
         self.modules = modules
         self.include_output = include_output
         self.include_inputs = include_inputs
-        self.aliased_paths = aliased_paths if aliased_paths is not None else {}
 
         if self.modules is not None:
             self.modules = {m if isinstance(m, str) else m.path for m in self.modules}
 
-        self.cache = Cache.CacheDict({}, alias=alias).save()
+        self.cache = Cache.CacheDict({}, tree=tree).save()
 
     def add(self, module_path: str, key: str, value: Any):
         """Add a value to the cache with optional transformations.
@@ -387,14 +448,6 @@ class Cache:
 
         if module_path not in self.cache:
             self.cache[module_path] = Cache.Entry(**{key: value})
-
-            # Register the module's user-facing path (derived from the envoy
-            # tree at cache creation) so aliased navigation can find it. Only
-            # cached modules get entries — navigation and IndexError semantics
-            # depend on the table mirroring what was actually recorded.
-            alias_path = self.aliased_paths.get(module_path)
-            if alias_path is not None and alias_path != module_path:
-                self.cache._alias_paths[alias_path] = module_path
         else:
             entry = self.cache[module_path]
 
@@ -646,32 +699,15 @@ class InterleavingTracer(Tracer):
             A :class:`Cache.CacheDict` that is populated during execution.
         """
 
-        # Both rename views come from the envoy tree, the source of truth for
-        # rename semantics: ``alias_dict`` (alias → module name) drives the
-        # leaf-alias route of CacheDict navigation, and ``aliased_paths``
-        # (real path → user-facing path, from Envoy._aliased_paths) drives
-        # the alias-path route for collapsing/re-mount renames.
-        rename_dict = (
-            self.model._alias.rename if self.model._alias is not None else dict()
-        )
-        # Rename values may be a list of aliases (e.g. ``{"transformer":
-        # ["model", "mdl"]}``); map every alias back to its module name.
-        alias_dict = {}
-        for name, aliases in rename_dict.items():
-            if isinstance(aliases, str):
-                aliases = [aliases]
-            for alias in aliases:
-                alias_dict[alias] = name
-
-        aliased_paths = (
-            self.model._aliased_paths() if self.model._alias is not None else {}
-        )
-
         if not self.model.interleaving:
             raise ValueError("Cannot create a cache outside an invoker.")
 
         from ..hooks import cache_output_hook, cache_input_hook
 
+        # Weights-free skeleton of the envoy tree: CacheDict navigation
+        # resolves attribute/index access (including renames) against it,
+        # so rename semantics come from the same Aliaser state that answers
+        # ``model.layers`` — one source of truth.
         cache_obj = Cache(
             modules,
             device,
@@ -679,8 +715,7 @@ class InterleavingTracer(Tracer):
             detach,
             include_output,
             include_inputs,
-            aliased_paths=aliased_paths,
-            alias=alias_dict,
+            tree=self.model._skeleton(),
         )
 
         mediator = self.model.interleaver.current

--- a/src/nnsight/intervention/tracing/tracer.py
+++ b/src/nnsight/intervention/tracing/tracer.py
@@ -4,7 +4,7 @@ import inspect
 from dataclasses import dataclass
 
 
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Set, Tuple, Union
 
 import torch
 from torch._subclasses.fake_tensor import FakeCopyMode, FakeTensorMode
@@ -110,7 +110,7 @@ class Cache:
                 for k in dict.__iter__(data):
                     dict.__setitem__(self, k, dict.__getitem__(data, k))
 
-        def _resolved_path(self):
+        def _resolved_path(self) -> str:
             """Resolve ``_path`` to a real storage key.
 
             When navigation lands on an aliased path produced by a
@@ -126,27 +126,27 @@ class Cache:
             return self._alias_paths.get(self._path, self._path)
 
         @property
-        def output(self):
+        def output(self) -> Any:
             """
             Returns the output attribute from the Cache.Entry at the current path.
             """
             return dict.__getitem__(self, self._resolved_path()).output
 
         @property
-        def inputs(self):
+        def inputs(self) -> Any:
             """
             Returns the inputs attribute from the Cache.Entry at the current path.
             """
             return dict.__getitem__(self, self._resolved_path()).inputs
 
         @property
-        def input(self):
+        def input(self) -> Any:
             """
             Returns the input property from the Cache.Entry at the current path.
             """
             return dict.__getitem__(self, self._resolved_path()).input
 
-        def _scoped_iter(self):
+        def _scoped_iter(self) -> Iterator[str]:
             """Iterate keys visible at the current ``_path`` scope.
 
             For the root view (``_path == ""``) this is every key. For a
@@ -205,7 +205,7 @@ class Cache:
             )
             return f"{{{body}}}"
 
-        def _child(self, path):
+        def _child(self, path: str) -> "Cache.CacheDict":
             """Build a sub-view CacheDict scoped at ``path``."""
             return Cache.CacheDict(
                 self,
@@ -215,7 +215,7 @@ class Cache:
                 alias_paths=self._alias_paths,
             )
 
-        def _alias_path_prefix(self, path):
+        def _alias_path_prefix(self, path: str) -> bool:
             """True if ``path`` is an alias path or a prefix of one.
 
             Lets attribute/index navigation walk the authoritative
@@ -228,7 +228,9 @@ class Cache:
             )
 
         @staticmethod
-        def _replace_segments(segments, pattern, replacement):
+        def _replace_segments(
+            segments: List[str], pattern: List[str], replacement: List[str]
+        ) -> List[str]:
             """Replace each non-overlapping occurrence of ``pattern`` (a
             contiguous run of path segments) in ``segments`` with
             ``replacement``. Matching is whole-segment, so a rename like
@@ -248,7 +250,7 @@ class Cache:
                     i += 1
             return out
 
-        def _add_alias_path(self, module_path):
+        def _add_alias_path(self, module_path: str) -> None:
             if not self._rename:
                 return
 
@@ -285,7 +287,9 @@ class Cache:
             if alias_path != module_path:
                 self._alias_paths[alias_path] = module_path
 
-        def __getitem__(self, key):
+        def __getitem__(
+            self, key: Union[str, int]
+        ) -> "Union[Cache.CacheDict, Cache.Entry, List[Cache.Entry]]":
             # Real storage keys are authoritative: check them before any alias
             # translation so a rename can never shadow a genuinely cached
             # module of the same name (e.g. ``rename={"a": "b", "b": "a"}``).
@@ -343,7 +347,7 @@ class Cache:
 
             return dict.__getitem__(self, key)
 
-        def __getattr__(self, attr: str):
+        def __getattr__(self, attr: str) -> "Cache.CacheDict":
             path = self._path + "." + attr if self._path != "" else attr
 
             # (1) Direct route: ``path`` is a real storage key or a

--- a/src/nnsight/intervention/tracing/tracer.py
+++ b/src/nnsight/intervention/tracing/tracer.py
@@ -83,7 +83,6 @@ class Cache:
             data: "Union[Cache.CacheDict, Dict[str, Cache.Entry]]",
             path: str = "",
             alias: Optional[Dict[str, str]] = None,
-            rename: Optional[Dict[str, str]] = None,
             alias_paths: Optional[Dict[str, str]] = None,
         ):
             self._path = path
@@ -91,7 +90,6 @@ class Cache:
             # be shared by every CacheDict in the process, so alias paths
             # registered by one cache would leak into navigation of all others.
             self._alias = alias if alias is not None else {}
-            self._rename = rename if rename is not None else {}
             self._alias_paths = alias_paths if alias_paths is not None else {}
 
             # Copy underlying storage directly, bypassing any CacheDict
@@ -210,7 +208,6 @@ class Cache:
             return Cache.CacheDict(
                 self,
                 path,
-                rename=self._rename,
                 alias=self._alias,
                 alias_paths=self._alias_paths,
             )
@@ -226,66 +223,6 @@ class Cache:
             return any(
                 key == path or key.startswith(path + ".") for key in self._alias_paths
             )
-
-        @staticmethod
-        def _replace_segments(
-            segments: List[str], pattern: List[str], replacement: List[str]
-        ) -> List[str]:
-            """Replace each non-overlapping occurrence of ``pattern`` (a
-            contiguous run of path segments) in ``segments`` with
-            ``replacement``. Matching is whole-segment, so a rename like
-            ``{"h": "layers"}`` rewrites the ``h`` component without
-            corrupting ``lm_head`` the way substring replacement would.
-            """
-            if not pattern or len(pattern) > len(segments):
-                return segments
-            out = []
-            i = 0
-            while i < len(segments):
-                if segments[i : i + len(pattern)] == pattern:
-                    out.extend(replacement)
-                    i += len(pattern)
-                else:
-                    out.append(segments[i])
-                    i += 1
-            return out
-
-        def _add_alias_path(self, module_path: str) -> None:
-            if not self._rename:
-                return
-
-            # The root component (``cache.model``) is the fixed cache root
-            # and is never renamed in access space, so protect it from the
-            # replacements below. Without this a rename like ``{"model":
-            # "foo"}`` would also rewrite the root segment
-            # (``model.model.layers.0`` -> ``foo.foo.layers.0``) and the
-            # user-facing ``cache.model.foo.layers[0]`` would never match.
-            root, _, rest = str(module_path).partition(".")
-
-            if rest == "":
-                return
-
-            segments = rest.split(".")
-
-            for path, aliases in self._rename.items():
-                pattern = path.removeprefix(".").split(".")
-                if isinstance(aliases, str):
-                    aliases = [aliases]
-                # With multiple aliases for one module the first one names the
-                # alias path; the others stay reachable through the leaf-alias
-                # route in ``__getattr__``.
-                replacement = [
-                    s for s in aliases[0].removeprefix(".").split(".") if s
-                ]
-                segments = self._replace_segments(segments, pattern, replacement)
-
-            if not segments:
-                return
-
-            alias_path = ".".join([root, *segments])
-
-            if alias_path != module_path:
-                self._alias_paths[alias_path] = module_path
 
         def __getitem__(
             self, key: Union[str, int]
@@ -392,7 +329,7 @@ class Cache:
         detach: Optional[bool] = True,
         include_output: bool = True,
         include_inputs: bool = False,
-        rename: Optional[Dict[str, str]] = None,
+        aliased_paths: Optional[Dict[str, str]] = None,
         alias: Optional[Dict[str, str]] = None,
     ):
         """Initialize a Cache with optional transformation parameters.
@@ -405,7 +342,10 @@ class Cache:
             detach: Whether to detach tensors from the computation graph.
             include_output: Whether to cache module outputs.
             include_inputs: Whether to cache module inputs.
-            rename: Rename mapping for alias path resolution.
+            aliased_paths: Real path → user-facing path for every module, as
+                computed from the envoy tree (:meth:`Envoy._aliased_paths`).
+                Renamed paths of cached modules are registered in the
+                ``CacheDict``'s alias-path map as values arrive.
             alias: Alias mapping for ``CacheDict`` attribute access.
         """
         self.device = device
@@ -414,11 +354,12 @@ class Cache:
         self.modules = modules
         self.include_output = include_output
         self.include_inputs = include_inputs
+        self.aliased_paths = aliased_paths if aliased_paths is not None else {}
 
         if self.modules is not None:
             self.modules = {m if isinstance(m, str) else m.path for m in self.modules}
 
-        self.cache = Cache.CacheDict({}, rename=rename, alias=alias).save()
+        self.cache = Cache.CacheDict({}, alias=alias).save()
 
     def add(self, module_path: str, key: str, value: Any):
         """Add a value to the cache with optional transformations.
@@ -446,7 +387,14 @@ class Cache:
 
         if module_path not in self.cache:
             self.cache[module_path] = Cache.Entry(**{key: value})
-            self.cache._add_alias_path(module_path)
+
+            # Register the module's user-facing path (derived from the envoy
+            # tree at cache creation) so aliased navigation can find it. Only
+            # cached modules get entries — navigation and IndexError semantics
+            # depend on the table mirroring what was actually recorded.
+            alias_path = self.aliased_paths.get(module_path)
+            if alias_path is not None and alias_path != module_path:
+                self.cache._alias_paths[alias_path] = module_path
         else:
             entry = self.cache[module_path]
 
@@ -698,6 +646,11 @@ class InterleavingTracer(Tracer):
             A :class:`Cache.CacheDict` that is populated during execution.
         """
 
+        # Both rename views come from the envoy tree, the source of truth for
+        # rename semantics: ``alias_dict`` (alias → module name) drives the
+        # leaf-alias route of CacheDict navigation, and ``aliased_paths``
+        # (real path → user-facing path, from Envoy._aliased_paths) drives
+        # the alias-path route for collapsing/re-mount renames.
         rename_dict = (
             self.model._alias.rename if self.model._alias is not None else dict()
         )
@@ -709,6 +662,10 @@ class InterleavingTracer(Tracer):
                 aliases = [aliases]
             for alias in aliases:
                 alias_dict[alias] = name
+
+        aliased_paths = (
+            self.model._aliased_paths() if self.model._alias is not None else {}
+        )
 
         if not self.model.interleaving:
             raise ValueError("Cannot create a cache outside an invoker.")
@@ -722,8 +679,8 @@ class InterleavingTracer(Tracer):
             detach,
             include_output,
             include_inputs,
-            rename_dict,
-            alias_dict,
+            aliased_paths=aliased_paths,
+            alias=alias_dict,
         )
 
         mediator = self.model.interleaver.current

--- a/src/nnsight/intervention/tracing/tracer.py
+++ b/src/nnsight/intervention/tracing/tracer.py
@@ -278,11 +278,12 @@ class Cache:
             )
 
         def _facing_paths(self) -> Dict[str, str]:
-            """Real path → canonical user-facing path, from the skeleton.
+            """Real path → one display spelling, for ``keys(alias=True)``.
 
-            The canonical spelling uses, at each step, the first alias
-            registered for the child (or its real name), with re-mount
-            aliases overriding the whole subtree they re-mount.
+            Display only — navigation never consults this. Every alias of a
+            module navigates via :meth:`PathNode.resolve`; this just picks a
+            single spelling per module for enumeration (first alias at each
+            step, re-mount aliases overriding the subtree they re-mount).
             """
             facing: Dict[str, str] = {}
             remounts: Dict[str, str] = {}

--- a/src/nnsight/intervention/tracing/tracer.py
+++ b/src/nnsight/intervention/tracing/tracer.py
@@ -262,16 +262,22 @@ class Cache:
 
             if isinstance(name, int):
                 path = self._path + "." + f"{name}"
+                prefix = self._path + "."
 
                 if any(key.startswith(path) for key in self) or self._alias_path_prefix(
                     path
                 ):
                     return self._child(path)
+                # Out-of-bounds on a modulelist: a sibling numeric index exists
+                # under ``_path`` but ``name`` isn't one of them. Check both the
+                # real keys and the alias-path keyspace so renamed/collapsed
+                # modulelists raise ``IndexError`` rather than leaking a
+                # ``KeyError`` from the ``dict.__getitem__`` fallback below.
                 elif any(
-                    key.startswith(self._path + ".")
-                    and len(key) >= len(self._path) + 1
-                    and key[len(self._path) + 1].isdigit()
-                    for key in self
+                    key.startswith(prefix)
+                    and len(key) > len(prefix)
+                    and key[len(prefix)].isdigit()
+                    for key in (*self, *self._alias_paths)
                 ):
                     raise IndexError(
                         f"Index {key} is out of bounds for modulelist or module does not allow indexing."

--- a/src/nnsight/intervention/tracing/tracer.py
+++ b/src/nnsight/intervention/tracing/tracer.py
@@ -317,19 +317,16 @@ class Cache:
             self, key: Union[str, int]
         ) -> "Union[Cache.CacheDict, Cache.Entry, List[Cache.Entry]]":
             if isinstance(key, str):
-                # Real storage keys are authoritative: check them before any
-                # alias resolution so a rename can never shadow a genuinely
-                # cached module of the same name. This also keeps IPython
-                # pretty-printers (which call ``obj[k]`` for each ``k`` in
-                # ``keys()``) from re-resolving absolute keys.
+                # Real storage is authoritative — an alias must never shadow
+                # a genuinely cached key, and absolute keys from ``keys()``
+                # must round-trip for IPython pretty-printing.
                 if dict.__contains__(self, key):
                     return dict.__getitem__(self, key)
 
                 node = self._ensure_node()
 
-                # Resolve the (possibly dotted, possibly aliased) key against
-                # the skeleton — relative to this view first, then as an
-                # absolute path from the root.
+                # Aliased/dotted keys: relative to this view first, then
+                # absolute from the root.
                 target = node.navigate(key) if node is not None else None
                 if target is None and self._tree is not None:
                     target = self._tree.navigate(key)
@@ -345,10 +342,8 @@ class Cache:
                 if target is not None and self._cached_under(target):
                     return self._child(target)
 
-                # The index names no cached module, but numeric siblings
-                # exist: this is a modulelist and the index is out of bounds
-                # (or points at an uncached element) — IndexError, not a
-                # KeyError leak from the fallback below.
+                # Numeric siblings exist, so this is a modulelist — raise
+                # IndexError rather than leaking KeyError from the fallback.
                 if node is not None and any(
                     name.isdigit() for name in node.children
                 ):
@@ -704,10 +699,8 @@ class InterleavingTracer(Tracer):
 
         from ..hooks import cache_output_hook, cache_input_hook
 
-        # Weights-free skeleton of the envoy tree: CacheDict navigation
-        # resolves attribute/index access (including renames) against it,
-        # so rename semantics come from the same Aliaser state that answers
-        # ``model.layers`` — one source of truth.
+        # The cache navigates a weights-free snapshot of the envoy tree, so
+        # rename semantics come from one source of truth.
         cache_obj = Cache(
             modules,
             device,

--- a/src/nnsight/intervention/tracing/tracer.py
+++ b/src/nnsight/intervention/tracing/tracer.py
@@ -137,6 +137,7 @@ class Cache:
             self._path = path
             self._node = node if node is not None else tree
             self._tree = tree
+            self._derived_len = None
 
             # Copy underlying storage directly, bypassing any CacheDict
             # overrides (``__getitem__``, ``__iter__``, ``keys``) on
@@ -245,22 +246,29 @@ class Cache:
         def _ensure_node(self) -> Optional[PathNode]:
             """This view's skeleton node, deriving a bare tree from the
             storage keys if none was provided (direct construction without a
-            model). The derived tree navigates real paths only — no aliases.
+            model). The derived tree navigates real paths only — no aliases —
+            and is rebuilt when storage has grown since it was derived.
             """
-            if self._node is None:
-                root = PathNode(path="")
-                for key in dict.__iter__(self):
-                    node = root
-                    prefix = ""
-                    for segment in key.split("."):
-                        prefix = segment if prefix == "" else prefix + "." + segment
-                        nxt = node.children.get(segment)
-                        if nxt is None:
-                            nxt = PathNode(path=prefix)
-                            node.children[segment] = nxt
-                        node = nxt
-                self._tree = root
-                self._node = root if self._path == "" else root.navigate(self._path)
+            if self._node is not None and (
+                self._derived_len is None
+                or self._derived_len == dict.__len__(self)
+            ):
+                return self._node
+
+            root = PathNode(path="")
+            for key in dict.__iter__(self):
+                node = root
+                prefix = ""
+                for segment in key.split("."):
+                    prefix = segment if prefix == "" else prefix + "." + segment
+                    nxt = node.children.get(segment)
+                    if nxt is None:
+                        nxt = PathNode(path=prefix)
+                        node.children[segment] = nxt
+                    node = nxt
+            self._derived_len = dict.__len__(self)
+            self._tree = root
+            self._node = root if self._path == "" else root.navigate(self._path)
             return self._node
 
         def _cached_under(self, node: PathNode) -> bool:
@@ -358,7 +366,7 @@ class Cache:
             # Guard the fields this method itself relies on: during
             # unpickling ``__getattr__`` can fire before ``__setstate__``
             # restores them, and falling through would recurse.
-            if attr in ("_path", "_node", "_tree"):
+            if attr in ("_path", "_node", "_tree", "_derived_len"):
                 raise AttributeError(attr)
 
             node = self._ensure_node()
@@ -381,6 +389,11 @@ class Cache:
 
         def __setstate__(self, state):
             self.__dict__.update(state)
+            # Caches pickled by versions without the skeleton carry none of
+            # its fields; default them so navigation falls back to the
+            # storage-derived trie instead of raising.
+            for name in ("_path", "_node", "_tree", "_derived_len"):
+                self.__dict__.setdefault(name, None if name != "_path" else "")
 
     def __init__(
         self,

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -1454,10 +1454,25 @@ class TestCache:
                 cache.model.layers[i].input,
             )
 
+        # Dict-style access with a path relative to a sub-view must resolve
+        # through the alias map too.
+        assert torch.equal(
+            cache.model["layers.0"].output,
+            cache["model.transformer.h.0"].output,
+        )
+
         # Out-of-bounds on the renamed modulelist must raise IndexError, not
         # leak a KeyError from the underlying dict.
         with pytest.raises(IndexError):
             cache.model.layers[999]
+
+        # Layer 1 is not cached (strided subset) but layer 10 is: index 1 must
+        # not segment-match ``h.10`` and hand back a broken sub-view. Both the
+        # renamed and the real route must raise IndexError.
+        with pytest.raises(IndexError):
+            cache.model.layers[1]
+        with pytest.raises(IndexError):
+            cache.model.transformer.h[1]
 
         # Full cache (no ``modules=``): navigating into a submodule of a
         # re-mounted block must resolve through the alias path too.
@@ -1490,6 +1505,77 @@ class TestCache:
             cache["model.model.layers.0"].output[0],
             cache.model.foo.layers[0].output[0],
         )
+
+    @torch.no_grad()
+    def test_cache_list_rename(self, MSG_prompt: str):
+        """Renames with a list of aliases must not break cache creation.
+
+        ``rename={"transformer": ["model", "mdl"]}`` is documented Aliaser
+        syntax; building the cache's alias dict from it must not crash, and
+        both aliases must navigate to the module.
+        """
+        gpt2 = nnsight.LanguageModel(
+            "openai-community/gpt2",
+            rename={"transformer": ["model", "mdl"], "h": "layers"},
+        )
+
+        with gpt2.trace(MSG_prompt) as tracer:
+            cache = tracer.cache(modules=[gpt2.mdl.layers[0]]).save()
+
+        assert torch.equal(
+            cache["model.transformer.h.0"].output[0],
+            cache.model.model.layers[0].output[0],
+        )
+        assert torch.equal(
+            cache["model.transformer.h.0"].output[0],
+            cache.model.mdl.layers[0].output[0],
+        )
+
+    def test_cache_dict_state_isolated(self):
+        """CacheDict instances must not share alias/rename state.
+
+        Mutable default arguments would make ``_alias_paths`` a single dict
+        shared by every cache in the process, leaking alias paths registered
+        by one (renamed) cache into the navigation of all others.
+        """
+        from nnsight.intervention.tracing.tracer import Cache
+
+        a = Cache.CacheDict({}, rename={"h": "layers"})
+        b = Cache.CacheDict({})
+
+        assert a._alias_paths is not b._alias_paths
+        assert a._alias is not b._alias
+        assert a._rename is not b._rename
+
+        dict.__setitem__(
+            a, "model.transformer.h.0", Cache.Entry(output=1)
+        )
+        a._add_alias_path("model.transformer.h.0")
+
+        assert "model.transformer.layers.0" in a._alias_paths
+        assert not b._alias_paths
+
+    def test_cache_alias_never_shadows_real_key(self):
+        """A rename must not reroute access to a genuinely cached module.
+
+        With ``rename={"a": "b", "b": "a"}`` the alias path of ``model.x.b``
+        is ``model.x.a`` — which is also a real storage key. Real keys are
+        authoritative for both dict-style access and ``.output`` resolution.
+        """
+        from nnsight.intervention.tracing.tracer import Cache
+
+        rename = {"a": "b", "b": "a"}
+        cd = Cache.CacheDict(
+            {}, rename=rename, alias={v: k for k, v in rename.items()}
+        )
+        for path, out in (("model.x.a", "A"), ("model.x.b", "B")):
+            dict.__setitem__(cd, path, Cache.Entry(output=out))
+            cd._add_alias_path(path)
+
+        assert cd["model.x.a"].output == "A"
+        assert cd["model.x.b"].output == "B"
+        assert cd.model.x.a.output == "A"
+        assert cd.model.x.b.output == "B"
 
 
 # =============================================================================

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -1614,6 +1614,45 @@ class TestCache:
             cache.model.blocks[0].output[0],
         )
 
+    @torch.no_grad()
+    def test_cache_navigation_matches_envoy(self, MSG_prompt: str):
+        """Cache navigation is equivalent to envoy navigation.
+
+        Both resolve aliases through ``Aliaser.resolve``, so every spelling
+        that reaches a module on the model — real names, leaf aliases,
+        collapsing re-mounts, and any mix — reaches the same entry on the
+        cache.
+        """
+        from nnsight import util
+
+        gpt2 = nnsight.LanguageModel(
+            "openai-community/gpt2",
+            rename={"transformer": "model", "h": "layers", "model.layers": "layers"},
+        )
+
+        with gpt2.trace(MSG_prompt) as tracer:
+            cache = tracer.cache(modules=[gpt2.layers[0]]).save()
+
+        spellings = [
+            "transformer.h",
+            "transformer.layers",
+            "model.h",
+            "model.layers",
+            "layers",
+        ]
+
+        for spelling in spellings:
+            envoy = util.fetch_attr(gpt2, spelling)
+            assert envoy.path == "model.transformer.h"
+
+            view = cache.model
+            for segment in spelling.split("."):
+                view = getattr(view, segment)
+            assert torch.equal(
+                view[0].output[0],
+                cache["model.transformer.h.0"].output[0],
+            )
+
 
 # =============================================================================
 # Module Renaming

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -1492,6 +1492,9 @@ class TestCache:
         assert root.aliases["model"].path == "model.transformer"
         assert "lm_head" in root.children
 
+        # keys(alias=True) enumerates one renamed spelling per cached module.
+        assert "model.layers.0" in cache.keys(alias=True)
+
     @torch.no_grad()
     def test_cache_rename_preserves_root(self, MSG_prompt: str):
         """A rename matching the root component name must not corrupt the root.
@@ -1555,6 +1558,26 @@ class TestCache:
         assert a.model.x.output == 1
         with pytest.raises(AttributeError):
             b.model
+
+        # The storage-derived fallback trie must pick up keys added after
+        # the first navigation.
+        dict.__setitem__(a, "model.y", Cache.Entry(output=2))
+        assert a.model.y.output == 2
+
+    def test_cache_dict_old_pickle_state(self):
+        """Caches pickled before the skeleton fields existed still navigate.
+
+        ``__setstate__`` defaults the missing fields so attribute access
+        falls back to the storage-derived trie instead of raising.
+        """
+        from nnsight.intervention.tracing.tracer import Cache
+
+        d = Cache.CacheDict({})
+        dict.__setitem__(d, "model.x", Cache.Entry(output=1))
+        d.__dict__.clear()
+        d.__setstate__({"_path": "", "_alias": {}, "_alias_paths": {}})
+
+        assert d.model.x.output == 1
 
     def test_cache_alias_never_shadows_real_key(self):
         """A rename must not reroute access to a genuinely cached module.
@@ -1704,6 +1727,18 @@ class TestRename:
 
         assert mlp_out_0 is not None
         assert mlp_out_1 is not None
+
+    @torch.no_grad()
+    def test_rename_dotted_alias_value(self, MSG_prompt: str):
+        """Alias values may carry a leading dot (documented Aliaser form)."""
+        gpt2 = nnsight.LanguageModel(
+            "openai-community/gpt2", rename={".transformer.h": ".layers"}
+        )
+
+        with gpt2.trace(MSG_prompt):
+            out = gpt2.layers[0].output.save()
+
+        assert out is not None
 
     @torch.no_grad()
     def test_rename_module_list_path(self, MSG_prompt: str):

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -1436,8 +1436,12 @@ class TestCache:
             rename={"transformer": "model", "h": "layers", "model.layers": "layers"},
         )
 
+        # Explicit subset (strided) with inputs, exercising ``.output``,
+        # ``.input`` and out-of-bounds indexing through the renamed path.
         with gpt2.trace(MSG_prompt) as tracer:
-            cache = tracer.cache(modules=[l for l in gpt2.layers[::2]]).save()
+            cache = tracer.cache(
+                modules=[l for l in gpt2.layers[::2]], include_inputs=True
+            ).save()
 
         for i in range(0, 12, 2):
             # dict-style (real key) and attribute-style (renamed) must agree.
@@ -1445,6 +1449,25 @@ class TestCache:
                 cache[f"model.transformer.h.{i}"].output,
                 cache.model.layers[i].output,
             )
+            assert torch.equal(
+                cache[f"model.transformer.h.{i}"].input,
+                cache.model.layers[i].input,
+            )
+
+        # Out-of-bounds on the renamed modulelist must raise IndexError, not
+        # leak a KeyError from the underlying dict.
+        with pytest.raises(IndexError):
+            cache.model.layers[999]
+
+        # Full cache (no ``modules=``): navigating into a submodule of a
+        # re-mounted block must resolve through the alias path too.
+        with gpt2.trace(MSG_prompt) as tracer:
+            cache = tracer.cache().save()
+
+        assert torch.equal(
+            cache["model.transformer.h.0.attn"].output[0],
+            cache.model.layers[0].attn.output[0],
+        )
 
     @torch.no_grad()
     def test_cache_rename_preserves_root(self, MSG_prompt: str):

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -1422,6 +1422,52 @@ class TestCache:
             cache.model.model.h["second_layer"].output,
         )
 
+    @torch.no_grad()
+    def test_cache_collapsing_rename(self, MSG_prompt: str):
+        """Attribute access through a collapsing / re-mount rename (issue #535).
+
+        A rename whose key is a dotted path (e.g. ``"model.layers": "layers"``)
+        re-mounts a nested module at the root. The renamed access path
+        (``cache.model.layers[i]``) is not a prefix of any real storage key, so
+        it must resolve through the alias-path map rather than the real keys.
+        """
+        gpt2 = nnsight.LanguageModel(
+            "openai-community/gpt2",
+            rename={"transformer": "model", "h": "layers", "model.layers": "layers"},
+        )
+
+        with gpt2.trace(MSG_prompt) as tracer:
+            cache = tracer.cache(modules=[l for l in gpt2.layers[::2]]).save()
+
+        for i in range(0, 12, 2):
+            # dict-style (real key) and attribute-style (renamed) must agree.
+            assert torch.equal(
+                cache[f"model.transformer.h.{i}"].output,
+                cache.model.layers[i].output,
+            )
+
+    @torch.no_grad()
+    def test_cache_rename_preserves_root(self, MSG_prompt: str):
+        """A rename matching the root component name must not corrupt the root.
+
+        With ``rename={"model": "foo"}`` the real key ``model.model.layers.0``
+        must alias to ``model.foo.layers.0`` (renaming only the nested
+        ``model``), not ``foo.foo.layers.0`` — the ``cache.model`` root is fixed
+        (issue #535, original example).
+        """
+        lm = nnsight.LanguageModel(
+            "yujiepan/llama-3.2-tiny-random",
+            rename={"model": "foo", "model.language_model": "foo"},
+        )
+
+        with lm.trace(MSG_prompt) as tracer:
+            cache = tracer.cache(modules=[lm.foo.layers[0]]).save()
+
+        assert torch.equal(
+            cache["model.model.layers.0"].output[0],
+            cache.model.foo.layers[0].output[0],
+        )
+
 
 # =============================================================================
 # Module Renaming

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -1484,6 +1484,14 @@ class TestCache:
             cache.model.layers[0].attn.output[0],
         )
 
+        # The alias paths the cache navigates are derived from the envoy
+        # tree itself, so they agree with what envoy attribute access
+        # resolves — including chained renames and re-mounts.
+        facing = gpt2._aliased_paths()
+        assert facing["model.transformer.h.0"] == "model.layers.0"
+        assert facing["model.transformer.h.0.attn"] == "model.layers.0.attn"
+        assert facing["model.lm_head"] == "model.lm_head"
+
     @torch.no_grad()
     def test_cache_rename_preserves_root(self, MSG_prompt: str):
         """A rename matching the root component name must not corrupt the root.
@@ -1532,7 +1540,7 @@ class TestCache:
         )
 
     def test_cache_dict_state_isolated(self):
-        """CacheDict instances must not share alias/rename state.
+        """CacheDict instances must not share alias state.
 
         Mutable default arguments would make ``_alias_paths`` a single dict
         shared by every cache in the process, leaking alias paths registered
@@ -1540,19 +1548,14 @@ class TestCache:
         """
         from nnsight.intervention.tracing.tracer import Cache
 
-        a = Cache.CacheDict({}, rename={"h": "layers"})
+        a = Cache.CacheDict({})
         b = Cache.CacheDict({})
 
         assert a._alias_paths is not b._alias_paths
         assert a._alias is not b._alias
-        assert a._rename is not b._rename
 
-        dict.__setitem__(
-            a, "model.transformer.h.0", Cache.Entry(output=1)
-        )
-        a._add_alias_path("model.transformer.h.0")
+        a._alias_paths["model.layers.0"] = "model.transformer.h.0"
 
-        assert "model.transformer.layers.0" in a._alias_paths
         assert not b._alias_paths
 
     def test_cache_alias_never_shadows_real_key(self):
@@ -1564,13 +1567,13 @@ class TestCache:
         """
         from nnsight.intervention.tracing.tracer import Cache
 
-        rename = {"a": "b", "b": "a"}
         cd = Cache.CacheDict(
-            {}, rename=rename, alias={v: k for k, v in rename.items()}
+            {},
+            alias={"b": "a", "a": "b"},
+            alias_paths={"model.x.a": "model.x.b", "model.x.b": "model.x.a"},
         )
         for path, out in (("model.x.a", "A"), ("model.x.b", "B")):
             dict.__setitem__(cd, path, Cache.Entry(output=out))
-            cd._add_alias_path(path)
 
         assert cd["model.x.a"].output == "A"
         assert cd["model.x.b"].output == "B"

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -1495,6 +1495,12 @@ class TestCache:
         # keys(alias=True) enumerates one renamed spelling per cached module.
         assert "model.layers.0" in cache.keys(alias=True)
 
+        # Membership agrees with lookup, renamed spellings included.
+        assert "model.layers.0" in cache
+        assert "model.transformer.h.0" in cache
+        assert "layers.0" in cache.model
+        assert "model.layers.999" not in cache
+
     @torch.no_grad()
     def test_cache_rename_preserves_root(self, MSG_prompt: str):
         """A rename matching the root component name must not corrupt the root.
@@ -1563,6 +1569,37 @@ class TestCache:
         # the first navigation.
         dict.__setitem__(a, "model.y", Cache.Entry(output=2))
         assert a.model.y.output == 2
+
+    @torch.no_grad()
+    def test_cache_hooks_removed_after_trace(
+        self, gpt2: nnsight.LanguageModel, MSG_prompt: str
+    ):
+        """Cache hooks are removed when the trace exits.
+
+        They used to leak (dead mediators were pruned before ``cancel()``
+        could drain their hooks), so the next trace on the same model
+        re-fired them into the first trace's cache, silently turning its
+        entries into lists.
+        """
+        from nnsight.intervention.tracing.tracer import Cache
+
+        module = gpt2.transformer.h[0]._module
+        hooks_before = len(module._forward_hooks) + len(module._forward_pre_hooks)
+
+        with gpt2.trace(MSG_prompt) as tracer:
+            cache = tracer.cache(modules=[gpt2.transformer.h[0]]).save()
+
+        output = cache["model.transformer.h.0"].output
+
+        with gpt2.trace(MSG_prompt):
+            pass
+
+        hooks_after = len(module._forward_hooks) + len(module._forward_pre_hooks)
+        assert hooks_after == hooks_before
+
+        entry = dict.__getitem__(cache, "model.transformer.h.0")
+        assert isinstance(entry, Cache.Entry)
+        assert torch.equal(cache["model.transformer.h.0"].output, output)
 
     def test_cache_dict_old_pickle_state(self):
         """Caches pickled before the skeleton fields existed still navigate.

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -1484,13 +1484,13 @@ class TestCache:
             cache.model.layers[0].attn.output[0],
         )
 
-        # The alias paths the cache navigates are derived from the envoy
-        # tree itself, so they agree with what envoy attribute access
-        # resolves — including chained renames and re-mounts.
-        facing = gpt2._aliased_paths()
-        assert facing["model.transformer.h.0"] == "model.layers.0"
-        assert facing["model.transformer.h.0.attn"] == "model.layers.0.attn"
-        assert facing["model.lm_head"] == "model.lm_head"
+        # Navigation resolves against a skeleton of the envoy tree, so
+        # aliases agree with what envoy attribute access resolves —
+        # including chained renames and re-mounts.
+        root = gpt2._skeleton().children["model"]
+        assert root.aliases["layers"].path == "model.transformer.h"
+        assert root.aliases["model"].path == "model.transformer"
+        assert "lm_head" in root.children
 
     @torch.no_grad()
     def test_cache_rename_preserves_root(self, MSG_prompt: str):
@@ -1540,38 +1540,43 @@ class TestCache:
         )
 
     def test_cache_dict_state_isolated(self):
-        """CacheDict instances must not share alias state.
+        """CacheDict instances must not share navigation state.
 
-        Mutable default arguments would make ``_alias_paths`` a single dict
-        shared by every cache in the process, leaking alias paths registered
-        by one (renamed) cache into the navigation of all others.
+        Each cache derives (or is given) its own skeleton; one cache's
+        storage or tree must never leak into another's navigation.
         """
         from nnsight.intervention.tracing.tracer import Cache
 
         a = Cache.CacheDict({})
         b = Cache.CacheDict({})
 
-        assert a._alias_paths is not b._alias_paths
-        assert a._alias is not b._alias
+        dict.__setitem__(a, "model.x", Cache.Entry(output=1))
 
-        a._alias_paths["model.layers.0"] = "model.transformer.h.0"
-
-        assert not b._alias_paths
+        assert a.model.x.output == 1
+        with pytest.raises(AttributeError):
+            b.model
 
     def test_cache_alias_never_shadows_real_key(self):
         """A rename must not reroute access to a genuinely cached module.
 
-        With ``rename={"a": "b", "b": "a"}`` the alias path of ``model.x.b``
-        is ``model.x.a`` — which is also a real storage key. Real keys are
-        authoritative for both dict-style access and ``.output`` resolution.
+        With a swap rename ``{"a": "b", "b": "a"}`` each name is both a real
+        child and an alias for the sibling. Real children are authoritative
+        in ``PathNode.resolve``, so navigation and dict access return each
+        module's own entry.
         """
-        from nnsight.intervention.tracing.tracer import Cache
+        from nnsight.intervention.tracing.tracer import Cache, PathNode
 
-        cd = Cache.CacheDict(
-            {},
-            alias={"b": "a", "a": "b"},
-            alias_paths={"model.x.a": "model.x.b", "model.x.b": "model.x.a"},
+        a = PathNode(path="model.x.a")
+        b = PathNode(path="model.x.b")
+        x = PathNode(
+            path="model.x",
+            children={"a": a, "b": b},
+            aliases={"a": b, "b": a},
         )
+        root = PathNode(path="model", children={"x": x})
+        tree = PathNode(path="", children={"model": root})
+
+        cd = Cache.CacheDict({}, tree=tree)
         for path, out in (("model.x.a", "A"), ("model.x.b", "B")):
             dict.__setitem__(cd, path, Cache.Entry(output=out))
 
@@ -1579,6 +1584,35 @@ class TestCache:
         assert cd["model.x.b"].output == "B"
         assert cd.model.x.a.output == "A"
         assert cd.model.x.b.output == "B"
+
+    @torch.no_grad()
+    def test_cache_collapsing_list_rename(self, MSG_prompt: str):
+        """Secondary aliases of a collapsing rename navigate too.
+
+        Skeleton nodes register every alias of a module, not just the first
+        one, so ``blocks`` works even though the collapsed target only
+        resolves through chained renames.
+        """
+        gpt2 = nnsight.LanguageModel(
+            "openai-community/gpt2",
+            rename={
+                "transformer": "model",
+                "h": "layers",
+                "model.layers": ["layers", "blocks"],
+            },
+        )
+
+        with gpt2.trace(MSG_prompt) as tracer:
+            cache = tracer.cache(modules=[gpt2.layers[0]]).save()
+
+        assert torch.equal(
+            cache["model.transformer.h.0"].output[0],
+            cache.model.layers[0].output[0],
+        )
+        assert torch.equal(
+            cache["model.transformer.h.0"].output[0],
+            cache.model.blocks[0].output[0],
+        )
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Started as a fix for #535 (cache attribute access broken under collapsing/re-mount renames) and grew into a robustness pass over the activation-cache subsystem. Three headline changes:

1. **Cache navigation is structural and shares rename semantics with the envoy tree** — fixes #535 and the whole class of string-matching bugs around it.
2. **Cache hooks are actually removed at trace exit** — previously they leaked, and the *next* trace on the same model silently corrupted the old cache.
3. **Membership (`in`) and lookup (`[]`) share one resolution semantics** — renamed spellings included.

## 1. Rename navigation (fixes #535)

Cache storage keys are always **real** module paths (dict-style access, `keys()`, iteration unchanged). Navigation resolves against a **weights-free skeleton of the envoy tree**:

- `Envoy._skeleton()` snapshots the tree as `PathNode`s: real path, children by name, aliases resolved to their *target nodes* via `Aliaser.resolve(envoy, alias)` — the **same function** `Envoy.__getattr__` uses, so cache and envoy cannot disagree about what an alias means. Nodes hold no modules: the skeleton pickles, travels with remote results, and keeps no weights alive.
- `CacheDict` navigation is per-segment tree descent (`PathNode.resolve`, real children authoritative over aliases). Navigation refuses to descend into subtrees where nothing was cached, and error messages now distinguish *"exists on the model but was never cached"* from *"no such module"*.
- Every alias of a module navigates — `cache.model.transformer.h[x]`, `cache.model.model.layers[x]`, `cache.model.layers[x]`, and secondary aliases of collapsing renames (`{"model.layers": ["layers", "blocks"]}`) all reach the same entry. `test_cache_navigation_matches_envoy` sweeps the spellings and asserts envoy/cache equivalence.
- List-valued renames (documented Aliaser syntax) no longer crash `tracer.cache()`; dot-prefixed alias values (`{".transformer.h": ".layers"}`, also documented) now work on the envoy side too (`Aliaser.build` normalizes them).
- Out-of-bounds indices on (renamed) module lists raise `IndexError`; index 1 can no longer string-prefix-match `h.10`. Old pickles (no skeleton fields) fall back to a storage-derived trie, as do `CacheDict`s constructed without a model.
- Also fixed along the way: shared-mutable-default state across all `CacheDict`s in a process; the fixed `cache.model` root being corrupted by renames like `{"model": "foo"}`.

## 2. Hook lifecycle

Persistent cache hooks were never removed: dead mediators are pruned from `interleaver.mediators` (in `__exit__` and `check_dangling_mediators`) *before* `cancel()` runs `remove_hooks()`, so the handles leaked onto the modules. Consequence: run a second `model.trace(...)` on the same model and the first trace's cache hooks fire again — entries silently become `[Entry, Entry]` lists and previously-working `.output` calls raise `AttributeError: 'list' object has no attribute 'output'`.

Hooks can't be removed the moment a mediator dies (vLLM re-enters the interleaver context per engine step and cache hooks must keep recording across steps), so pruned mediators' handles are **retired** to the interleaver and drained in `cancel()` — the documented single per-trace cleanup path. `test_cache_hooks_removed_after_trace` asserts hook counts return to baseline and a prior cache survives subsequent traces intact.

## 3. Membership = lookup

`"model.layers.0" in cache` was `False` while `cache["model.layers.0"]` succeeded. `__contains__` now delegates to `__getitem__`, so `in` covers renamed spellings and sub-view-relative keys exactly like access does.

## Tests

Nine new/extended tests in `tests/test_lm.py::TestCache` plus one in `TestRename` (dotted alias values): collapsing renames (incl. list-valued and secondary aliases), root protection (issue #535's original example), envoy/cache navigation equivalence sweep, membership/lookup agreement, state isolation, alias-never-shadows-real-key, old-pickle compatibility, and hook removal across traces.

`tests/test_lm.py`: **90 passed** · `test_tiny.py`: 18 · `test_envoys/test_source/test_iter_edge_cases/test_memory_cleanup/test_multiple_wrappers/test_transform/test_0516_features`: 115 passed, 1 xpassed (all on `dev` base). All three repro snippets from the #535 thread verified. The branch was also adversarially reviewed by an independent agent (A/B behavioral comparison against `dev` on seven access patterns, pickle/deepcopy round-trips, multi-fire generation, swap renames); its findings are addressed in the later commits.

https://claude.ai/code/session_01GPKVtGmUQWFsS7dMEUsNNe