### PR TITLE
Trace a model sharded with transformers tensor parallelism

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -44,4 +44,4 @@ jobs:
         env:
           CUDA_VISIBLE_DEVICES: ""
           HF_HUB_DISABLE_PROGRESS_BARS: "1"
-        run: pytest tests/ -q --ignore=tests/vllm
+        run: pytest tests/ -q --ignore=tests/vllm --ignore=tests/tp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,9 @@ If you're new to nnsight, read [docs/concepts/index.md](docs/concepts/index.md) 
 - [docs/patterns/gradient-based-attribution.md](docs/patterns/gradient-based-attribution.md)
 - [docs/patterns/attribution-patching.md](docs/patterns/attribution-patching.md)
 
+### "My model is too big for one GPU"
+- [docs/models/tensor-parallel.md](docs/models/tensor-parallel.md) — `transformers` tensor parallelism: `distributed_config=DistributedConfig(tp_size=N)` under `torchrun`, sharded activations gathered so the trace reads as it would on one GPU
+
 ### "I want to run remotely on NDIF"
 - [docs/remote/ndif-overview.md](docs/remote/ndif-overview.md) — what NDIF is, job lifecycle
 - [docs/remote/api-key-and-config.md](docs/remote/api-key-and-config.md) — set up your API key
@@ -91,7 +94,8 @@ If you're new to nnsight, read [docs/concepts/index.md](docs/concepts/index.md) 
 | Any `torch.nn.Module` | `NNsight(module)` | [docs/models/nnsight-base.md](docs/models/nnsight-base.md) |
 | **HuggingFace model (text/vision/multimodal/audio)** | `TransformersModel("repo/id", task=...)` | [docs/models/transformers-model.md](docs/models/transformers-model.md) |
 | Diffusion pipelines | `DiffusionModel("repo/id", ...)` | [docs/models/diffusion-model.md](docs/models/diffusion-model.md) |
-| High-throughput / production / TP | `VLLM("repo/id", mode="sync"\|"async")` | [docs/models/vllm.md](docs/models/vllm.md) |
+| High-throughput / production | `VLLM("repo/id", mode="sync"\|"async")` | [docs/models/vllm.md](docs/models/vllm.md) |
+| **Model too big for one GPU (tensor parallel)** | `TransformersModel(..., distributed_config=DistributedConfig(tp_size=N))` under `torchrun` | [docs/models/tensor-parallel.md](docs/models/tensor-parallel.md) |
 | Causal LM (**deprecated** alias) | `LanguageModel(...)` → use `TransformersModel(task="text-generation")` | [docs/models/language-model.md](docs/models/language-model.md) |
 | Vision-language (**deprecated** alias) | `VisionLanguageModel(...)` → use `TransformersModel(task="image-text-to-text")` | [docs/models/vision-language-model.md](docs/models/vision-language-model.md) |
 

--- a/docs/developing/fragments-proposal.md
+++ b/docs/developing/fragments-proposal.md
@@ -1,25 +1,30 @@
 ---
-title: "Proposal: one seam for distributed values"
-one_liner: vLLM and tensor parallelism both make a fragment whole at a location, in two unrelated subclasses of two unrelated base classes. What a shared collaborator would look like, what it costs, and when to do it.
-tags: [internals, dev, proposal]
+title: "One seam for distributed values"
+one_liner: vLLM and tensor parallelism both make a fragment whole at a location; they now do it through one collaborator on the interleaver instead of two unrelated subclasses. Why it sits there, and what the port cost.
+tags: [internals, dev]
 related: [docs/developing/vllm-integration.md, docs/developing/interleaver-internals.md, docs/developing/batching-internals.md, docs/models/tensor-parallel.md]
-sources: [src/nnsight/modeling/tp/interleaver.py, src/nnsight/modeling/vllm/batching.py, src/nnsight/intervention/interleaver.py, src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py]
+sources: [src/nnsight/intervention/fragments.py, src/nnsight/modeling/tp/fragments.py, src/nnsight/modeling/vllm/fragments.py, src/nnsight/modeling/vllm/batching.py, src/nnsight/intervention/interleaver.py, src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py]
 ---
 
-# Proposal: one seam for distributed values
+# One seam for distributed values
 
-**Status: not implemented.** Written down after an audit of the tensor-parallel
-work. Do it when either the MoE gather or a third distributed runtime lands —
-doing it now, purely for symmetry, buys tidiness and risks a runtime whose tests
-need GPUs.
+**Status: implemented.** Written down after an audit of the tensor-parallel
+work, then built. Both runtimes now go through
+[`Fragments`][nnsight.intervention.fragments.Fragments]; `TPInterleaver` and the
+gather half of `VLLMBatcher` are gone.
+
+Verified on 8xA100: the vLLM tensor-parallel suite passed 17/17 before the port
+and 17/17 after, the MoE suite alongside it, the full vLLM suite 112 passed with
+one pre-existing failure (`test_temperature_changes_samples`, confirmed identical
+with the change reverted), and the transformers TP suite 129.
 
 ## The observation
 
-nnsight has two implementations of the same idea, and they share no code:
+nnsight had two implementations of the same idea, sharing no code:
 
 | | vLLM | tensor parallelism |
 |---|---|---|
-| where | [`VLLMBatcher`][nnsight.modeling.vllm.batching.VLLMBatcher] | [`TPInterleaver`][nnsight.modeling.tp.interleaver.TPInterleaver] |
+| where | `VLLMBatcher` | `TPInterleaver` |
 | extends | `Batcher` | `Interleaver` |
 | "is this a fragment?" | a module registered by `watch` | a `_hf_tp_plan` stamp, per `SHARDED_SIDES` |
 | "make it whole" | all-gather, or all-reduce for a deferred MoE partial | `all_gather` |
@@ -34,9 +39,9 @@ The concrete cost is not duplication — the two gathers are genuinely different
 collectives. It is that **`VLLMBatcher` already knows how to gather a
 deferred-reduce MoE partial** (`vllm/batching.py`: all-reduce, then divide by
 `tp_size * ep_size` so the block's own reduce sums it exactly once) and that
-knowledge is structurally unreachable from `TPInterleaver`. Meanwhile the
-transformers TP path refuses every expert-parallel style it cannot gather. We are
-paying for the same hole twice, in two places that cannot lend each other
+knowledge was structurally unreachable from `TPInterleaver`. Meanwhile the
+transformers TP path refused every expert-parallel style it could not gather. We
+were paying for the same hole twice, in two places that could not lend each other
 anything.
 
 ## Why they ended up in different base classes
@@ -53,9 +58,9 @@ brackets that its **model runner** installs (`GPUModelRunner.py`), which it can 
 because it owns the forward.
 
 `Interleaver.handle` is already the once-per-visit bracket, so `TPInterleaver`
-needs no memo and no external bracket. That is the real argument, and it points
-at the right shape for a shared seam: **it belongs on the interleaver, called once
-per visit, with the runtime supplying only the policy.**
+needed no memo and no external bracket. That is the real argument, and it is what
+decided the shape: **it belongs on the interleaver, called once per visit, with
+the runtime supplying only the policy.**
 
 (The rationale this replaces claimed `_batcher_class` would resolve to the
 *client's* class across a remote trace. It does not: `Envoy.__getstate__` pickles
@@ -66,7 +71,8 @@ would just have been called at the wrong granularity.)
 
 ## The shape
 
-A collaborator object, not a subclass:
+A collaborator object, not a subclass. As built it also carries `enabled`,
+`begin` and `read` — see below for why:
 
 ```python
 # src/nnsight/intervention/fragments.py
@@ -110,44 +116,54 @@ class Interleaver:
         return self.fragments.fragment(provider, value) if gathering else value
 ```
 
-`observed` moves up from `TPInterleaver` unchanged — it is already generic ("is
+`observed` moved up from `TPInterleaver` unchanged — it was already generic ("is
 any worker or cache waiting on *this* visit"), and it is what keeps an untouched
 location free.
 
 Then:
 
-- **`TPFragments`** is today's `SHARDED_SIDES` table plus `_gather`/`_reshard`,
-  around 110 lines. `TPInterleaver` disappears entirely, and with it the
-  install-one-on-every-`HuggingFaceModel`-in-case-it-is-sharded dance in
-  `huggingface.py`. The rules are recorded by whatever walks the tree; the
-  interleaver stops knowing what a shard is.
-- **`VLLMFragments`** is today's `_whole`/`_shard`, keyed by location instead of
-  by a `watch`ed module. vLLM's runner already walks the modules at load, so it
-  registers `location -> module` there once instead of installing two hooks per
-  parallel layer. `self.gathered`, `watch`, `release` and the four hook installers
-  all delete. `VLLMBatcher` shrinks to the `batching = True` override — roughly 15
-  lines where there are now 210.
+- **`TPFragments`** is the `SHARDED_SIDES` table plus `_gather`/`_reshard`.
+  `TPInterleaver` is gone, and with it the install-one-on-every-`HuggingFaceModel`
+  dance — a HuggingFace model now gets an ordinary `Interleaver` carrying
+  `TPFragments`. The interleaver no longer knows what a shard is.
+- **`VLLMFragments`** is the old `_whole`/`_shard`, keyed by location instead of
+  by a `watch`ed module: `instrument` records `location -> (module, side)` as the
+  tree is built. `self.gathered`, `watch`, `release`, `narrow`/`widen` and **both
+  hook installers in `GPUModelRunner`** are gone. `VLLMBatcher` is down to
+  `batching = True` and a constructor, from about 210 lines.
 
-## What it costs
+## Three things the sketch above missed
 
-- A refactor of the vLLM path, whose tests need GPUs. This is the whole risk.
-- `VLLMBatcher._whole` currently needs the live module for `isinstance` checks, so
-  the location-to-module map must be built at load. That is a real behavioral
-  change if vLLM ever swaps modules mid-run — **unverified**; check before
-  starting.
+- **`enabled`.** Without it, an unsharded HuggingFace model would call `observed`
+  — which loops every mediator — at every location, where before it cost one
+  attribute check. A `Fragments` starts disabled and a subclass flips it on
+  finding something actually split.
+- **`read(location)`.** The `.source` warning under tensor parallelism has to fire
+  for values that are *not* fragments (that is the whole point: they can't be
+  gathered, so the reader is told). It needed a hook of its own, called for any
+  observed location.
+- **`begin()`.** `TPInterleaver.__enter__` cleared its warned-set each run so a
+  long-lived model actor warns every user, not just the first. With the subclass
+  gone that needed an explicit per-run hook.
+
+## What it cost
+
+- One real bug, caught by the vLLM suite: rewriting `VLLMBatcher` dropped its
+  `__init__`, and the base `Batcher` requires an `envoy` the model runner has no
+  tree to supply yet. The engine failed to start.
+- The module-swap worry turned out to be a non-issue, and for a reason worth
+  recording: the previous design registered forward hooks on those same module
+  objects at load, so a swapped module would have gone just as dead. Holding a
+  reference is no weaker than what it replaced.
 - External subclasses of `VLLMBatcher` break. Unlikely to exist, not impossible.
 
-## What it buys
+## What it bought
 
 - One place to add a gather rule, so the MoE work lands once instead of twice.
 - A third runtime implements one small object instead of choosing a base class
   and inheriting a scheduling concern it does not care about.
-- `Interleaver` stops having a subclass whose only job is a policy decision, and
-  `Batcher` goes back to being only about rows.
-
-## When
-
-When the MoE gather is picked up, or when a third distributed runtime appears.
-Not before: the present arrangement is correct, tested on hardware at degree 2 and
-4, and the duplication is costing exactly one thing (the MoE knowledge) that
-nothing is currently asking for.
+- `Interleaver` no longer has a subclass whose only job is a policy decision, and
+  `Batcher` is back to being only about rows.
+- Two fewer forward hooks per parallel layer in vLLM, and the load-order
+  dependency they relied on — watch registered *before* the tree, release *after*
+  — is gone with them. That was correct and entirely invisible.

--- a/docs/developing/fragments-proposal.md
+++ b/docs/developing/fragments-proposal.md
@@ -1,0 +1,153 @@
+---
+title: "Proposal: one seam for distributed values"
+one_liner: vLLM and tensor parallelism both make a fragment whole at a location, in two unrelated subclasses of two unrelated base classes. What a shared collaborator would look like, what it costs, and when to do it.
+tags: [internals, dev, proposal]
+related: [docs/developing/vllm-integration.md, docs/developing/interleaver-internals.md, docs/developing/batching-internals.md, docs/models/tensor-parallel.md]
+sources: [src/nnsight/modeling/tp/interleaver.py, src/nnsight/modeling/vllm/batching.py, src/nnsight/intervention/interleaver.py, src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py]
+---
+
+# Proposal: one seam for distributed values
+
+**Status: not implemented.** Written down after an audit of the tensor-parallel
+work. Do it when either the MoE gather or a third distributed runtime lands —
+doing it now, purely for symmetry, buys tidiness and risks a runtime whose tests
+need GPUs.
+
+## The observation
+
+nnsight has two implementations of the same idea, and they share no code:
+
+| | vLLM | tensor parallelism |
+|---|---|---|
+| where | [`VLLMBatcher`][nnsight.modeling.vllm.batching.VLLMBatcher] | [`TPInterleaver`][nnsight.modeling.tp.interleaver.TPInterleaver] |
+| extends | `Batcher` | `Interleaver` |
+| "is this a fragment?" | a module registered by `watch` | a `_hf_tp_plan` stamp, per `SHARDED_SIDES` |
+| "make it whole" | all-gather, or all-reduce for a deferred MoE partial | `all_gather` |
+| "put it back" | re-shard, scaling a write-back by `tp_size * ep_size` | `split` |
+
+Both answer the same three questions about a value at a location. Neither
+`Batcher` (which exists to narrow a batch's rows) nor `Interleaver` (which exists
+to schedule greenlets) is *about* that question, so each subclass carries the
+answer as a passenger.
+
+The concrete cost is not duplication — the two gathers are genuinely different
+collectives. It is that **`VLLMBatcher` already knows how to gather a
+deferred-reduce MoE partial** (`vllm/batching.py`: all-reduce, then divide by
+`tp_size * ep_size` so the block's own reduce sums it exactly once) and that
+knowledge is structurally unreachable from `TPInterleaver`. Meanwhile the
+transformers TP path refuses every expert-parallel style it cannot gather. We are
+paying for the same hole twice, in two places that cannot lend each other
+anything.
+
+## Why they ended up in different base classes
+
+Worth recording, because the reason is not the one that was originally written
+down.
+
+`Batcher.narrow`/`widen` are called **once per mediator** — inside the loop that
+serves each parked worker in turn. A batcher that gathered would fire one
+collective per *reader* of a location, so ranks would run different numbers of
+collectives depending on how many workers happened to be parked. That is a
+deadlock. vLLM pays for it with `self.gathered` memoization plus `watch`/`release`
+brackets that its **model runner** installs (`GPUModelRunner.py`), which it can do
+because it owns the forward.
+
+`Interleaver.handle` is already the once-per-visit bracket, so `TPInterleaver`
+needs no memo and no external bracket. That is the real argument, and it points
+at the right shape for a shared seam: **it belongs on the interleaver, called once
+per visit, with the runtime supplying only the policy.**
+
+(The rationale this replaces claimed `_batcher_class` would resolve to the
+*client's* class across a remote trace. It does not: `Envoy.__getstate__` pickles
+the envoy by value, but `_batcher_class` is a class attribute and cloudpickle
+serializes an importable class by reference, so it resolves to the server's value
+exactly like `interleaver`. Verified directly. A `TPBatcher` was reachable; it
+would just have been called at the wrong granularity.)
+
+## The shape
+
+A collaborator object, not a subclass:
+
+```python
+# src/nnsight/intervention/fragments.py
+
+class Fragments:
+    """Whether a value at a location is a piece of a larger one, and how to
+    make it whole for a reader and put it back for the model.
+
+    The default is the identity: no location is a fragment, nothing is gathered.
+    A distributed runtime supplies a subclass; everything else is unaffected.
+    """
+
+    def fragmented(self, location: str) -> bool:
+        return False
+
+    def whole(self, location: str, value: Any) -> Any:
+        return value
+
+    def fragment(self, location: str, whole: Any) -> Any:
+        return whole
+```
+
+`Interleaver` grows one attribute and one branch:
+
+```python
+class Interleaver:
+    fragments: Fragments | None = None
+
+    def handle(self, provider, value):
+        gathering = (
+            self.fragments is not None
+            and self.fragments.fragmented(provider)
+            and self.observed(provider)
+        )
+        if gathering:
+            value = self.fragments.whole(provider, value)
+
+        ...the existing mediator loop, skip assembly and cache offering,
+           entirely unchanged...
+
+        return self.fragments.fragment(provider, value) if gathering else value
+```
+
+`observed` moves up from `TPInterleaver` unchanged — it is already generic ("is
+any worker or cache waiting on *this* visit"), and it is what keeps an untouched
+location free.
+
+Then:
+
+- **`TPFragments`** is today's `SHARDED_SIDES` table plus `_gather`/`_reshard`,
+  around 110 lines. `TPInterleaver` disappears entirely, and with it the
+  install-one-on-every-`HuggingFaceModel`-in-case-it-is-sharded dance in
+  `huggingface.py`. The rules are recorded by whatever walks the tree; the
+  interleaver stops knowing what a shard is.
+- **`VLLMFragments`** is today's `_whole`/`_shard`, keyed by location instead of
+  by a `watch`ed module. vLLM's runner already walks the modules at load, so it
+  registers `location -> module` there once instead of installing two hooks per
+  parallel layer. `self.gathered`, `watch`, `release` and the four hook installers
+  all delete. `VLLMBatcher` shrinks to the `batching = True` override — roughly 15
+  lines where there are now 210.
+
+## What it costs
+
+- A refactor of the vLLM path, whose tests need GPUs. This is the whole risk.
+- `VLLMBatcher._whole` currently needs the live module for `isinstance` checks, so
+  the location-to-module map must be built at load. That is a real behavioral
+  change if vLLM ever swaps modules mid-run — **unverified**; check before
+  starting.
+- External subclasses of `VLLMBatcher` break. Unlikely to exist, not impossible.
+
+## What it buys
+
+- One place to add a gather rule, so the MoE work lands once instead of twice.
+- A third runtime implements one small object instead of choosing a base class
+  and inheriting a scheduling concern it does not care about.
+- `Interleaver` stops having a subclass whose only job is a policy decision, and
+  `Batcher` goes back to being only about rows.
+
+## When
+
+When the MoE gather is picked up, or when a third distributed runtime appears.
+Not before: the present arrangement is correct, tested on hardware at degree 2 and
+4, and the duplication is costing exactly one thing (the MoE knowledge) that
+nothing is currently asking for.

--- a/docs/developing/index.md
+++ b/docs/developing/index.md
@@ -68,12 +68,12 @@ as an edit).
 - `docs/developing/batching-internals.md` — `Batcher` add/narrow/widen, batch
   groups, `gather_skip`/`assemble_skip`.
 
-### Proposals (not implemented)
+### Distributed values
 
-- `docs/developing/fragments-proposal.md` — vLLM and tensor parallelism both make
-  a fragment whole at a location, in unrelated subclasses of unrelated base
-  classes. What one shared collaborator would look like, and why the reason
-  originally given for keeping them apart was wrong.
+- `docs/developing/fragments-proposal.md` — `Fragments`, the one seam both vLLM
+  and transformers tensor parallelism use to make a sharded value whole at a
+  location. Why it hangs off the interleaver rather than the batcher, and what
+  the port cost.
 
 ### Backends
 

--- a/docs/developing/index.md
+++ b/docs/developing/index.md
@@ -68,6 +68,13 @@ as an edit).
 - `docs/developing/batching-internals.md` — `Batcher` add/narrow/widen, batch
   groups, `gather_skip`/`assemble_skip`.
 
+### Proposals (not implemented)
+
+- `docs/developing/fragments-proposal.md` — vLLM and tensor parallelism both make
+  a fragment whole at a location, in unrelated subclasses of unrelated base
+  classes. What one shared collaborator would look like, and why the reason
+  originally given for keeping them apart was wrong.
+
 ### Backends
 
 - `docs/developing/backends.md` — the `Backend` base and the existing backends

--- a/docs/developing/vllm-integration.md
+++ b/docs/developing/vllm-integration.md
@@ -40,7 +40,7 @@ runs it against the real module, and ships saved values back.
 - **Worker process(es).** vLLM spawns these with `worker_cls =
   "nnsight.modeling.vllm.workers.GPUWorker.NNsightGPUWorker"` (`vllm.py:189`). The
   worker builds a *second* `VLLM` Envoy over the actually-loaded module
-  (`GPUModelRunner.load_model`), which owns the `Interleaver` and `VLLMBatcher` and
+  (`GPUModelRunner.load_model`), which owns the `Interleaver`, its `VLLMFragments` and the `VLLMBatcher`, and
   is where interventions run.
 
 Model-parallel init happens in the client process before the meta build (vLLM builds
@@ -136,26 +136,32 @@ recomputed every step:
   into a `ValueError` (barrier) or `OutOfOrderError` (the run already ran past its
   location); an over-iterated `tracer.iter` only warns.
 
-## Tensor parallelism: `VLLMBatcher`
+## Tensor parallelism: `VLLMFragments`
 
 When `tensor_parallel_size > 1`, parallel linears shard tensors across GPUs;
-intervention code must see the whole tensor. `VLLMBatcher(Batcher)`
-(`batching.py:32`) gathers before a worker reads and re-shards after it writes.
+intervention code must see the whole tensor. `VLLMFragments(Fragments)`
+(`fragments.py`) says which locations are a rank's piece and how to reassemble
+them; the `Interleaver` brackets the gather (see
+[`nnsight.intervention.fragments`][nnsight.intervention.fragments]).
 
-- Its `batching` property is always `True` — a request's tokens sit alongside others
-  in the slab, so even a lone invoke must be narrowed to its own span.
-- `narrow`/`widen` (`:62`/`:65`) first call `_whole(value)` to assemble the full
-  tensor, then do the base row math on the `[start, size]` token span.
-- `_whole(value)` (`:74`) all-gathers or all-reduces per layer kind:
-  `ColumnParallelLinear` output → `all_gather`; `RowParallelLinear` input →
-  `all_gather`; `RowParallelLinear` output → `all_reduce`. `_shard(value)` (`:113`)
-  is the inverse. `watch`/`release` (`:134`/`:156`) track the current module and,
-  after an edit, re-shard the reassembled whole so vLLM's forward resumes correctly.
+- `instrument` records `location -> (module, side)` as the Envoy tree is built,
+  for the layers that really shard: `ColumnParallelLinear` output unless it
+  gathers its own, `RowParallelLinear` input when `input_is_parallel`, its output
+  unless `reduce_results`, and a `FusedMoE` output that defers its combine.
+- `whole` all-gathers or all-reduces per layer kind; `fragment` is the inverse,
+  dividing an MoE write-back by `tp_size * ep_size` so the block's own reduce sums
+  it exactly once. With TP=1 nothing is recorded and `enabled` stays `False`.
+- `VLLMBatcher` keeps only the row math: its `batching` property is always `True`,
+  because a request's tokens sit alongside others in the slab, so even a lone
+  invoke must be narrowed to its own span.
 
-The gather/re-shard hooks are wired in the runner: `_watch_parallel_linears`
-(`GPUModelRunner.py:58`) registers **before** the interleaver's hooks (gather first),
-`_release_parallel_linears` (`:78`) **after** (re-shard last). With TP=1 neither is
-wired — it's pure overhead. See [batching-internals.md](./batching-internals.md).
+This used to live in `VLLMBatcher` with two extra pairs of forward hooks per
+parallel layer, installed either side of building the tree so they bracketed the
+interleaver's. It needed them because `Batcher.narrow` runs once per *parked
+worker*, so the gather had to be memoized and explicitly released — several
+workers reading one value would otherwise have run several collectives and
+deadlocked the ranks. On the interleaver the bracket is already once-per-visit,
+so none of that is needed. See [batching-internals.md](./batching-internals.md).
 
 ## Sync result collection
 
@@ -262,7 +268,7 @@ test guarding it):
   each does not merge back (unlike the in-process local path). Each invoke saves its
   own values.
 - **`defer_exceptions` must drop a worker on all TP ranks or none**, and the lazy
-  gather in `VLLMBatcher` assumes every rank runs identical mediators in lockstep — a
+  gather in `VLLMFragments` assumes every rank runs identical mediators in lockstep — a
   rank-divergent error or a rank-local read hangs the collective.
 - **`tracer.result` is not served on vLLM.** Read generated tokens via `model.logits`/
   `model.samples` (or the streamed `RequestOutput` in async), never `tracer.result`
@@ -280,7 +286,8 @@ tests, and for the mediator payload to ride Ray's transport). See
 
 - `src/nnsight/modeling/vllm/vllm.py` — `VLLM` (`:36`), `_attach_mediators` (`:403`),
   `_collect` (`:382`), `trace` override (`:330`), `logits`/`samples` eproperties (`:144`)
-- `src/nnsight/modeling/vllm/batching.py:32` — `VLLMBatcher`
+- `src/nnsight/modeling/vllm/fragments.py` — `VLLMFragments`
+- `src/nnsight/modeling/vllm/batching.py` — `VLLMBatcher` (row scoping only)
 - `src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py` — runner (`:324`),
   `Requests` (`:97`), `collect_nnsight` (`:471`)
 - `src/nnsight/modeling/vllm/engines/engine.py:17` — `NNsightLLMEngine` (sync)
@@ -293,6 +300,7 @@ tests, and for the mediator payload to ride Ray's transport). See
 
 - [serialization.md](./serialization.md) — how mediators survive process boundaries
 - [batching-internals.md](./batching-internals.md) — the `Batcher`/`VLLMBatcher` contract
+- [fragments-proposal.md](./fragments-proposal.md) — the seam both distributed runtimes share
 - [extending-envoy.md](./extending-envoy.md) — how `logits`/`samples` are exposed
 - [adding-a-new-runtime.md](./adding-a-new-runtime.md) — vLLM as the reference runtime
 - `tests/vllm/` — the reference test suite (needs GPU + `vllm`)

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -2,7 +2,7 @@
 title: Model Classes
 one_liner: Decision tree for picking the right nnsight model wrapper.
 tags: [models, index]
-related: [docs/models/transformers-model.md, docs/models/nnsight-base.md, docs/models/diffusion-model.md, docs/models/vllm.md, docs/models/language-model.md, docs/models/vision-language-model.md]
+related: [docs/models/transformers-model.md, docs/models/tensor-parallel.md, docs/models/nnsight-base.md, docs/models/diffusion-model.md, docs/models/vllm.md, docs/models/language-model.md, docs/models/vision-language-model.md]
 sources: [src/nnsight/__init__.py:53, src/nnsight/modeling/base.py:6, src/nnsight/modeling/transformers.py:161, src/nnsight/modeling/diffusion.py:38, src/nnsight/modeling/vllm/vllm.py:36, src/nnsight/modeling/language.py:19, src/nnsight/modeling/vlm.py:29]
 ---
 
@@ -23,8 +23,11 @@ Pick the model wrapper that matches what you have. All wrappers expose the same 
 - You have a **diffusers `DiffusionPipeline`** (Stable Diffusion, Flux, DiT, SDXL, etc.) and want to trace UNet / transformer / VAE / text-encoder activations.
   - See [docs/models/diffusion-model.md](diffusion-model.md). Class: `nnsight.DiffusionModel`.
 
-- You need **production throughput, tensor parallelism, continuous batching, or async streaming** with NNsight interventions.
+- You need **production throughput, continuous batching, or async streaming** with NNsight interventions.
   - See [docs/models/vllm.md](vllm.md). Class: `nnsight.modeling.vllm.VLLM`.
+
+- Your model is **too big for one GPU** and you want to trace it split across several with `transformers` tensor parallelism (one process per GPU, launched with `torchrun`).
+  - See [docs/models/tensor-parallel.md](tensor-parallel.md). Still `TransformersModel` — pass `distributed_config=DistributedConfig(tp_size=N)`; sharded activations are gathered for you.
 
 ### Deprecated aliases
 
@@ -39,6 +42,7 @@ Pick the model wrapper that matches what you have. All wrappers expose the same 
 | `NNsight` | `nnsight` | Any `torch.nn.Module` | None (you instantiate) |
 | `DiffusionModel` | `nnsight` | diffusers pipelines | `diffusers.DiffusionPipeline` |
 | `VLLM` | `nnsight.modeling.vllm` | High-throughput serving with interventions | `vllm.LLM` (sync) / `vllm.v1.engine.async_llm.AsyncLLM` (async) |
+| `TransformersModel` + `DistributedConfig` | `nnsight` + `transformers.distributed` | A model sharded across GPUs (tensor parallel) | `transformers.pipeline` |
 | `LanguageModel` *(deprecated)* | `nnsight` | → `TransformersModel(task="text-generation")` | `transformers.pipeline` |
 | `VisionLanguageModel` *(deprecated)* | `nnsight` | → `TransformersModel(task="image-text-to-text")` | `transformers.pipeline` |
 

--- a/docs/models/tensor-parallel.md
+++ b/docs/models/tensor-parallel.md
@@ -112,14 +112,27 @@ it puts two obligations on the code:
 **Every rank produces the same saved values**, since they are computed from
 gathered tensors. Print or write results from one rank, or you get N copies.
 
+## Requires transformers >= 5.15
+
+Below that, a checkpoint with `tie_word_embeddings=True` — Llama-3.2, Qwen2.5,
+most small models — has its LM head gathered but never sharded, so logits come
+back `tp_size` times too wide. The argmax still lands inside the first copy, so
+nothing downstream looks wrong. nnsight raises `UnsupportedTransformersVersion`
+rather than let that through.
+
 ## What is not supported
 
-Mixture-of-experts sharding (`grouped_gemm`, `ep_router`, `moe_tp_experts`, and
-the rest of the expert-parallel family) and MLA's split kv projection slice by
-*expert* rather than along the feature dimension, so the gather here does not
-apply. Loading such a model tensor-parallel raises `UnsupportedParallelStyle`
-naming the module and style — deliberately, rather than handing you a fragment of
-a tensor and letting you draw conclusions from it.
+A few expert-parallel styles slice by *expert* rather than along the feature
+dimension, so the gather here does not apply: `grouped_gemm`, `ep_router`,
+`megamoe_*`, `moe_identity_expert`, and MLA's split kv projection
+(`mla_kv_a_proj`). Loading such a model tensor-parallel raises
+`UnsupportedParallelStyle` naming the module and style — deliberately, rather than
+handing you a fragment of a tensor and letting you draw conclusions from it.
+
+**Most mixture-of-experts checkpoints are fine.** `moe_tp_experts`, which Mixtral,
+DeepSeek-V3, Qwen3-MoE and around twenty-five other shipped configs use,
+all-reduces inside its own forward — both sides arrive whole and nothing needs
+gathering.
 
 `float`/`bfloat16` results differ slightly from a single-GPU run (relative error
 around 1e-3 to 1e-2, growing with depth) because an all-reduce sums in a
@@ -128,14 +141,21 @@ the test suite asserts generated ids are identical.
 
 ## Under the hood
 
-`TPInterleaver` ([`nnsight.modeling.tp`][nnsight.modeling.tp]) subclasses the
-[`Interleaver`][nnsight.intervention.interleaver.Interleaver] and brackets
-`handle`: gather the value, serve the parked workers the whole tensor, re-split
-what they leave. Every `HuggingFaceModel` is built with one; it stays inert
-(`enabled = False`, behaving exactly like the base) until it instruments a module
-transformers has stamped with a `_hf_tp_plan`, which is also where it records
-which locations are sharded. That covers eager loading and the
+`TPFragments` ([`nnsight.modeling.tp`][nnsight.modeling.tp]) says which locations
+hold one rank's slice and how to reassemble them; the
+[`Interleaver`][nnsight.intervention.interleaver.Interleaver] does the bracketing —
+gather the value, serve the parked workers the whole tensor, re-split what they
+leave — once per visit, and only when something is actually waiting to read it.
+
+Every `HuggingFaceModel` is built with an ordinary interleaver carrying one of
+these. It stays inert (`enabled = False`, one attribute check per location) until
+it instruments a module transformers has stamped with a `_hf_tp_plan`, which is
+also where it records the rules. That covers eager loading and the
 meta-then-`dispatch()` path without either needing to know about it.
+
+The same seam serves vLLM's tensor parallelism, which shards differently and
+gathers with different collectives — see
+[`nnsight.intervention.fragments`][nnsight.intervention.fragments].
 
 ## Related
 

--- a/docs/models/tensor-parallel.md
+++ b/docs/models/tensor-parallel.md
@@ -120,6 +120,40 @@ back `tp_size` times too wide. The argmax still lands inside the first copy, so
 nothing downstream looks wrong. nnsight raises `UnsupportedTransformersVersion`
 rather than let that through.
 
+## A checkpoint that cannot be split at all
+
+Not every model publishes a sharding plan. gpt2 is the obvious one: its config
+has no `base_model_tp_plan`, so there is nothing telling transformers which
+weights to cut or along which dimension.
+
+**transformers does not refuse this, and does not warn.** Given a plan of `None`
+it shards *nothing* — `verify_tp_plan` returns early and no hooks are installed —
+so every rank loads a complete copy of the weights. The model then answers
+correctly off one rank while the other cards hold redundant copies. Nothing
+fails; you simply paid `tp_size` GPUs for one GPU's worth of work.
+
+nnsight raises `UnshardableCheckpoint` instead, before the weights are fetched:
+
+```python
+TransformersModel(
+    "openai-community/gpt2",
+    distributed_config=DistributedConfig(tp_size=2),
+)
+# UnshardableCheckpoint: this checkpoint cannot be split tensor-parallel, so
+# tp_size=2 would load a whole copy of it onto every rank rather than a shard.
+```
+
+The same error covers a degree that does not divide evenly — `tp_size=3` on a
+model that splits 8 ways — because the all-gather assumes every rank holds an
+equal piece, so an uneven degree returns the wrong shape rather than running
+slower. The message lists the degrees that would work.
+
+To find out in advance, ask
+[`max_tp_size`][nnsight.modeling.tp.plan.max_tp_size] for the largest degree a
+config supports; every workable degree is one of its divisors, and `None` means
+the model has to be spread some other way (one GPU, or `device_map` over
+several).
+
 ## What is not supported
 
 A few expert-parallel styles slice by *expert* rather than along the feature

--- a/docs/models/tensor-parallel.md
+++ b/docs/models/tensor-parallel.md
@@ -1,0 +1,146 @@
+---
+title: Tensor Parallelism
+one_liner: Trace a model sharded across GPUs with transformers tensor parallelism — sharded activations are gathered so a trace reads exactly as it would on one GPU.
+tags: [models, transformers, tensor-parallel, multi-gpu, distributed]
+related: [docs/models/transformers-model.md, docs/models/vllm.md, docs/models/index.md, docs/usage/generate.md, docs/usage/cache.md]
+sources: [src/nnsight/modeling/tp/interleaver.py, src/nnsight/modeling/huggingface.py, tests/test_transformers_tensor_parallel.py, tests/tp_worker.py]
+---
+
+# Tensor Parallelism
+
+## What this is for
+
+A model too big for one GPU can be **split across several** with transformers'
+native tensor parallelism: each rank holds a slice of every attention and MLP
+projection. This is different from `device_map="auto"`, which puts whole *layers*
+on different GPUs and runs them one after another — tensor parallelism splits
+*within* each layer and runs the ranks together.
+
+The catch for interpretability is that a sharded module's activation, on any one
+rank, is only that rank's slice of the real tensor. nnsight gathers those slices
+before your intervention sees the value and re-splits whatever you leave behind,
+so **the trace you write is the trace you would write against one GPU**.
+
+There is nothing to install, import, or enable.
+
+## The canonical pattern
+
+Tensor parallelism needs one process per GPU, so the script is launched with
+`torchrun` (or `python -m torch.distributed.run`) and **every rank runs the whole
+script, including your intervention code**.
+
+```python
+# tp_trace.py  —  torchrun --nproc_per_node=4 tp_trace.py
+import torch
+from transformers.distributed import DistributedConfig
+from nnsight.modeling.transformers import TransformersModel
+
+model = TransformersModel(
+    "meta-llama/Llama-3.2-3B",
+    task="text-generation",
+    dispatch=True,
+    dtype=torch.bfloat16,
+    distributed_config=DistributedConfig(tp_size=4),
+)
+
+with model.trace("The Eiffel Tower is in the city of"):
+    # gate_proj is column-parallel: each rank computes 2048 of these 8192
+    # features. Read it and you get all 8192.
+    gate = model.model.layers[5].mlp.gate_proj.output.save()
+    logits = model.lm_head.output.save()
+
+print(gate.shape)  # (1, 11, 8192) on every rank, not (1, 11, 2048)
+```
+
+Edits work the same way: you edit the whole tensor and nnsight puts each rank's
+piece back.
+
+```python
+with model.trace(prompt):
+    # Spans rank boundaries; you never think about that.
+    model.model.layers[5].mlp.gate_proj.output[..., :3000] = 0
+    logits = model.lm_head.output.save()
+```
+
+> `tp_plan="auto"` / `tp_size=` are **not** `from_pretrained` arguments in
+> transformers 5.x, despite what its `from_pretrained` docstring still says. Use
+> `distributed_config=DistributedConfig(tp_size=N)`.
+
+## What is sharded and what is not
+
+Most of what people read is **already whole** and costs nothing: a row-parallel
+layer all-reduces its output, so a decoder layer, `self_attn`, `mlp`, and the
+final norm all arrive complete. Only two kinds of value are really a slice:
+
+| | Sharded? | Example |
+|---|---|---|
+| Column-parallel **output** | yes, gathered for you | `q_proj`, `k_proj`, `v_proj`, `gate_proj`, `up_proj` |
+| Row-parallel **input** | yes, gathered for you | `o_proj.input`, `down_proj.input` |
+| Row-parallel output | no — all-reduced | `o_proj.output`, `down_proj.output` |
+| Whole modules | no | `model.layers[i].output`, `mlp.output`, `norm.output` |
+| The LM head | no — gathered by transformers | `lm_head.output` |
+| Embeddings | no — all-reduced | `embed_tokens.output` |
+
+The gather only fires when an intervention is actually parked on that location,
+so reading a handful of locations does not pay for the hundreds you ignored. A
+`tracer.cache()` gathers only the modules it selects.
+
+## Rules for intervention code under TP
+
+**Every rank runs your block.** That is what keeps the collectives lined up, and
+it puts two obligations on the code:
+
+1. **No rank-dependent control flow.** Nothing may branch on rank, and nothing
+   may take a different path on different ranks — the ranks would stop agreeing
+   on when to gather, and the run deadlocks.
+
+2. **Seed before you sample.** This one is a correctness bug, not an
+   inconsistency. If sampling diverges, the ranks generate *different tokens*,
+   and then the model's own all-reduces sum activations computed from different
+   sequences — the output is wrong on every rank, not merely different. Use
+   greedy decoding, or seed identically on every rank:
+
+   ```python
+   torch.manual_seed(0)                      # same on every rank
+   with model.generate(prompt, max_new_tokens=20) as tracer:
+       out = tracer.result.save()
+   ```
+
+   Many checkpoints ship `do_sample: true` in `generation_config.json`, so this
+   bites without you asking for sampling.
+
+**Every rank produces the same saved values**, since they are computed from
+gathered tensors. Print or write results from one rank, or you get N copies.
+
+## What is not supported
+
+Mixture-of-experts sharding (`grouped_gemm`, `ep_router`, `moe_tp_experts`, and
+the rest of the expert-parallel family) and MLA's split kv projection slice by
+*expert* rather than along the feature dimension, so the gather here does not
+apply. Loading such a model tensor-parallel raises `UnsupportedParallelStyle`
+naming the module and style — deliberately, rather than handing you a fragment of
+a tensor and letting you draw conclusions from it.
+
+`float`/`bfloat16` results differ slightly from a single-GPU run (relative error
+around 1e-3 to 1e-2, growing with depth) because an all-reduce sums in a
+different order than one big matmul. Token choices are unaffected in practice;
+the test suite asserts generated ids are identical.
+
+## Under the hood
+
+`TPInterleaver` ([`nnsight.modeling.tp`][nnsight.modeling.tp]) subclasses the
+[`Interleaver`][nnsight.intervention.interleaver.Interleaver] and brackets
+`handle`: gather the value, serve the parked workers the whole tensor, re-split
+what they leave. Every `HuggingFaceModel` is built with one; it stays inert
+(`enabled = False`, behaving exactly like the base) until it instruments a module
+transformers has stamped with a `_hf_tp_plan`, which is also where it records
+which locations are sharded. That covers eager loading and the
+meta-then-`dispatch()` path without either needing to know about it.
+
+## Related
+
+- [transformers-model.md](transformers-model.md) — the wrapper being sharded.
+- [vllm.md](vllm.md) — the other way to shard across GPUs, with its own tradeoffs
+  (throughput and continuous batching, one prompt per invoke).
+- [../usage/cache.md](../usage/cache.md) — `tracer.cache()`, which gathers only
+  what it selects.

--- a/docs/patterns/per-head-attention.md
+++ b/docs/patterns/per-head-attention.md
@@ -156,7 +156,7 @@ indexes `value[0]`:
 
 ```python
 from transformers.models.gpt2.modeling_gpt2 import GPT2Attention
-from nnsight.intervention.envoy import Envoy
+from nnsight import Envoy
 from nnsight.intervention.eproperty import eproperty
 from nnsight.modeling.transformers import TransformersModel
 

--- a/docs/patterns/sae-and-auxiliary-modules.md
+++ b/docs/patterns/sae-and-auxiliary-modules.md
@@ -178,7 +178,7 @@ site with the `envoys=` argument, which maps a module **type** or a dotted **pat
 suffix** to a custom `Envoy` class.
 
 ```python
-from nnsight.intervention.envoy import Envoy
+from nnsight import Envoy
 from nnsight.intervention.eproperty import eproperty
 
 class SAEView(Envoy):

--- a/docs/usage/invoke-and-batching.md
+++ b/docs/usage/invoke-and-batching.md
@@ -148,7 +148,7 @@ Base `NNsight` runs a single invoke fine, but batching two or more raises
 
 ```python
 import torch
-from nnsight.intervention.envoy import Envoy
+from nnsight import Envoy
 
 class BatchEnvoy(Envoy):
     def _batch_size(self, *inputs, **kwargs):

--- a/src/nnsight/__init__.py
+++ b/src/nnsight/__init__.py
@@ -62,6 +62,8 @@ from .tracing.hint import Object  # noqa: F401
 # nnsight.NNsight(module): wrap an arbitrary torch.nn.Module for tracing.
 from .modeling.base import NNsight  # noqa: F401
 
+from .intervention.envoy import Envoy  # noqa: F401
+
 # Model classes are exposed lazily so importing nnsight doesn't pull in
 # transformers/diffusers model machinery until one is actually constructed
 # (and an optional dep like diffusers only errors when its model is used).

--- a/src/nnsight/intervention/cache.py
+++ b/src/nnsight/intervention/cache.py
@@ -100,8 +100,8 @@ class Cache:
         # CacheView); tree navigation needs a model re-attached.
         return {**self.__dict__, "model": None}
 
-    def observe(self, location: str, value: Any) -> None:
-        """Record ``value`` if ``location`` is a selected module's input/output.
+    def _select(self, location: str) -> "tuple[str, str] | None":
+        """``(module_path, slot)`` if ``location`` is one this cache keeps, else None.
 
         ``location`` is ``"{module_path}.output"`` or ``"{module_path}.input"``.
         Anything else (source ops, skip gates, the run ``result``) has a base that
@@ -110,17 +110,39 @@ class Cache:
         if location.endswith(".output"):
             path, key = location[: -len(".output")], "output"
             if not self.include_output:
-                return
+                return None
         elif location.endswith(".input"):
             path, key = location[: -len(".input")], "inputs"
             if not self.include_inputs:
-                return
+                return None
         else:
-            return
+            return None
 
         if self.targets is not None and path not in self.targets:
+            return None
+
+        return path, key
+
+    def wants(self, location: str) -> bool:
+        """Whether this cache would record ``location``.
+
+        The same question [`observe`][nnsight.intervention.cache.Cache.observe]
+        answers by recording, asked without recording — for a caller that has to
+        do work *before* the value can be offered, and only wants to do it for
+        locations some cache actually keeps (see
+        [`TPInterleaver`][nnsight.modeling.tp.interleaver.TPInterleaver], which
+        must run a collective first). Shares `_select` with ``observe`` so the two
+        can't drift.
+        """
+        return self._select(location) is not None
+
+    def observe(self, location: str, value: Any) -> None:
+        """Record ``value`` if ``location`` is a selected module's input/output."""
+        selected = self._select(location)
+        if selected is None:
             return
 
+        path, key = selected
         self._record(path, key, self._transform(value))
 
     def _transform(self, value: Any) -> Any:

--- a/src/nnsight/intervention/cache.py
+++ b/src/nnsight/intervention/cache.py
@@ -130,7 +130,7 @@ class Cache:
         answers by recording, asked without recording — for a caller that has to
         do work *before* the value can be offered, and only wants to do it for
         locations some cache actually keeps (see
-        [`TPInterleaver`][nnsight.modeling.tp.interleaver.TPInterleaver], which
+        [`TPFragments`][nnsight.modeling.tp.fragments.TPFragments], which
         must run a collective first). Shares `_select` with ``observe`` so the two
         can't drift.
         """

--- a/src/nnsight/intervention/fragments.py
+++ b/src/nnsight/intervention/fragments.py
@@ -1,0 +1,108 @@
+"""When a value at a location is a piece of a larger one.
+
+On a model split across devices, what a module hands back can be a fragment: one
+rank's columns of a linear's output, one rank's partial sum, one rank's share of
+an expert combine. A user asked for the layer, not a quarter of it, so a runtime
+that shards has to make the value whole before intervention code sees it and put
+it back before the model's own forward carries on.
+
+Which values are fragments, and what "whole" means for each, is the *runtime's*
+knowledge — transformers labels its shards one way, vLLM another, and the
+collectives differ. Everything else about the bracket is the same regardless, so
+that part lives here and in
+[`Interleaver.handle`][nnsight.intervention.interleaver.Interleaver.handle],
+which is the one place that sees a location's value exactly once per visit.
+
+## Why once per visit matters
+
+It is the whole reason this hangs off the interleaver rather than the batcher.
+
+[`Batcher.narrow`][nnsight.intervention.batching.Batcher.narrow] is called **once
+per mediator** — once for each worker parked on a location. A batcher that
+gathered would therefore fire one collective per *reader*, and since which
+workers are parked is a property of the user's block rather than of the model,
+ranks would run different numbers of collectives and deadlock. Doing it in
+``handle`` sidesteps that: one visit, one collective, however many workers read
+it, with no memoization to keep in step.
+
+## The rules a subclass must follow
+
+* **Never branch on rank.** Every rank runs the same intervention block and must
+  reach the same collectives in the same order. `fragmented` in particular is
+  asked on every rank and must answer identically on all of them.
+* **`fragment` must undo `whole`.** What comes back goes into the model's own
+  forward. A value `whole` passed through untouched must come back untouched — a
+  tensor that was never a fragment must not be split.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class Fragments:
+    """A runtime's answer to "is this value a piece of a larger one".
+
+    The base is the identity: nothing is a fragment, nothing is gathered, and an
+    [`Interleaver`][nnsight.intervention.interleaver.Interleaver] carrying one of
+    these behaves exactly as one carrying none. A distributed runtime subclasses
+    it; everything else is unaffected.
+    """
+
+    #: Whether this tree has any fragments at all. False is the common case even
+    #: for a runtime that *can* shard — a HuggingFace model is built with a
+    #: `TPFragments` whether or not it was loaded across ranks — so it is checked
+    #: before anything else and costs one attribute lookup per handled location.
+    #: A subclass flips it in `instrument` on finding something actually split.
+    enabled: bool = False
+
+    def instrument(self, envoy: Any) -> None:
+        """Learn what this envoy's values are, as the tree is built.
+
+        Called for every envoy from
+        [`Interleaver.instrument`][nnsight.intervention.interleaver.Interleaver.instrument],
+        which is the one moment both the module — carrying whatever its runtime
+        stamped on it — and its path are in hand. Default: nothing to learn.
+        """
+
+    def begin(self) -> None:
+        """Called as a run starts, for whatever is per-run rather than per-model.
+
+        The rules themselves are a property of the loaded model and outlive a
+        run; anything a *reader* should be told about is not. Default: nothing to
+        reset.
+        """
+
+    def read(self, location: str) -> None:
+        """Called when something is about to read ``location``.
+
+        Only for locations something is actually waiting on, and regardless of
+        whether they are fragments — which is what makes this the place to say
+        something about a value the runtime *cannot* make whole. Default: nothing
+        to say.
+        """
+
+    def fragmented(self, location: str) -> bool:
+        """Whether the value at ``location`` is one piece of a larger tensor.
+
+        Answered from the location alone, so it costs a dict lookup on the hot
+        path and needs nothing from the value. Default: never.
+        """
+        return False
+
+    def whole(self, location: str, value: Any) -> Any:
+        """The real value at ``location``, assembled from every device's piece.
+
+        Only called when `fragmented` said so *and* something is actually waiting
+        to read it. Default: unreachable, since nothing is ever fragmented.
+        """
+        return value
+
+    def fragment(self, location: str, whole: Any) -> Any:
+        """This device's piece of ``whole``, as the model's own forward expects.
+
+        The inverse of `whole`, called with whatever intervention code left
+        behind — so an edit made to the assembled tensor is carried back into the
+        model rather than discarded.
+        """
+        return whole

--- a/src/nnsight/intervention/interleaver.py
+++ b/src/nnsight/intervention/interleaver.py
@@ -51,6 +51,7 @@ from ..tracing.util import Scope
 
 if TYPE_CHECKING:
     from .envoy import Envoy
+    from .fragments import Fragments
 
 
 class Event(enum.Enum):
@@ -506,11 +507,21 @@ class Interleaver:
         sourced: Op-location -> the instrumented callable a worker drilled into
             (see [`nnsight.intervention.source`][nnsight.intervention.source]), or ``None`` while one is
             requested but not yet built. Per-run; cleared on entry.
+        fragments: A [`Fragments`][nnsight.intervention.fragments.Fragments] for a
+            model whose values are split across devices, or ``None``. When set,
+            `handle` gathers a fragment before serving workers and re-splits it
+            afterwards.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, fragments: Optional["Fragments"] = None) -> None:
         self.handles: dict[str, list[torch.utils.hooks.RemovableHandle]] = {}
         self.mediators: list[Mediator] = []
+        # What, if anything, makes a value at a location whole before workers see
+        # it — see intervention/fragments.py. None on an ordinary model, and on a
+        # distributed one it is the runtime's own object. Kept as a collaborator
+        # rather than a subclass because *when* to gather is a property of this
+        # class and *what* to gather is a property of the runtime.
+        self.fragments: Optional["Fragments"] = fragments
         # The batcher for the current run (combined-input assembly + narrow/widen),
         # or None when not batching. Owned by the tracer and registered here for the
         # run by `Envoy.interleave` (see intervention/envoy.py); each mediator reads
@@ -541,6 +552,8 @@ class Interleaver:
         """
         self.interleaving = True
         self.sourced.clear()
+        if self.fragments is not None:
+            self.fragments.begin()
         try:
             for mediator in self.mediators:
                 if mediator.worker is not None:
@@ -565,6 +578,35 @@ class Interleaver:
         # has done its job unwinding the model, so swallow it here.
         return exc_type is EarlyStopException
 
+    def observed(self, provider: str) -> bool:
+        """Whether anything is waiting on *this* visit to ``provider``.
+
+        Mirrors the match [`Mediator.handle`][nnsight.intervention.interleaver.Mediator.handle]
+        makes — a worker parks already carrying the occurrence tag it wants, so
+        this is the same single string comparison against this visit's count.
+        Deliberately not "is any worker parked anywhere": a worker waiting on a
+        *later* iteration of this location must not trigger work now.
+
+        A ``tracer.cache()`` counts too — it would otherwise record fragments —
+        but only for the locations it actually keeps. A cache is usually scoped to
+        a handful of modules, so asking it (rather than assuming any open cache
+        wants everything) is the difference between a few collectives and one at
+        every sharded module in the model.
+
+        Used to gate the gather in `handle`. Every rank evaluates it over the same
+        block, so it answers the same everywhere.
+        """
+        for mediator in self.mediators:
+            pending = mediator.pending
+            if (
+                pending is not None
+                and pending[1] == f"{provider}.i{mediator.iterations[provider]}"
+            ):
+                return True
+            if any(cache.wants(provider) for cache in mediator.caches):
+                return True
+        return False
+
     def instrument(self, envoy: Envoy) -> None:
         """Install this interleaver's forward hooks on an envoy's module.
 
@@ -587,6 +629,15 @@ class Interleaver:
         # (which happens before pre-hooks run) — needed when a skip's replacement is
         # read from the module's own input first.
         install_skip(envoy)
+
+        # The one moment both the module — carrying whatever its runtime stamped
+        # on it — and its path are in hand, which is what a distributed runtime
+        # needs to record which of this envoy's values are pieces of larger ones.
+        # Called again through `Envoy._update` when real weights are dispatched
+        # under a tree built on meta, which is where a shard first becomes
+        # visible.
+        if self.fragments is not None:
+            self.fragments.instrument(envoy)
 
         path = envoy.path
 
@@ -620,6 +671,22 @@ class Interleaver:
         own rows of the batch — narrowed the same way the worker's reads are.
         Caches select which locations to keep themselves.
         """
+        # A fragment is made whole before any worker sees it, and only when one
+        # is actually waiting: a trace reads a handful of locations out of
+        # hundreds, and a collective at every other one would cost far more than
+        # the reads do. `observed` answers the same on every rank, which is what
+        # keeps their collectives matched.
+        gathering = False
+        if (
+            self.fragments is not None
+            and self.fragments.enabled
+            and self.observed(provider)
+        ):
+            self.fragments.read(provider)
+            if self.fragments.fragmented(provider):
+                gathering = True
+                value = self.fragments.whole(provider, value)
+
         for mediator in self.mediators:
             try:
                 value = mediator.handle(provider, value)
@@ -647,6 +714,12 @@ class Interleaver:
             )
             for cache in mediator.caches:
                 cache.observe(provider, served)
+
+        # Back to the piece the model's own forward expects, carrying whatever
+        # the workers left behind — so an edit to the assembled tensor reaches
+        # the model rather than being dropped with the gather.
+        if gathering:
+            value = self.fragments.fragment(provider, value)
         return value
 
     def check_dangling_mediators(self) -> None:

--- a/src/nnsight/modeling/huggingface.py
+++ b/src/nnsight/modeling/huggingface.py
@@ -130,24 +130,38 @@ class HuggingFaceModel(Remotable):
         config = AutoConfig.from_pretrained(repo_id, revision=self.revision)
         return self._auto().from_config(config)
 
-    def _load(self, repo_id: str, *args: Any, **kwargs: Any) -> torch.nn.Module:
-        # Before the weights are fetched, because that is the only point where a
-        # refusal is cheap and the message can still say what to do instead.
-        # transformers accepts an impossible degree silently -- see
-        # `check_tp_request` -- so a checkpoint that cannot be split would
-        # otherwise load a full copy on every rank and look like it worked.
+    def _refuse_impossible_tp(self, repo_id: str, kwargs: dict) -> None:
+        """Raise if this load asks for a degree the checkpoint cannot be split into.
+
+        Called from every ``_load``, before the weights are fetched -- the only
+        point where a refusal is cheap and the message can still say what to do
+        instead. transformers accepts an impossible degree silently (see
+        [`check_tp_request`][nnsight.modeling.tp.plan.check_tp_request]), so a
+        checkpoint that cannot be split would otherwise load a full copy onto
+        every rank and look like it worked.
+
+        A subclass that builds the model some other way -- ``TransformersModel``
+        goes through ``transformers.pipeline`` -- has to call this itself, since
+        it does not reach the base's ``_load``. Reading the raw ``kwargs`` rather
+        than a split-out subset is deliberate: ``distributed_config`` travels
+        differently on each path, and a check that silently sees nothing is worse
+        than no check.
+        """
         from .tp import check_tp_request, requested_tp_size
 
         tp_size = requested_tp_size(kwargs.get("distributed_config"))
-        if tp_size is not None:
-            from transformers import AutoConfig
+        if tp_size is None:
+            # The ordinary path: no degree asked for, so no config to read.
+            return
 
-            # Only read when a degree was actually asked for: the ordinary path
-            # should not pay a config load for a check that cannot apply to it.
-            check_tp_request(
-                AutoConfig.from_pretrained(repo_id, revision=self.revision), tp_size
-            )
+        from transformers import AutoConfig
 
+        check_tp_request(
+            AutoConfig.from_pretrained(repo_id, revision=self.revision), tp_size
+        )
+
+    def _load(self, repo_id: str, *args: Any, **kwargs: Any) -> torch.nn.Module:
+        self._refuse_impossible_tp(repo_id, kwargs)
         return self._auto().from_pretrained(repo_id, revision=self.revision, **kwargs)
 
     def _remoteable_model_key(self) -> str:

--- a/src/nnsight/modeling/huggingface.py
+++ b/src/nnsight/modeling/huggingface.py
@@ -131,6 +131,23 @@ class HuggingFaceModel(Remotable):
         return self._auto().from_config(config)
 
     def _load(self, repo_id: str, *args: Any, **kwargs: Any) -> torch.nn.Module:
+        # Before the weights are fetched, because that is the only point where a
+        # refusal is cheap and the message can still say what to do instead.
+        # transformers accepts an impossible degree silently -- see
+        # `check_tp_request` -- so a checkpoint that cannot be split would
+        # otherwise load a full copy on every rank and look like it worked.
+        from .tp import check_tp_request, requested_tp_size
+
+        tp_size = requested_tp_size(kwargs.get("distributed_config"))
+        if tp_size is not None:
+            from transformers import AutoConfig
+
+            # Only read when a degree was actually asked for: the ordinary path
+            # should not pay a config load for a check that cannot apply to it.
+            check_tp_request(
+                AutoConfig.from_pretrained(repo_id, revision=self.revision), tp_size
+            )
+
         return self._auto().from_pretrained(repo_id, revision=self.revision, **kwargs)
 
     def _remoteable_model_key(self) -> str:

--- a/src/nnsight/modeling/huggingface.py
+++ b/src/nnsight/modeling/huggingface.py
@@ -39,6 +39,20 @@ class HuggingFaceModel(Remotable):
             repo_id if isinstance(repo_id, str) else getattr(repo_id, "name_or_path", None)
         )
         self.revision = revision
+
+        # A model loaded with `distributed_config=DistributedConfig(tp_size=N)`
+        # has its linears split across ranks, so a plain interleaver would hand
+        # intervention code one rank's slice of an activation. Whether this model
+        # is sharded isn't known yet — it only becomes visible as the weights
+        # load — so give the tree an interleaver that can handle it either way:
+        # it stays disabled (and behaves exactly like the base) unless it finds
+        # something actually split while instrumenting. Explicit rather than
+        # setdefault so a caller-supplied interleaver still wins.
+        if "interleaver" not in kwargs:
+            from .tp import TPInterleaver
+
+            kwargs["interleaver"] = TPInterleaver()
+
         # revision is used by _load/_load_meta via self.revision, not threaded
         # through super (it must not reach Envoy.__init__ on the passthrough).
         super().__init__(repo_id, *args, **kwargs)

--- a/src/nnsight/modeling/huggingface.py
+++ b/src/nnsight/modeling/huggingface.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import json
+import logging
+import math
 from typing import Any, Optional
 
 import torch
 
 from .mixins.remotable import Remotable
+
+logger = logging.getLogger("nnsight")
 
 # Canonical repo ids, keyed by the user-supplied id (resolves casing/redirects
 # so different spellings of the same model produce the same remote key).
@@ -82,6 +86,97 @@ class HuggingFaceModel(Remotable):
         return json.dumps(
             {"repo_id": _ID_CACHE[self.repo_id], "revision": self.revision}
         )
+
+    @classmethod
+    def _remoteable_estimate_bytes(
+        cls, model_key: str, dtype: str, trust_remote_code: bool = False
+    ) -> int:
+        """Size the weights from the Hub's parameter count, without building the
+        architecture.
+
+        The Hub indexes every safetensors checkpoint and reports how many
+        parameters it holds, so the number the base class builds a whole meta
+        model to count is one request away. Falls back to that build when the
+        count isn't published — an older ``.bin``-only repo, a private mirror, or
+        no network — so this is a shortcut, never the only route.
+
+        Buffers are not in the Hub's count (they aren't checkpoint tensors).
+        They're a rounding error next to the parameters for a transformer, and
+        the caller pads.
+        """
+        from .mixins.remotable import bytes_per_element
+
+        data = json.loads(model_key)
+        repo_id, revision = data.get("repo_id"), data.get("revision")
+
+        parameters = cls._hub_parameter_count(repo_id, revision)
+        if parameters is None:
+            logger.debug(
+                f"No parameter count published for {repo_id!r}; sizing it by "
+                "building the architecture instead"
+            )
+            return super()._remoteable_estimate_bytes(
+                model_key, dtype, trust_remote_code=trust_remote_code
+            )
+
+        return math.ceil(parameters * bytes_per_element(dtype))
+
+    @staticmethod
+    def _hub_parameter_count(repo_id: str, revision: Optional[str]) -> Optional[int]:
+        """Total parameters the Hub reports for a repo, or None if it doesn't."""
+        try:
+            from huggingface_hub import HfApi
+
+            info = HfApi().model_info(repo_id, revision=revision)
+        except Exception:
+            return None
+
+        safetensors = getattr(info, "safetensors", None)
+        return getattr(safetensors, "total", None)
+
+    @classmethod
+    def _remoteable_checkpoint_config(
+        cls, model_key: str, trust_remote_code: bool = False
+    ) -> Optional[Any]:
+        """The repo's config, read from the Hub cache without any weights."""
+        return cls._config(model_key, trust_remote_code)
+
+    @classmethod
+    def _config(cls, model_key: str, trust_remote_code: bool) -> Optional[Any]:
+        from transformers import AutoConfig
+
+        data = json.loads(model_key)
+        try:
+            return AutoConfig.from_pretrained(
+                data.get("repo_id"),
+                revision=data.get("revision"),
+                trust_remote_code=trust_remote_code,
+            )
+        except Exception:
+            logger.debug(f"Could not read a config for {data.get('repo_id')!r}")
+            return None
+
+    @classmethod
+    def _remoteable_checkpoint_revision(
+        cls, model_key: str, **kwargs: Any
+    ) -> Optional[str]:
+        """The revision the key pins, straight out of it."""
+        return json.loads(model_key).get("revision")
+
+    @classmethod
+    def _remoteable_max_tp_size(
+        cls, model_key: str, trust_remote_code: bool = False
+    ) -> Optional[int]:
+        """The largest tensor-parallel degree, read from the checkpoint's config.
+
+        Config only — no weights, no architecture — since the sharding plan and
+        the dimensions it has to divide are both declared there. See
+        [`max_tp_size`][nnsight.modeling.tp.plan.max_tp_size].
+        """
+        from .tp import max_tp_size
+
+        config = cls._config(model_key, trust_remote_code)
+        return max_tp_size(config) if config is not None else None
 
     @classmethod
     def _remoteable_from_model_key(cls, model_key: str, **kwargs: Any) -> HuggingFaceModel:

--- a/src/nnsight/modeling/huggingface.py
+++ b/src/nnsight/modeling/huggingface.py
@@ -15,6 +15,63 @@ logger = logging.getLogger("nnsight")
 # so different spellings of the same model produce the same remote key).
 _ID_CACHE: dict[str, str] = {}
 
+# Configs already read, keyed by (model_key, trust_remote_code) — see `_config`.
+_CONFIG_CACHE: dict[tuple, Any] = {}
+
+# How long to wait on the Hub when describing a checkpoint. These calls happen on
+# a placement path — a server deciding where a model goes, before it loads
+# anything — where the caller would rather be told "couldn't reach the Hub" than
+# wait indefinitely.
+#
+# Per request, matching what huggingface_hub already applies to everything it
+# fetches (`HF_HUB_ETAG_TIMEOUT` and `HF_HUB_DOWNLOAD_TIMEOUT`, both 10s). So
+# `AutoConfig.from_pretrained` is bounded whether or not anything here says so —
+# it takes no timeout argument, but its transport does — and the number below
+# only has to be passed where an API accepts one. What is *not* bounded is the
+# number of requests a read makes, so treat this as a bound on progress, not on
+# the call.
+HUB_TIMEOUT_SECONDS = 10.0
+
+
+class CheckpointUnreachable(Exception):
+    """The checkpoint could not be read — the Hub was slow, down, or refused.
+
+    Distinct from *reading it and finding nothing*, which every reader here
+    reports as ``None``. Collapsing the two is how a network problem comes to
+    look like a fact about a model: a config that failed to download makes
+    ``max_tp_size`` return ``None``, and ``None`` is the answer meaning "this
+    model cannot be split at all", so a perfectly shardable model gets placed
+    across cards layer-by-layer and nothing says why.
+    """
+
+
+def _unreachable(error: BaseException) -> bool:
+    """Whether ``error`` means "couldn't read it" rather than "it isn't there".
+
+    ``LocalEntryNotFoundError`` is the important one and reads backwards: the Hub
+    raises it when it could *not reach the network* and found nothing cached, so
+    despite the name it is a connectivity failure, not a missing file.
+    ``RepositoryNotFoundError`` and ``EntryNotFoundError``, by contrast, are the
+    Hub successfully telling us there is nothing there.
+    """
+    from huggingface_hub.errors import (
+        HfHubHTTPError,
+        LocalEntryNotFoundError,
+        OfflineModeIsEnabled,
+        RepositoryNotFoundError,
+        RevisionNotFoundError,
+    )
+
+    if isinstance(error, (RepositoryNotFoundError, RevisionNotFoundError)):
+        return False
+    if isinstance(error, (LocalEntryNotFoundError, OfflineModeIsEnabled)):
+        return True
+    if isinstance(error, HfHubHTTPError):
+        # 5xx is the Hub failing; 4xx is the Hub answering.
+        response = getattr(error, "response", None)
+        return getattr(response, "status_code", 0) >= 500
+    return isinstance(error, (OSError, TimeoutError))
+
 
 class HuggingFaceModel(Remotable):
     """nnsight wrapper around a HuggingFace Hub model.
@@ -48,14 +105,15 @@ class HuggingFaceModel(Remotable):
         # has its linears split across ranks, so a plain interleaver would hand
         # intervention code one rank's slice of an activation. Whether this model
         # is sharded isn't known yet — it only becomes visible as the weights
-        # load — so give the tree an interleaver that can handle it either way:
-        # it stays disabled (and behaves exactly like the base) unless it finds
-        # something actually split while instrumenting. Explicit rather than
-        # setdefault so a caller-supplied interleaver still wins.
+        # load — so give the tree an ordinary interleaver carrying rules that can
+        # handle it either way: they stay inert (one attribute check per handled
+        # location) unless they find something actually split while instrumenting.
+        # Explicit rather than setdefault so a caller-supplied interleaver wins.
         if "interleaver" not in kwargs:
-            from .tp import TPInterleaver
+            from ..intervention.interleaver import Interleaver
+            from .tp import TPFragments
 
-            kwargs["interleaver"] = TPInterleaver()
+            kwargs["interleaver"] = Interleaver(fragments=TPFragments())
 
         # revision is used by _load/_load_meta via self.revision, not threaded
         # through super (it must not reach Envoy.__init__ on the passthrough).
@@ -91,77 +149,128 @@ class HuggingFaceModel(Remotable):
     def _remoteable_estimate_bytes(
         cls, model_key: str, dtype: str, trust_remote_code: bool = False
     ) -> int:
-        """Size the weights from the Hub's parameter count, without building the
-        architecture.
+        """Size the weights from the Hub's parameter count.
 
-        The Hub indexes every safetensors checkpoint and reports how many
-        parameters it holds, so the number the base class builds a whole meta
-        model to count is one request away. Falls back to that build when the
-        count isn't published — an older ``.bin``-only repo, a private mirror, or
-        no network — so this is a shortcut, never the only route.
-
-        Buffers are not in the Hub's count (they aren't checkpoint tensors).
-        They're a rounding error next to the parameters for a transformer, and
-        the caller pads.
+        The size half of
+        [`_remoteable_describe_checkpoint`][nnsight.modeling.huggingface.HuggingFaceModel._remoteable_describe_checkpoint],
+        for a caller that wants only that. Not a separate implementation — the
+        two must not be able to disagree about how big a model is, since one of
+        them decides where it goes.
         """
-        from .mixins.remotable import bytes_per_element
-
-        data = json.loads(model_key)
-        repo_id, revision = data.get("repo_id"), data.get("revision")
-
-        parameters = cls._hub_parameter_count(repo_id, revision)
-        if parameters is None:
-            logger.debug(
-                f"No parameter count published for {repo_id!r}; sizing it by "
-                "building the architecture instead"
-            )
-            return super()._remoteable_estimate_bytes(
-                model_key, dtype, trust_remote_code=trust_remote_code
-            )
-
-        return math.ceil(parameters * bytes_per_element(dtype))
+        return cls._remoteable_describe_checkpoint(
+            model_key, dtype, trust_remote_code=trust_remote_code
+        ).size_bytes
 
     @staticmethod
     def _hub_parameter_count(repo_id: str, revision: Optional[str]) -> Optional[int]:
-        """Total parameters the Hub reports for a repo, or None if it doesn't."""
-        try:
-            from huggingface_hub import HfApi
+        """Total parameters the Hub reports for a repo, or None if it doesn't.
 
-            info = HfApi().model_info(repo_id, revision=revision)
-        except Exception:
+        Raises:
+            CheckpointUnreachable: if the Hub could not be read. The caller has a
+                fallback for a repo that publishes no count; it should not use it
+                for a repo it simply failed to ask.
+        """
+        from huggingface_hub import HfApi
+
+        try:
+            info = HfApi().model_info(
+                repo_id, revision=revision, timeout=HUB_TIMEOUT_SECONDS
+            )
+        except Exception as error:
+            if _unreachable(error):
+                raise CheckpointUnreachable(
+                    f"could not read {repo_id!r} from the Hub: {error}"
+                ) from error
             return None
 
         safetensors = getattr(info, "safetensors", None)
         return getattr(safetensors, "total", None)
 
     @classmethod
-    def _remoteable_checkpoint_config(
-        cls, model_key: str, trust_remote_code: bool = False
-    ) -> Optional[Any]:
-        """The repo's config, read from the Hub cache without any weights."""
-        return cls._config(model_key, trust_remote_code)
+    def _remoteable_describe_checkpoint(
+        cls, model_key: str, dtype: str, trust_remote_code: bool = False
+    ) -> "CheckpointInfo":
+        """Describe the repo from its metadata: one config read, one Hub record.
+
+        The whole reason this is one call. Every field here comes from something
+        already fetched — the revision is in the key, the config is memoized by
+        `_config`, and the parameter count and the size are the same Hub record
+        read once — where asking question by question meant fetching the config
+        twice for a checkpoint nobody had seen before.
+
+        The Hub indexes every safetensors checkpoint and reports how many
+        parameters it holds, so the number the base class builds a whole meta
+        model to count is one request away. Buffers are not in that count (they
+        aren't checkpoint tensors); they're a rounding error next to the
+        parameters for a transformer, and the caller pads.
+        """
+        from .mixins.remotable import CheckpointInfo, bytes_per_element
+
+        data = json.loads(model_key)
+        repo_id, revision = data.get("repo_id"), data.get("revision")
+
+        parameters = cls._hub_parameter_count(repo_id, revision)
+        if parameters is None:
+            # No published count — an older .bin-only repo, a private mirror.
+            # Fall back to building the architecture to count it, which is what
+            # the base class does, and take the config on the way past.
+            logger.debug(
+                f"No parameter count published for {repo_id!r}; sizing it by "
+                "building the architecture instead"
+            )
+            size_bytes = super()._remoteable_estimate_bytes(
+                model_key, dtype, trust_remote_code=trust_remote_code
+            )
+        else:
+            size_bytes = math.ceil(parameters * bytes_per_element(dtype))
+
+        return CheckpointInfo(
+            size_bytes=size_bytes,
+            n_params=parameters,
+            config=cls._config(model_key, trust_remote_code),
+            revision=revision,
+        )
 
     @classmethod
     def _config(cls, model_key: str, trust_remote_code: bool) -> Optional[Any]:
+        """The repo's config, fetched at most once per (key, trust) pair.
+
+        Memoized because several of the questions a server asks before placing a
+        model are all answered from this one object — its size, how many ways it
+        shards, what to show in a status — and each used to fetch it again. A
+        config is immutable for a pinned revision, and for an unpinned one the
+        answer is "whatever the branch said when this process first asked", which
+        is already true of every other read on this path.
+
+        Returns ``None`` when the repo has no readable config.
+
+        Raises:
+            CheckpointUnreachable: if the Hub could not be read at all.
+        """
+        cache_key = (model_key, trust_remote_code)
+        if cache_key in _CONFIG_CACHE:
+            return _CONFIG_CACHE[cache_key]
+
         from transformers import AutoConfig
 
         data = json.loads(model_key)
         try:
-            return AutoConfig.from_pretrained(
+            config = AutoConfig.from_pretrained(
                 data.get("repo_id"),
                 revision=data.get("revision"),
                 trust_remote_code=trust_remote_code,
             )
-        except Exception:
+        except Exception as error:
+            if _unreachable(error):
+                raise CheckpointUnreachable(
+                    f"could not read a config for {data.get('repo_id')!r}: {error}"
+                ) from error
             logger.debug(f"Could not read a config for {data.get('repo_id')!r}")
+            _CONFIG_CACHE[cache_key] = None
             return None
 
-    @classmethod
-    def _remoteable_checkpoint_revision(
-        cls, model_key: str, **kwargs: Any
-    ) -> Optional[str]:
-        """The revision the key pins, straight out of it."""
-        return json.loads(model_key).get("revision")
+        _CONFIG_CACHE[cache_key] = config
+        return config
 
     @classmethod
     def _remoteable_max_tp_size(

--- a/src/nnsight/modeling/mixins/remotable.py
+++ b/src/nnsight/modeling/mixins/remotable.py
@@ -15,24 +15,58 @@ model-specific halves — `_remoteable_model_key` and
 `_remoteable_from_model_key` — and may carry per-request state across with
 `_remoteable_get_env` / `_remoteable_set_env`.
 
-A server also has to answer two questions about a checkpoint it has never
-loaded, in order to decide where to put it: how much GPU memory it needs
-([`estimate_bytes`][nnsight.modeling.mixins.remotable.Remotable.estimate_bytes])
-and how many ways it can be split across cards
-([`max_tp_size`][nnsight.modeling.mixins.remotable.Remotable.max_tp_size]). Both
-answer from the key alone, and both have a subclass hook so a wrapper that can
-answer cheaply — a HuggingFace model can read the parameter count off the Hub —
-doesn't pay for building the architecture just to count it.
+A server also has to know things about a checkpoint it has never loaded, to
+decide where to put it. Those come in two shapes, and the split is deliberate:
+
+* **What the checkpoint is** —
+  [`describe_checkpoint`][nnsight.modeling.mixins.remotable.Remotable.describe_checkpoint]
+  returns a [`CheckpointInfo`][nnsight.modeling.mixins.remotable.CheckpointInfo]:
+  its size in a given dtype, its parameter count, its config, its revision. One
+  call, because a wrapper that can answer any of these cheaply answers all of
+  them from the same read — a HuggingFace model fetches one config and one Hub
+  record rather than one per question.
+* **What a runtime can do with it** —
+  [`max_tp_size`][nnsight.modeling.mixins.remotable.Remotable.max_tp_size] stays
+  its own question, and should. How many ways weights can be split is a property
+  of the *loader*, not of the checkpoint: the same files shard eight ways under
+  transformers tensor parallelism and not at all under something else. Folding it
+  into a description of the checkpoint would make it look like a fact about the
+  files.
+
+Both answer from the key alone, and both have a subclass hook, so a wrapper that
+can answer cheaply doesn't pay for building the architecture just to count it.
 """
 
 from __future__ import annotations
 
 import math
+from dataclasses import dataclass
 from typing import Any, Optional
 
 from ...tracing.backend import Backend
 from ...util import from_import_path, to_import_path
 from .meta import Meta
+
+
+@dataclass
+class CheckpointInfo:
+    """What a placement decision needs to know about a checkpoint.
+
+    Every field is optional and defaults to ``None``: a wrapper answers what it
+    can, and a caller treats a ``None`` as "this wrapper doesn't know" rather
+    than as a fact. Deliberately not a place for anything runtime-specific —
+    see the module docstring on why ``max_tp_size`` is asked separately.
+    """
+
+    #: The weights' size in the dtype that was asked for. ``None`` only if the
+    #: wrapper cannot size its own checkpoint at all.
+    size_bytes: Optional[int] = None
+    #: How many parameters, if the wrapper knows without loading them.
+    n_params: Optional[int] = None
+    #: The checkpoint's own config object, for a server reporting what it holds.
+    config: Optional[Any] = None
+    #: Which revision the key names, if it names one.
+    revision: Optional[str] = None
 
 
 #: Bytes per stored element for names that aren't torch dtypes — quantizations,
@@ -220,20 +254,21 @@ class Remotable(Meta):
         return math.ceil(elements * bytes_per_element(dtype))
 
     @classmethod
-    def _remoteable_checkpoint_config(
-        cls, model_key: str, trust_remote_code: bool = False
-    ) -> Optional[Any]:
-        """This checkpoint's config. Base default: ``None`` — not every wrapper
-        has one, and nothing here should have to invent it."""
-        return None
+    def _remoteable_describe_checkpoint(
+        cls, model_key: str, dtype: str, trust_remote_code: bool = False
+    ) -> "CheckpointInfo":
+        """Everything a placement decision needs, from one look at the checkpoint.
 
-    @classmethod
-    def _remoteable_checkpoint_revision(
-        cls, model_key: str, **kwargs: Any
-    ) -> Optional[str]:
-        """This checkpoint's revision. Base default: ``None`` — a key that names
-        no revision has none to report."""
-        return None
+        Base default: size it the expensive way and say nothing else. A subclass
+        that can read its checkpoint's metadata should override this rather than
+        the individual pieces — the point of one call is that a wrapper reading a
+        config can answer every field from the *same* read.
+        """
+        return CheckpointInfo(
+            size_bytes=cls._remoteable_estimate_bytes(
+                model_key, dtype, trust_remote_code=trust_remote_code
+            )
+        )
 
     @classmethod
     def _remoteable_max_tp_size(
@@ -311,27 +346,25 @@ class Remotable(Meta):
         return model_cls._remoteable_estimate_bytes(suffix, dtype, **kwargs)
 
     @classmethod
-    def checkpoint_config(cls, model_key: str, **kwargs: Any) -> Optional[Any]:
-        """The checkpoint's own config object, or ``None`` if it has no notion of one.
+    def describe_checkpoint(
+        cls, model_key: str, dtype: str, **kwargs: Any
+    ) -> "CheckpointInfo":
+        """What this checkpoint is, without loading it.
 
-        For a server reporting what it has loaded — architecture, hidden size,
-        the rest — without holding the model to ask.
+        One call rather than one per question, because the questions a server
+        asks before placing a model — how big, how many parameters, what
+        architecture, which revision — are all answered from the same metadata,
+        and asking separately meant fetching it repeatedly.
+
+        Args:
+            model_key: A full key, ``"import.path.ClassName:model_key"``.
+            dtype: What the weights will be held in — a torch dtype name, or a
+                quantization named as a string (see
+                [`bytes_per_element`][nnsight.modeling.mixins.remotable.bytes_per_element]).
         """
         import_path, suffix = model_key.split(":", 1)
         model_cls: type[Remotable] = from_import_path(import_path)
-        return model_cls._remoteable_checkpoint_config(suffix, **kwargs)
-
-    @classmethod
-    def checkpoint_revision(cls, model_key: str, **kwargs: Any) -> Optional[str]:
-        """Which revision of the checkpoint the key names, if it names one.
-
-        Reported alongside the config by a server listing what it has loaded, so
-        two deployments of the same repo at different revisions are tellable
-        apart.
-        """
-        import_path, suffix = model_key.split(":", 1)
-        model_cls: type[Remotable] = from_import_path(import_path)
-        return model_cls._remoteable_checkpoint_revision(suffix, **kwargs)
+        return model_cls._remoteable_describe_checkpoint(suffix, dtype, **kwargs)
 
     @classmethod
     def max_tp_size(cls, model_key: str, **kwargs: Any) -> Optional[int]:

--- a/src/nnsight/modeling/mixins/remotable.py
+++ b/src/nnsight/modeling/mixins/remotable.py
@@ -14,15 +14,77 @@ remote (or local-simulation) backend keyed by it. Subclasses supply the two
 model-specific halves — `_remoteable_model_key` and
 `_remoteable_from_model_key` — and may carry per-request state across with
 `_remoteable_get_env` / `_remoteable_set_env`.
+
+A server also has to answer two questions about a checkpoint it has never
+loaded, in order to decide where to put it: how much GPU memory it needs
+([`estimate_bytes`][nnsight.modeling.mixins.remotable.Remotable.estimate_bytes])
+and how many ways it can be split across cards
+([`max_tp_size`][nnsight.modeling.mixins.remotable.Remotable.max_tp_size]). Both
+answer from the key alone, and both have a subclass hook so a wrapper that can
+answer cheaply — a HuggingFace model can read the parameter count off the Hub —
+doesn't pay for building the architecture just to count it.
 """
 
 from __future__ import annotations
 
-from typing import Any
+import math
+from typing import Any, Optional
 
 from ...tracing.backend import Backend
 from ...util import from_import_path, to_import_path
 from .meta import Meta
+
+
+#: Bytes per stored element for names that aren't torch dtypes — quantizations,
+#: which are how a checkpoint is *held* rather than a type torch has. A caller
+#: sizing a deployment names these as plainly as it names ``"bfloat16"``.
+#:
+#: These are the nominal widths and they under-count real footprint:
+#: bitsandbytes leaves the LM head (usually the embeddings and norms too) in 16
+#: bits and stores an absmax/scale tensor per block, none of which is in the
+#: parameter count. `accelerate`'s memory estimator makes the same simplification.
+#: Anything placing a model on this number should pad it.
+_QUANTIZED_BYTES: dict[str, float] = {
+    "int4": 0.5,
+    "nf4": 0.5,
+    "fp4": 0.5,
+    "4bit": 0.5,
+    "int8": 1.0,
+    "fp8": 1.0,
+    "8bit": 1.0,
+}
+
+
+def bytes_per_element(dtype: str) -> float:
+    """How many bytes one weight occupies when held as ``dtype``.
+
+    Accepts what torch calls a dtype (``"bfloat16"``, ``"float32"``, with or
+    without a ``torch.`` prefix) and what only a quantizer calls one
+    (``"int4"``, ``"nf4"``, ``"fp8"``). Fractional for sub-byte formats, so the
+    result is a float — round the product, not this.
+
+    Raises:
+        ValueError: for a name that is neither, rather than defaulting to a
+            plausible width: a wrong guess here silently mis-sizes a deployment.
+    """
+    import torch
+
+    name = dtype.removeprefix("torch.").lower()
+
+    # The table wins over torch, which reports sub-byte dtypes as one byte
+    # because that is the smallest thing it can address: `torch.int4.itemsize`
+    # is 1, and sizing 4-bit weights by it would ask for twice the memory.
+    if name in _QUANTIZED_BYTES:
+        return _QUANTIZED_BYTES[name]
+
+    resolved = getattr(torch, name, None)
+    if isinstance(resolved, torch.dtype):
+        return float(resolved.itemsize)
+
+    raise ValueError(
+        f"Unknown dtype {dtype!r}: not a torch dtype and not one of "
+        f"{sorted(_QUANTIZED_BYTES)}."
+    )
 
 
 class Remotable(Meta):
@@ -133,6 +195,60 @@ class Remotable(Meta):
         raise NotImplementedError()
 
     @classmethod
+    def _remoteable_estimate_bytes(
+        cls, model_key: str, dtype: str, trust_remote_code: bool = False
+    ) -> int:
+        """Size this checkpoint's weights, given the key suffix.
+
+        Base default: build the architecture on the meta device and count what
+        it holds. That costs a config read and the graph, but no weights and no
+        device, and it works for any wrapper — which is why it is the fallback
+        every subclass drops back to.
+
+        Elements are counted rather than bytes summed, because the size wanted is
+        the size *as it will be held*, and that can be a dtype the meta build
+        cannot use (a 4-bit quantization has no torch dtype to build with).
+        """
+        model = cls.from_model_key(
+            f"{to_import_path(cls)}:{model_key}",
+            dispatch=False,
+            trust_remote_code=trust_remote_code,
+        )
+        module = model._module
+        elements = sum(p.nelement() for p in module.parameters())
+        elements += sum(b.nelement() for b in module.buffers())
+        return math.ceil(elements * bytes_per_element(dtype))
+
+    @classmethod
+    def _remoteable_checkpoint_config(
+        cls, model_key: str, trust_remote_code: bool = False
+    ) -> Optional[Any]:
+        """This checkpoint's config. Base default: ``None`` — not every wrapper
+        has one, and nothing here should have to invent it."""
+        return None
+
+    @classmethod
+    def _remoteable_checkpoint_revision(
+        cls, model_key: str, **kwargs: Any
+    ) -> Optional[str]:
+        """This checkpoint's revision. Base default: ``None`` — a key that names
+        no revision has none to report."""
+        return None
+
+    @classmethod
+    def _remoteable_max_tp_size(
+        cls, model_key: str, trust_remote_code: bool = False
+    ) -> Optional[int]:
+        """The largest tensor-parallel degree this checkpoint supports.
+
+        Base default: ``None`` — a wrapper says nothing about tensor parallelism
+        unless it knows better. Nothing is inferred from the architecture here,
+        because splitting a model is a property of the runtime that loads it, not
+        of the tree alone.
+        """
+        return None
+
+    @classmethod
     def _remoteable_from_model_key(cls, model_key: str, **kwargs: Any) -> Remotable:
         """Rebuild a model wrapper from the suffix `_remoteable_model_key` made.
 
@@ -173,3 +289,60 @@ class Remotable(Meta):
         import_path, model_key = model_key.split(":", 1)
         model_cls: type[Remotable] = from_import_path(import_path)
         return model_cls._remoteable_from_model_key(model_key, **kwargs)
+
+    @classmethod
+    def estimate_bytes(cls, model_key: str, dtype: str, **kwargs: Any) -> int:
+        """How much memory this checkpoint's weights need, without loading them.
+
+        Resolves the wrapper class from the key the same way
+        [`from_model_key`][nnsight.modeling.mixins.remotable.Remotable.from_model_key]
+        does, then asks it. What comes back counts parameters and buffers only —
+        no activations, no CUDA context, no framework overhead — so a caller
+        placing a model needs to pad it.
+
+        Args:
+            model_key: A full key, ``"import.path.ClassName:model_key"``.
+            dtype: What the weights will be held in — a torch dtype name, or a
+                quantization named as a string (see
+                [`bytes_per_element`][nnsight.modeling.mixins.remotable.bytes_per_element]).
+        """
+        import_path, suffix = model_key.split(":", 1)
+        model_cls: type[Remotable] = from_import_path(import_path)
+        return model_cls._remoteable_estimate_bytes(suffix, dtype, **kwargs)
+
+    @classmethod
+    def checkpoint_config(cls, model_key: str, **kwargs: Any) -> Optional[Any]:
+        """The checkpoint's own config object, or ``None`` if it has no notion of one.
+
+        For a server reporting what it has loaded — architecture, hidden size,
+        the rest — without holding the model to ask.
+        """
+        import_path, suffix = model_key.split(":", 1)
+        model_cls: type[Remotable] = from_import_path(import_path)
+        return model_cls._remoteable_checkpoint_config(suffix, **kwargs)
+
+    @classmethod
+    def checkpoint_revision(cls, model_key: str, **kwargs: Any) -> Optional[str]:
+        """Which revision of the checkpoint the key names, if it names one.
+
+        Reported alongside the config by a server listing what it has loaded, so
+        two deployments of the same repo at different revisions are tellable
+        apart.
+        """
+        import_path, suffix = model_key.split(":", 1)
+        model_cls: type[Remotable] = from_import_path(import_path)
+        return model_cls._remoteable_checkpoint_revision(suffix, **kwargs)
+
+    @classmethod
+    def max_tp_size(cls, model_key: str, **kwargs: Any) -> Optional[int]:
+        """The largest number of ranks this checkpoint's weights split into.
+
+        ``None`` when the model cannot be tensor-parallel at all. Otherwise the
+        degrees that actually work are the **divisors** of this number, so a
+        caller wanting to split a model *n* ways takes the smallest divisor
+        ``>= n`` — there may be none, and then the model has to be spread some
+        other way.
+        """
+        import_path, suffix = model_key.split(":", 1)
+        model_cls: type[Remotable] = from_import_path(import_path)
+        return model_cls._remoteable_max_tp_size(suffix, **kwargs)

--- a/src/nnsight/modeling/tp/__init__.py
+++ b/src/nnsight/modeling/tp/__init__.py
@@ -9,17 +9,23 @@ into the whole tensor a user asked for.
 """
 
 from .interleaver import (
+    MINIMUM_TRANSFORMERS,
     SHARDED_SIDES,
     UNSUPPORTED,
     TPInterleaver,
     UnsupportedParallelStyle,
+    UnsupportedTransformersVersion,
     is_sharded,
 )
+from .plan import max_tp_size
 
 __all__ = [
+    "MINIMUM_TRANSFORMERS",
     "SHARDED_SIDES",
     "UNSUPPORTED",
     "TPInterleaver",
     "UnsupportedParallelStyle",
+    "UnsupportedTransformersVersion",
     "is_sharded",
+    "max_tp_size",
 ]

--- a/src/nnsight/modeling/tp/__init__.py
+++ b/src/nnsight/modeling/tp/__init__.py
@@ -18,7 +18,12 @@ from .fragments import (
     UnsupportedTransformersVersion,
     is_sharded,
 )
-from .plan import max_tp_size
+from .plan import (
+    UnshardableCheckpoint,
+    check_tp_request,
+    max_tp_size,
+    requested_tp_size,
+)
 
 __all__ = [
     "MINIMUM_TRANSFORMERS",
@@ -28,5 +33,8 @@ __all__ = [
     "UnsupportedParallelStyle",
     "UnsupportedTransformersVersion",
     "is_sharded",
+    "UnshardableCheckpoint",
+    "check_tp_request",
     "max_tp_size",
+    "requested_tp_size",
 ]

--- a/src/nnsight/modeling/tp/__init__.py
+++ b/src/nnsight/modeling/tp/__init__.py
@@ -2,17 +2,18 @@
 
 Nothing here needs installing or enabling. A
 [`HuggingFaceModel`][nnsight.modeling.huggingface.HuggingFaceModel] is always
-built with a [`TPInterleaver`][nnsight.modeling.tp.interleaver.TPInterleaver],
-which stays inert unless it finds the model actually sharded. See
-[`interleaver`][nnsight.modeling.tp.interleaver] for how a shard is turned back
-into the whole tensor a user asked for.
+built with a [`TPFragments`][nnsight.modeling.tp.fragments.TPFragments], which
+stays inert unless it finds the model actually sharded. See
+[`fragments`][nnsight.modeling.tp.fragments] for which values are pieces and how
+they are reassembled, and
+[`nnsight.intervention.fragments`][nnsight.intervention.fragments] for when.
 """
 
-from .interleaver import (
+from .fragments import (
     MINIMUM_TRANSFORMERS,
     SHARDED_SIDES,
     UNSUPPORTED,
-    TPInterleaver,
+    TPFragments,
     UnsupportedParallelStyle,
     UnsupportedTransformersVersion,
     is_sharded,
@@ -23,7 +24,7 @@ __all__ = [
     "MINIMUM_TRANSFORMERS",
     "SHARDED_SIDES",
     "UNSUPPORTED",
-    "TPInterleaver",
+    "TPFragments",
     "UnsupportedParallelStyle",
     "UnsupportedTransformersVersion",
     "is_sharded",

--- a/src/nnsight/modeling/tp/__init__.py
+++ b/src/nnsight/modeling/tp/__init__.py
@@ -1,0 +1,25 @@
+"""Tracing a model sharded with transformers tensor parallelism.
+
+Nothing here needs installing or enabling. A
+[`HuggingFaceModel`][nnsight.modeling.huggingface.HuggingFaceModel] is always
+built with a [`TPInterleaver`][nnsight.modeling.tp.interleaver.TPInterleaver],
+which stays inert unless it finds the model actually sharded. See
+[`interleaver`][nnsight.modeling.tp.interleaver] for how a shard is turned back
+into the whole tensor a user asked for.
+"""
+
+from .interleaver import (
+    SHARDED_SIDES,
+    UNSUPPORTED,
+    TPInterleaver,
+    UnsupportedParallelStyle,
+    is_sharded,
+)
+
+__all__ = [
+    "SHARDED_SIDES",
+    "UNSUPPORTED",
+    "TPInterleaver",
+    "UnsupportedParallelStyle",
+    "is_sharded",
+]

--- a/src/nnsight/modeling/tp/fragments.py
+++ b/src/nnsight/modeling/tp/fragments.py
@@ -11,19 +11,19 @@ Two facts make this cheap to arrange.
 **transformers labels the shards for us.** ``apply_tensor_parallelism`` stamps
 every module it shards with ``_hf_tp_plan`` (the style name) and
 ``_hf_device_mesh``, so which side of which module carries a shard is read off
-the module, not guessed. The interleaver is handed every envoy through
-``instrument`` as the tree is built, so it records its own rules — and learns
-whether it has anything to do at all — right there.
+the module, not guessed. These rules are handed every envoy through
+``instrument`` as the tree is built, so they record themselves — and learn whether
+there is anything to do at all — right there.
 
 **nnsight already sees the post-TP value.** transformers registers its own
 forward hooks at load; nnsight registers the interleaver's when the
 [`Envoy`][nnsight.intervention.envoy.Envoy] tree is built, i.e. afterwards. Hooks
 fire in registration order, so by the time
-[`TPInterleaver.handle`][nnsight.modeling.tp.interleaver.TPInterleaver.handle]
+[`TPFragments.whole`][nnsight.modeling.tp.fragments.TPFragments.whole]
 runs, a row-parallel output has already been all-reduced and a
 ``colwise_gather_output`` head already all-gathered — those arrive whole and are
 left alone. Only the genuinely sharded sides are listed in
-[`SHARDED_SIDES`][nnsight.modeling.tp.interleaver.SHARDED_SIDES].
+[`SHARDED_SIDES`][nnsight.modeling.tp.fragments.SHARDED_SIDES].
 
 Every rank runs the same intervention block, so every rank reaches ``handle`` at
 the same location with the same parked workers and makes the same decision to
@@ -33,36 +33,12 @@ rank. For the same reason a run whose *sampling* diverges is not merely
 inconsistent but wrong — the ranks would go on to all-reduce activations computed
 from different tokens — so seed every rank identically before generating.
 
-## Why the interleaver and not the batcher
-
-vLLM does the equivalent gather in a
-[`Batcher`][nnsight.intervention.batching.Batcher] subclass
-([`VLLMBatcher`][nnsight.modeling.vllm.batching.VLLMBatcher]), so the obvious
-question is why this isn't one too.
-
-The reason is **when each is called**. ``Batcher.narrow``/``widen`` run once per
-*mediator* — inside the loop that serves each parked worker in turn
-(``Interleaver.handle``) — so a batcher that gathered would fire one collective
-per reader of a location. Ranks would then run different numbers of collectives
-depending on how many workers happened to be parked, which is a deadlock. vLLM
-pays for this with ``self.gathered`` memoization plus ``watch``/``release``
-brackets its *model runner* installs (see ``VLLMBatcher``'s own note that
-"several workers reading the same value would otherwise deadlock the ranks"), and
-it can do that because its runner constructs the batcher itself and owns the
-forward.
-
-``Interleaver.handle`` is already the once-per-visit bracket: it runs exactly
-once per location per visit however many workers read it. So the collective lands
-in the right place with no memoization and no external bracket, and it composes
-with the real batcher, whose dim-0 row narrowing happens inside it.
-
-*Not* the reason, though it was written here for a while and is worth correcting
-because it sounds plausible: that ``_batcher_class`` would resolve to the
-client's class across a remote trace. ``Envoy.__getstate__`` does pickle the
-envoy by value, but ``_batcher_class`` is a *class* attribute, and cloudpickle
-serializes an importable class by reference — so it resolves to the server's
-value, exactly like ``interleaver``. A ``TPBatcher`` would have been reachable;
-it would just have been called at the wrong granularity.
+Everything about *when* to gather — once per visit, only when something is
+waiting, re-split on the way out — belongs to
+[`Interleaver.handle`][nnsight.intervention.interleaver.Interleaver.handle] and is
+shared with every other distributed runtime. See
+[`nnsight.intervention.fragments`][nnsight.intervention.fragments] for that half,
+including why it is the interleaver's job and not the batcher's.
 """
 
 from __future__ import annotations
@@ -72,7 +48,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import torch
 
-from ...intervention.interleaver import Interleaver
+from ...intervention.fragments import Fragments
 from ...util import apply
 
 # Which side of a module carries this rank's slice, per transformers TP style.
@@ -283,9 +259,9 @@ def is_sharded(module: torch.nn.Module) -> bool:
 
     A caller's way to ask whether a loaded model is sharded at all, without
     reaching into transformers' stamps itself. Nothing in nnsight branches on it
-    — a [`TPInterleaver`][nnsight.modeling.tp.interleaver.TPInterleaver] is built
+    — a [`TPFragments`][nnsight.modeling.tp.fragments.TPFragments] is built
     for every HuggingFace model and stays inert until
-    [`instrument`][nnsight.modeling.tp.interleaver.TPInterleaver.instrument] finds
+    [`instrument`][nnsight.modeling.tp.fragments.TPFragments.instrument] finds
     a sharded module — but a server deciding how to run a replica wants it.
 
     A degenerate 1-rank mesh reads as not sharded: there is nothing to gather.
@@ -299,16 +275,15 @@ def is_sharded(module: torch.nn.Module) -> bool:
     return False
 
 
-class TPInterleaver(Interleaver):
-    """An [`Interleaver`][nnsight.intervention.interleaver.Interleaver] that hands
-    workers whole tensors on a tensor-parallel model.
+class TPFragments(Fragments):
+    """Which values a transformers-sharded model splits, and how to reassemble them.
 
     A [`HuggingFaceModel`][nnsight.modeling.huggingface.HuggingFaceModel] is built
     with one of these whether or not it is sharded, because whether it *is* only
     becomes knowable as the model loads. It starts
-    [`enabled`][nnsight.modeling.tp.interleaver.TPInterleaver.enabled]``=False``
-    and behaves exactly like the base interleaver until
-    [`instrument`][nnsight.modeling.tp.interleaver.TPInterleaver.instrument] finds
+    [`enabled`][nnsight.intervention.fragments.Fragments.enabled]``=False`` and
+    does nothing at all until
+    [`instrument`][nnsight.modeling.tp.fragments.TPFragments.instrument] finds
     something actually split across ranks.
 
     Attributes:
@@ -319,20 +294,14 @@ class TPInterleaver(Interleaver):
     """
 
     def __init__(self) -> None:
-        super().__init__()
         self.enabled = False
         self.tp_rules: Dict[str, Any] = {}
-        # Source locations already warned about this run; see `_warn_source`.
+        # Source locations already warned about; see `read`.
         self._warned: set = set()
-        # Locations whose gather has been shape-checked; see `_gather_whole`.
-        # Not cleared between runs: the rule for a location is a property of the
-        # loaded model, so re-checking it every trace buys nothing.
+        # Locations whose gather has been shape-checked; see `whole`.
+        # The rule for a location is a property of the loaded model, so
+        # re-checking it every trace buys nothing.
         self._checked: set = set()
-
-    def __enter__(self) -> "TPInterleaver":
-        # A fresh run: warn again about anything it reads (see `_warn_source`).
-        self._warned.clear()
-        return super().__enter__()
 
     def instrument(self, envoy: Any) -> None:
         """Install the hooks, and record whether this envoy's value is a shard.
@@ -385,33 +354,75 @@ class TPInterleaver(Interleaver):
         for side in SHARDED_SIDES[style]:
             self.tp_rules[f"{envoy.path}.{side}"] = mesh
 
-    def handle(self, provider: str, value: Any) -> Any:
-        """Gather ``value`` if it is a shard someone is waiting for, serve the
-        workers, then hand the model back its own slice.
+    def begin(self) -> None:
+        # A fresh run warns again about anything it reads. A model actor serves
+        # request after request from one process, and the second user deserves
+        # the same caveat as the first.
+        self._warned.clear()
 
-        On an unsharded model this is the base interleaver plus one attribute
-        check. Otherwise the gather is still skipped unless a worker is actually
-        parked on this visit
-        ([`observed`][nnsight.modeling.tp.interleaver.TPInterleaver.observed]), so
-        an untouched sharded location costs nothing — the common case, since a
-        trace reads a handful of locations out of hundreds.
+    def fragmented(self, location: str) -> bool:
+        """Whether this location's value is one rank's slice.
+
+        A dict lookup: the rules were recorded at instrument time, so nothing is
+        inspected here and nothing branches on rank.
         """
-        if not self.enabled:
-            return super().handle(provider, value)
+        return location in self.tp_rules
 
-        self._warn_source(provider)
+    def read(self, location: str) -> None:
+        """Warn that a ``.source`` read is this rank's shard, and hand it over.
 
-        mesh = self.tp_rules.get(provider)
-        if mesh is None or not self.observed(provider):
-            return super().handle(provider, value)
+        `.source` exposes a module's *intermediate* values, and the rules here
+        describe module *boundaries* — a different question. Measured at tp=2:
+        ``mlp.output`` and ``gate_proj.output`` arrive whole, while
+        ``mlp.source.self_gate_proj_0`` comes back at half width.
 
-        whole = super().handle(provider, self._gather_whole(provider, value, mesh))
-        return _reshard(whole, mesh)
+        These cannot be gathered for the reader. Knowing a value is sharded is
+        not enough to reassemble it: which axis it is split on changes through a
+        module's forward — a fused qkv projection is split by head on the way out
+        of the linear and by hidden dim after the reshape — and the axis is not
+        recoverable from the tensor at runtime. So the value is handed over as-is
+        with a warning, rather than refused (a `.source` read is often exactly
+        what someone debugging a sharded model wants) or silently corrected.
+
+        **Do not branch on one.** This is the only rank-dependent value nnsight
+        ever gives intervention code, and every rank must reach the same
+        collectives in the same order. ``if x.source.self_k_proj_0.output.max() >
+        t:`` takes different branches on different ranks and deadlocks the group.
+        """
+        if ".source." not in location or location in self._warned:
+            return
+
+        self._warned.add(location)
+        # This module's registry entry is cleared first because a model actor
+        # serves request after request from one process: Python's default filter
+        # shows a warning once per source line, so without this only the first
+        # user of a replica would ever see it.
+        globals().pop("__warningregistry__", None)
+        warnings.warn(
+            f"'{location}' reads inside a module's forward on a model split "
+            "across ranks. `.source` values can be this rank's shard, and which "
+            "axis they are split on changes through the forward, so they are "
+            "handed over as-is rather than gathered. A value past the layer that "
+            "all-reduces (a module's own `.input`/`.output`) is whole; one "
+            "between a column-parallel layer and it is not. Do not branch on one "
+            "— the ranks would diverge. Compare against a single-GPU run if it "
+            "matters.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    def whole(self, location: str, value: Any) -> Any:
+        """Every rank's slice of ``value``, concatenated into the real tensor."""
+        return self._gather_whole(location, value, self.tp_rules[location])
+
+    def fragment(self, location: str, whole: Any) -> Any:
+        """This rank's slice again, carrying whatever the workers left behind."""
+        return _reshard(whole, self.tp_rules[location])
 
     def _gather_whole(self, provider: str, value: Any, mesh: Any) -> Any:
         """``value`` gathered, checked once per location against the rule used.
 
-        The rules in [`SHARDED_SIDES`][nnsight.modeling.tp.interleaver.SHARDED_SIDES]
+        The rules in [`SHARDED_SIDES`][nnsight.modeling.tp.fragments.SHARDED_SIDES]
         are a claim about a transformers version, and most of them were settled by
         reading its source rather than by running a model. This is what turns a
         wrong claim from silent into loud.
@@ -420,7 +431,7 @@ class TPInterleaver(Interleaver):
         by ``world_size`` when gathered. A rule that named a whole value leaves
         the width unchanged after the collective — which is precisely the shape of
         the failure that motivated
-        [`MINIMUM_TRANSFORMERS`][nnsight.modeling.tp.interleaver.MINIMUM_TRANSFORMERS]:
+        [`MINIMUM_TRANSFORMERS`][nnsight.modeling.tp.fragments.MINIMUM_TRANSFORMERS]:
         a value already made whole by the model's own hook, gathered a second time
         and handed back ``tp_size`` times too wide with a plausible first copy.
         A version floor catches that for one known version; this catches it for
@@ -456,80 +467,3 @@ class TPInterleaver(Interleaver):
             )
         return gathered
 
-    def _warn_source(self, provider: str) -> None:
-        """Warn that a ``.source`` read is this rank's shard, and hand it over.
-
-        `.source` exposes a module's *intermediate* values, and the rules here
-        describe module *boundaries* — a different question. Measured at tp=2:
-        ``mlp.output`` and ``gate_proj.output`` arrive whole, while
-        ``mlp.source.self_gate_proj_0`` comes back at half width.
-
-        These cannot be gathered for the reader. Knowing a value is sharded is
-        easy — everything between a column-parallel output and the row-parallel
-        layer that all-reduces it is — but gathering needs the **axis**, and the
-        axis moves within that window as attention reshapes: measured at ``-1``
-        after ``k_proj``, ``2`` after ``view``, ``1`` after ``transpose``, back to
-        ``-1`` after the output reshape. Every rank holds the same shape, so
-        nothing at runtime recovers it.
-
-        A warning rather than an error because plenty of source reads under a
-        sharded model are perfectly whole — anything past the row-parallel layer
-        that closed the window (``mlp.source.self_down_proj_0`` measures 16 at
-        both tp=1 and tp=2), and anything in a part of the model that shards
-        nothing. Refusing the lot to catch the sharded ones blocks correct work;
-        saying so and handing the value over does not.
-
-        Warned once per location per run: a read inside a generation loop fires
-        on every token, and a caveat repeated hundreds of times is one nobody
-        reads either.
-        """
-        if ".source." not in provider or provider in self._warned:
-            return
-        if not self.observed(provider):
-            return
-
-        self._warned.add(provider)
-        # This module's registry entry is cleared first because a model actor
-        # serves request after request from one process: Python's default filter
-        # shows a warning once per source line, so without this only the first
-        # user of a replica would ever see it.
-        globals().pop("__warningregistry__", None)
-        warnings.warn(
-            f"'{provider}' reads inside a module's forward on a model split "
-            "across ranks. `.source` values can be this rank's shard, and which "
-            "axis they are split on changes through the forward, so they are "
-            "handed over as-is rather than gathered. A value past the layer that "
-            "all-reduces (a module's own `.input`/`.output`) is whole; one "
-            "between a column-parallel layer and it is not. Compare against a "
-            "single-GPU run if it matters.",
-            stacklevel=2,
-        )
-
-    def observed(self, provider: str) -> bool:
-        """Whether any worker is waiting on *this* visit to ``provider``.
-
-        Mirrors the match [`Mediator.handle`][nnsight.intervention.interleaver.Mediator.handle]
-        makes — a worker parks already carrying the occurrence tag it wants, so
-        this is the same single string comparison against this visit's count.
-        Deliberately not "is any worker parked anywhere": a worker waiting on a
-        *later* iteration of this location must not trigger the collective now.
-
-        A ``tracer.cache()`` counts too — it would otherwise record fragments —
-        but only for the locations it actually keeps. A cache is usually scoped to
-        a handful of modules, so asking it (rather than assuming any open cache
-        wants everything) is the difference between a few collectives and one at
-        every sharded module in the model.
-
-        Every rank evaluates this over the same block, so it answers the same
-        everywhere — which is what keeps the ranks' collectives matched.
-        """
-        for mediator in self.mediators:
-            pending = mediator.pending
-            if (
-                pending is not None
-                and pending[1] == f"{provider}.i{mediator.iterations[provider]}"
-            ):
-                return True
-            if any(cache.wants(provider) for cache in mediator.caches):
-                return True
-        return False

--- a/src/nnsight/modeling/tp/interleaver.py
+++ b/src/nnsight/modeling/tp/interleaver.py
@@ -1,0 +1,358 @@
+"""Show intervention code whole tensors on a tensor-parallel model.
+
+Under transformers tensor parallelism a module's activation can be one rank's
+slice rather than the real thing: a column-parallel linear splits its *output*
+across ranks, and a row-parallel linear takes its *input* already split. A user
+asked for the layer, not a quarter of it, so those values are gathered before a
+worker sees them and re-split before the model's own forward carries on.
+
+Two facts make this cheap to arrange.
+
+**transformers labels the shards for us.** ``apply_tensor_parallelism`` stamps
+every module it shards with ``_hf_tp_plan`` (the style name) and
+``_hf_device_mesh``, so which side of which module carries a shard is read off
+the module, not guessed. The interleaver is handed every envoy through
+``instrument`` as the tree is built, so it records its own rules — and learns
+whether it has anything to do at all — right there.
+
+**nnsight already sees the post-TP value.** transformers registers its own
+forward hooks at load; nnsight registers the interleaver's when the
+[`Envoy`][nnsight.intervention.envoy.Envoy] tree is built, i.e. afterwards. Hooks
+fire in registration order, so by the time
+[`TPInterleaver.handle`][nnsight.modeling.tp.interleaver.TPInterleaver.handle]
+runs, a row-parallel output has already been all-reduced and a
+``colwise_gather_output`` head already all-gathered — those arrive whole and are
+left alone. Only the genuinely sharded sides are listed in
+[`SHARDED_SIDES`][nnsight.modeling.tp.interleaver.SHARDED_SIDES].
+
+Every rank runs the same intervention block, so every rank reaches ``handle`` at
+the same location with the same parked workers and makes the same decision to
+gather. That is what keeps the collectives matched; it is also why a block whose
+control flow diverges across ranks deadlocks, and why nothing here may branch on
+rank. For the same reason a run whose *sampling* diverges is not merely
+inconsistent but wrong — the ranks would go on to all-reduce activations computed
+from different tokens — so seed every rank identically before generating.
+
+## Why the interleaver and not the batcher
+
+vLLM does the equivalent gather in a
+[`Batcher`][nnsight.intervention.batching.Batcher] subclass
+([`VLLMBatcher`][nnsight.modeling.vllm.batching.VLLMBatcher]), because it is
+already overriding the batcher for vLLM's flat token axis, and because its model
+runner constructs the batcher itself and assigns ``interleaver.batcher`` directly
+— no trace is deserialized in the worker, only a
+[`Mediator`][nnsight.intervention.interleaver.Mediator].
+
+That does not carry over to a deserialized *trace*, which is how a remote request
+runs. ``Envoy.__getstate__`` pickles the envoy **by value**, tagging only its
+module and its interleaver as persistent ids. So the tracer executing server-side
+holds a *copy of the client's* envoy, and
+``self.batcher = self.envoy._batcher_class(...)`` resolves against the client's
+class — while ``self.envoy.interleaver`` resolves, through the persistent id, to
+the **server's own** interleaver. Only one of those two is an object the serving
+process controls.
+
+Sitting on the interleaver is also the better fit on its own terms: the
+collective fires once per location per visit however many workers read it (no
+per-worker memoization needed), and it composes with the real batcher, whose
+dim-0 row narrowing happens inside this bracket.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any, Dict, Tuple
+
+import torch
+
+from ...intervention.interleaver import Interleaver
+from ...util import apply
+
+# Which side of a module carries this rank's slice, per transformers TP style.
+# A side listed here is sharded along the LAST dim and must be gathered before a
+# worker sees it; a side left out is already whole, because the style's own
+# collective (an all-reduce, or an all-gather for `gather_output`) ran in the TP
+# hook that fires before ours.
+#
+# Starred entries were measured on Llama-3.2-3B at tp=4: the sharded sides came
+# back at 1/4 width and reassembled with a rank-order `cat(-1)`, and the whole
+# sides were bit-identical across ranks. The rest follow from
+# transformers/integrations/tensor_parallel.py but no model in the test set
+# exercised them — treat them as unverified.
+SHARDED_SIDES: Dict[str, Tuple[str, ...]] = {
+    "colwise": ("output",),                   # * output features split
+    "packed_colwise": ("output",),            #   (fused gate_up, same split)
+    "colwise_gather_output": (),              # * gather_output=True -> whole
+    "rowwise": ("input",),                    # * input pre-split; output all-reduced
+    "rowwise_split_input": ("input",),        #   TP splits it in its own pre-hook
+    "packed_rowwise": ("input",),
+    "embedding_rowwise": (),                  # * vocab-parallel; output all-reduced
+    "embedding_colwise": ("output",),         #   hidden dim split
+    "sequence_parallel": ("output",),         #   reduce-scatter on the last dim
+    "all_reduce": (),                         #   output all-reduced -> whole
+    "replicated_with_grad_allreduce": (),     #   params replicated; activations whole
+}
+
+# Styles refused rather than guessed at. The expert-parallel family slices by
+# *expert*, not along the last dim, so neither the gather nor the re-split below
+# is meaningful for it; MLA's split kv projection needs its own rule. A model
+# that uses one of these fails at load instead of silently handing users a
+# fragment of a tensor.
+UNSUPPORTED: Dict[str, str] = {
+    "grouped_gemm": "expert-parallel (MoE)",
+    "ep_router": "expert-parallel (MoE)",
+    "megamoe_router": "expert-parallel (MoE)",
+    "moe_tp_experts": "expert-parallel (MoE)",
+    "megamoe_experts": "expert-parallel (MoE)",
+    "moe_identity_expert": "expert-parallel (MoE)",
+    "mla_kv_a_proj": "MLA split kv projection",
+}
+
+
+class UnsupportedParallelStyle(Exception):
+    """The model shards something interventions can't be shown whole."""
+
+
+def _shardable(tensor: torch.Tensor, world_size: int) -> bool:
+    """Whether ``tensor`` can be this rank's slice of a last-dim shard.
+
+    The sharded activation is always a float tensor whose last dim divides the
+    mesh — transformers' own all-gather assumes equal shards. Anything else (an
+    integer mask, a scalar, a ragged width) cannot be what was split, so it
+    passes through untouched rather than being corrupted by a collective.
+    """
+    return (
+        tensor.is_floating_point()
+        and tensor.dim() >= 1
+        and tensor.shape[-1] % world_size == 0
+    )
+
+
+def _gather(value: Any, mesh: Any) -> Any:
+    """Every rank's slice of ``value``, concatenated back into the whole tensor."""
+    from transformers.integrations.tensor_parallel import all_gather
+
+    world_size = mesh.size()
+    return apply(
+        value,
+        lambda tensor: (
+            all_gather(tensor, mesh) if _shardable(tensor, world_size) else tensor
+        ),
+        torch.Tensor,
+    )
+
+
+def _reshard(value: Any, mesh: Any) -> Any:
+    """This rank's slice of ``value``, as the model's own forward expects it.
+
+    transformers' ``split`` is the exact inverse of its ``all_gather`` — chunk
+    along the last dim, take this rank's — so a value no worker touched comes back
+    unchanged, and an edited one carries the edit. Both are autograd functions, so
+    the pair is transparent to a backward pass as well.
+    """
+    from transformers.integrations.tensor_parallel import split
+
+    world_size = mesh.size()
+    return apply(
+        value,
+        lambda tensor: (
+            split(tensor, mesh) if tensor.shape[-1] % world_size == 0 else tensor
+        ),
+        torch.Tensor,
+    )
+
+
+def is_sharded(module: torch.nn.Module) -> bool:
+    """Whether ``module``'s tree has anything split across a multi-rank mesh.
+
+    The test [`Envoy._interleaver_class`][nnsight.intervention.envoy.Envoy._interleaver_class]
+    uses to decide whether a model needs a
+    [`TPInterleaver`][nnsight.modeling.tp.interleaver.TPInterleaver] at all. A
+    degenerate 1-rank mesh reads as not sharded: there is nothing to gather.
+    """
+    for child in module.modules():
+        if getattr(child, "_hf_tp_plan", None) is None:
+            continue
+        mesh = getattr(child, "_hf_device_mesh", None)
+        if mesh is not None and mesh.size() > 1:
+            return True
+    return False
+
+
+class TPInterleaver(Interleaver):
+    """An [`Interleaver`][nnsight.intervention.interleaver.Interleaver] that hands
+    workers whole tensors on a tensor-parallel model.
+
+    A [`HuggingFaceModel`][nnsight.modeling.huggingface.HuggingFaceModel] is built
+    with one of these whether or not it is sharded, because whether it *is* only
+    becomes knowable as the model loads. It starts
+    [`enabled`][nnsight.modeling.tp.interleaver.TPInterleaver.enabled]``=False``
+    and behaves exactly like the base interleaver until
+    [`instrument`][nnsight.modeling.tp.interleaver.TPInterleaver.instrument] finds
+    something actually split across ranks.
+
+    Attributes:
+        enabled: Whether anything in this tree is sharded. False costs one
+            attribute check per handled location.
+        tp_rules: Sharded location -> the device mesh it is split over. A location
+            absent from it is already whole.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.enabled = False
+        self.tp_rules: Dict[str, Any] = {}
+        # Source locations already warned about this run; see `_warn_source`.
+        self._warned: set = set()
+
+    def __enter__(self) -> "TPInterleaver":
+        # A fresh run: warn again about anything it reads (see `_warn_source`).
+        self._warned.clear()
+        return super().__enter__()
+
+    def instrument(self, envoy: Any) -> None:
+        """Install the hooks, and record whether this envoy's value is a shard.
+
+        Called once per envoy as the tree is built, and again through
+        [`_update`][nnsight.intervention.envoy.Envoy._update] when real weights are
+        dispatched under a tree built on meta. That is the one moment both the
+        module — carrying transformers' ``_hf_tp_plan`` — and its path are in
+        hand, and it covers both load paths without either having to say so: a
+        meta module carries no plan and registers nothing, and the same envoy
+        re-instrumented over real weights registers then.
+
+        Raises:
+            UnsupportedParallelStyle: if this module is sharded in a way there is
+                no rule for. Refused as the tree is built rather than papered
+                over, since the alternative is silently handing users a fragment
+                of a tensor.
+        """
+        super().instrument(envoy)
+
+        module = envoy._module
+        style = getattr(module, "_hf_tp_plan", None)
+        if style is None:
+            return
+
+        if style in UNSUPPORTED:
+            raise UnsupportedParallelStyle(
+                f"'{envoy.path}' is sharded as '{style}' ({UNSUPPORTED[style]}), "
+                "which interventions can't be shown whole, so this model can't "
+                "be traced tensor-parallel."
+            )
+        if style not in SHARDED_SIDES:
+            raise UnsupportedParallelStyle(
+                f"'{envoy.path}' is sharded as '{style}', which is not a parallel "
+                "style this version of nnsight recognizes."
+            )
+
+        mesh = getattr(module, "_hf_device_mesh", None)
+        if mesh is None or mesh.size() == 1:
+            # Stamped but not actually split (a degenerate 1-rank mesh) — nothing
+            # to gather, and a collective over a 1-rank group is pure overhead.
+            return
+
+        self.enabled = True
+        for side in SHARDED_SIDES[style]:
+            self.tp_rules[f"{envoy.path}.{side}"] = mesh
+
+    def handle(self, provider: str, value: Any) -> Any:
+        """Gather ``value`` if it is a shard someone is waiting for, serve the
+        workers, then hand the model back its own slice.
+
+        On an unsharded model this is the base interleaver plus one attribute
+        check. Otherwise the gather is still skipped unless a worker is actually
+        parked on this visit
+        ([`observed`][nnsight.modeling.tp.interleaver.TPInterleaver.observed]), so
+        an untouched sharded location costs nothing — the common case, since a
+        trace reads a handful of locations out of hundreds.
+        """
+        if not self.enabled:
+            return super().handle(provider, value)
+
+        self._warn_source(provider)
+
+        mesh = self.tp_rules.get(provider)
+        if mesh is None or not self.observed(provider):
+            return super().handle(provider, value)
+
+        whole = super().handle(provider, _gather(value, mesh))
+        return _reshard(whole, mesh)
+
+    def _warn_source(self, provider: str) -> None:
+        """Warn that a ``.source`` read is this rank's shard, and hand it over.
+
+        `.source` exposes a module's *intermediate* values, and the rules here
+        describe module *boundaries* — a different question. Measured at tp=2:
+        ``mlp.output`` and ``gate_proj.output`` arrive whole, while
+        ``mlp.source.self_gate_proj_0`` comes back at half width.
+
+        These cannot be gathered for the reader. Knowing a value is sharded is
+        easy — everything between a column-parallel output and the row-parallel
+        layer that all-reduces it is — but gathering needs the **axis**, and the
+        axis moves within that window as attention reshapes: measured at ``-1``
+        after ``k_proj``, ``2`` after ``view``, ``1`` after ``transpose``, back to
+        ``-1`` after the output reshape. Every rank holds the same shape, so
+        nothing at runtime recovers it.
+
+        A warning rather than an error because plenty of source reads under a
+        sharded model are perfectly whole — anything past the row-parallel layer
+        that closed the window (``mlp.source.self_down_proj_0`` measures 16 at
+        both tp=1 and tp=2), and anything in a part of the model that shards
+        nothing. Refusing the lot to catch the sharded ones blocks correct work;
+        saying so and handing the value over does not.
+
+        Warned once per location per run: a read inside a generation loop fires
+        on every token, and a caveat repeated hundreds of times is one nobody
+        reads either.
+        """
+        if ".source." not in provider or provider in self._warned:
+            return
+        if not self.observed(provider):
+            return
+
+        self._warned.add(provider)
+        # This module's registry entry is cleared first because a model actor
+        # serves request after request from one process: Python's default filter
+        # shows a warning once per source line, so without this only the first
+        # user of a replica would ever see it.
+        globals().pop("__warningregistry__", None)
+        warnings.warn(
+            f"'{provider}' reads inside a module's forward on a model split "
+            "across ranks. `.source` values can be this rank's shard, and which "
+            "axis they are split on changes through the forward, so they are "
+            "handed over as-is rather than gathered. A value past the layer that "
+            "all-reduces (a module's own `.input`/`.output`) is whole; one "
+            "between a column-parallel layer and it is not. Compare against a "
+            "single-GPU run if it matters.",
+            stacklevel=2,
+        )
+
+    def observed(self, provider: str) -> bool:
+        """Whether any worker is waiting on *this* visit to ``provider``.
+
+        Mirrors the match [`Mediator.handle`][nnsight.intervention.interleaver.Mediator.handle]
+        makes — a worker parks already carrying the occurrence tag it wants, so
+        this is the same single string comparison against this visit's count.
+        Deliberately not "is any worker parked anywhere": a worker waiting on a
+        *later* iteration of this location must not trigger the collective now.
+
+        A ``tracer.cache()`` counts too — it would otherwise record fragments —
+        but only for the locations it actually keeps. A cache is usually scoped to
+        a handful of modules, so asking it (rather than assuming any open cache
+        wants everything) is the difference between a few collectives and one at
+        every sharded module in the model.
+
+        Every rank evaluates this over the same block, so it answers the same
+        everywhere — which is what keeps the ranks' collectives matched.
+        """
+        for mediator in self.mediators:
+            pending = mediator.pending
+            if (
+                pending is not None
+                and pending[1] == f"{provider}.i{mediator.iterations[provider]}"
+            ):
+                return True
+            if any(cache.wants(provider) for cache in mediator.caches):
+                return True
+        return False

--- a/src/nnsight/modeling/tp/interleaver.py
+++ b/src/nnsight/modeling/tp/interleaver.py
@@ -37,31 +37,38 @@ from different tokens — so seed every rank identically before generating.
 
 vLLM does the equivalent gather in a
 [`Batcher`][nnsight.intervention.batching.Batcher] subclass
-([`VLLMBatcher`][nnsight.modeling.vllm.batching.VLLMBatcher]), because it is
-already overriding the batcher for vLLM's flat token axis, and because its model
-runner constructs the batcher itself and assigns ``interleaver.batcher`` directly
-— no trace is deserialized in the worker, only a
-[`Mediator`][nnsight.intervention.interleaver.Mediator].
+([`VLLMBatcher`][nnsight.modeling.vllm.batching.VLLMBatcher]), so the obvious
+question is why this isn't one too.
 
-That does not carry over to a deserialized *trace*, which is how a remote request
-runs. ``Envoy.__getstate__`` pickles the envoy **by value**, tagging only its
-module and its interleaver as persistent ids. So the tracer executing server-side
-holds a *copy of the client's* envoy, and
-``self.batcher = self.envoy._batcher_class(...)`` resolves against the client's
-class — while ``self.envoy.interleaver`` resolves, through the persistent id, to
-the **server's own** interleaver. Only one of those two is an object the serving
-process controls.
+The reason is **when each is called**. ``Batcher.narrow``/``widen`` run once per
+*mediator* — inside the loop that serves each parked worker in turn
+(``Interleaver.handle``) — so a batcher that gathered would fire one collective
+per reader of a location. Ranks would then run different numbers of collectives
+depending on how many workers happened to be parked, which is a deadlock. vLLM
+pays for this with ``self.gathered`` memoization plus ``watch``/``release``
+brackets its *model runner* installs (see ``VLLMBatcher``'s own note that
+"several workers reading the same value would otherwise deadlock the ranks"), and
+it can do that because its runner constructs the batcher itself and owns the
+forward.
 
-Sitting on the interleaver is also the better fit on its own terms: the
-collective fires once per location per visit however many workers read it (no
-per-worker memoization needed), and it composes with the real batcher, whose
-dim-0 row narrowing happens inside this bracket.
+``Interleaver.handle`` is already the once-per-visit bracket: it runs exactly
+once per location per visit however many workers read it. So the collective lands
+in the right place with no memoization and no external bracket, and it composes
+with the real batcher, whose dim-0 row narrowing happens inside it.
+
+*Not* the reason, though it was written here for a while and is worth correcting
+because it sounds plausible: that ``_batcher_class`` would resolve to the
+client's class across a remote trace. ``Envoy.__getstate__`` does pickle the
+envoy by value, but ``_batcher_class`` is a *class* attribute, and cloudpickle
+serializes an importable class by reference — so it resolves to the server's
+value, exactly like ``interleaver``. A ``TPBatcher`` would have been reachable;
+it would just have been called at the wrong granularity.
 """
 
 from __future__ import annotations
 
 import warnings
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import torch
 
@@ -87,22 +94,54 @@ SHARDED_SIDES: Dict[str, Tuple[str, ...]] = {
     "rowwise_split_input": ("input",),        #   TP splits it in its own pre-hook
     "packed_rowwise": ("input",),
     "embedding_rowwise": (),                  # * vocab-parallel; output all-reduced
-    "embedding_colwise": ("output",),         #   hidden dim split
-    "sequence_parallel": ("output",),         #   reduce-scatter on the last dim
+    "embedding_colwise": (),                  # + output all-reduced (see below)
+    "sequence_parallel": ("output",),         # + reduce-scatter, on the LAST dim
     "all_reduce": (),                         #   output all-reduced -> whole
     "replicated_with_grad_allreduce": (),     #   params replicated; activations whole
+    "moe_tp_experts": (),                     # + output all-reduced (see below)
 }
 
-# Styles refused rather than guessed at. The expert-parallel family slices by
-# *expert*, not along the last dim, so neither the gather nor the re-split below
-# is meaningful for it; MLA's split kv projection needs its own rule. A model
-# that uses one of these fails at load instead of silently handing users a
-# fragment of a tensor.
+# Entries marked + were settled by reading transformers/integrations/
+# tensor_parallel.py rather than by running a model, because no checkpoint in the
+# test set exercises them. Each is a case where the obvious reading of the style's
+# *name* is wrong:
+#
+# * ``embedding_colwise`` splits the hidden dim, so its output looks like a
+#   fragment — but ``EmbeddingParallel._prepare_output_fn`` ends in an
+#   unconditional ``all_reduce_forward``; the ``embedding_dim_sharding == 0``
+#   branch above it guards only the vocab masking. Listing "output" here would
+#   all-gather an already-whole tensor and handed users one ``tp_size`` times too
+#   wide with a plausible first copy — the same failure as the tied-LM-head bug
+#   MINIMUM_TRANSFORMERS exists for, reintroduced by this table.
+# * ``moe_tp_experts`` is expert-parallel and was previously refused outright.
+#   Its forward needs nothing: ``_prepare_input_fn`` applies only
+#   ``all_reduce_backward`` (identity going forwards) and ``_prepare_output_fn``
+#   is ``all_reduce_forward``. Both sides are whole, exactly like ``all_reduce``.
+#   Refusing it cost every MoE checkpoint that uses it — 26 of the configs
+#   shipped with transformers 5.15, including Mixtral, DeepSeek-V3 and Qwen3-MoE,
+#   were refused for this and nothing else.
+# * ``sequence_parallel`` names a sequence dim and takes a ``sequence_dim=1``
+#   argument, which it stores and never uses: its reduce-scatter hardcodes
+#   ``x.dim() - 1``. The entry matches the implementation and contradicts the
+#   declared intent, so it is the one most likely to rot — see the shape check in
+#   `_gather_whole`, which is what would catch it.
+
+# Styles refused rather than guessed at, with the reason a user is shown. These
+# slice something other than the last dim — by expert, or into a fused kv
+# projection — so neither the gather nor the re-split above means anything for
+# them. A model using one fails at load rather than silently handing users a
+# fragment.
+#
+# Being on this list is a claim that the style *needs* a rule nnsight doesn't
+# have, not merely that no one has checked it. ``moe_tp_experts`` was here on the
+# strength of its name and did not belong: it is expert-parallel and still needs
+# nothing, because its forward all-reduces (see SHARDED_SIDES). Prefer reading
+# the style's ``_prepare_input_fn``/``_prepare_output_fn`` to inferring from the
+# family it belongs to — the two do not track each other.
 UNSUPPORTED: Dict[str, str] = {
     "grouped_gemm": "expert-parallel (MoE)",
     "ep_router": "expert-parallel (MoE)",
     "megamoe_router": "expert-parallel (MoE)",
-    "moe_tp_experts": "expert-parallel (MoE)",
     "megamoe_experts": "expert-parallel (MoE)",
     "moe_identity_expert": "expert-parallel (MoE)",
     "mla_kv_a_proj": "MLA split kv projection",
@@ -192,6 +231,26 @@ def _gather(value: Any, mesh: Any) -> Any:
     )
 
 
+def _last_dim(value: Any) -> Optional[int]:
+    """The last dimension of the one shardable tensor in ``value``, if there is one.
+
+    A location's value is often a tuple or a dataclass, most of whose members
+    are not fragments — a mask, a cache, ``None``. Exactly one shardable tensor
+    makes the width comparable before and after a gather; anything else (none, or
+    several of different widths) is not something to draw a conclusion from, and
+    the caller skips the check rather than guessing.
+    """
+    widths = []
+    apply(
+        value,
+        lambda tensor: widths.append(tensor.shape[-1])
+        if tensor.is_floating_point() and tensor.dim() >= 1
+        else None,
+        torch.Tensor,
+    )
+    return widths[0] if len(widths) == 1 else None
+
+
 def _reshard(value: Any, mesh: Any) -> Any:
     """This rank's slice of ``value``, as the model's own forward expects it.
 
@@ -199,6 +258,13 @@ def _reshard(value: Any, mesh: Any) -> Any:
     along the last dim, take this rank's — so a value no worker touched comes back
     unchanged, and an edited one carries the edit. Both are autograd functions, so
     the pair is transparent to a backward pass as well.
+
+    Guarded by the same predicate as the gather, and it must be: what goes back
+    is what the model's own forward consumes. A tensor ``_gather`` declined to
+    touch was never a fragment, so splitting it here hands the model a slice of
+    something whole. Divisibility alone is not enough to tell those apart — an
+    integer ``position_ids`` of width 8 at tp=4 divides perfectly, and every rank
+    would silently continue on a quarter of it. Wrong answers, not a hang.
     """
     from transformers.integrations.tensor_parallel import split
 
@@ -206,7 +272,7 @@ def _reshard(value: Any, mesh: Any) -> Any:
     return apply(
         value,
         lambda tensor: (
-            split(tensor, mesh) if tensor.shape[-1] % world_size == 0 else tensor
+            split(tensor, mesh) if _shardable(tensor, world_size) else tensor
         ),
         torch.Tensor,
     )
@@ -215,10 +281,14 @@ def _reshard(value: Any, mesh: Any) -> Any:
 def is_sharded(module: torch.nn.Module) -> bool:
     """Whether ``module``'s tree has anything split across a multi-rank mesh.
 
-    The test [`Envoy._interleaver_class`][nnsight.intervention.envoy.Envoy._interleaver_class]
-    uses to decide whether a model needs a
-    [`TPInterleaver`][nnsight.modeling.tp.interleaver.TPInterleaver] at all. A
-    degenerate 1-rank mesh reads as not sharded: there is nothing to gather.
+    A caller's way to ask whether a loaded model is sharded at all, without
+    reaching into transformers' stamps itself. Nothing in nnsight branches on it
+    — a [`TPInterleaver`][nnsight.modeling.tp.interleaver.TPInterleaver] is built
+    for every HuggingFace model and stays inert until
+    [`instrument`][nnsight.modeling.tp.interleaver.TPInterleaver.instrument] finds
+    a sharded module — but a server deciding how to run a replica wants it.
+
+    A degenerate 1-rank mesh reads as not sharded: there is nothing to gather.
     """
     for child in module.modules():
         if getattr(child, "_hf_tp_plan", None) is None:
@@ -254,6 +324,10 @@ class TPInterleaver(Interleaver):
         self.tp_rules: Dict[str, Any] = {}
         # Source locations already warned about this run; see `_warn_source`.
         self._warned: set = set()
+        # Locations whose gather has been shape-checked; see `_gather_whole`.
+        # Not cleared between runs: the rule for a location is a property of the
+        # loaded model, so re-checking it every trace buys nothing.
+        self._checked: set = set()
 
     def __enter__(self) -> "TPInterleaver":
         # A fresh run: warn again about anything it reads (see `_warn_source`).
@@ -331,8 +405,56 @@ class TPInterleaver(Interleaver):
         if mesh is None or not self.observed(provider):
             return super().handle(provider, value)
 
-        whole = super().handle(provider, _gather(value, mesh))
+        whole = super().handle(provider, self._gather_whole(provider, value, mesh))
         return _reshard(whole, mesh)
+
+    def _gather_whole(self, provider: str, value: Any, mesh: Any) -> Any:
+        """``value`` gathered, checked once per location against the rule used.
+
+        The rules in [`SHARDED_SIDES`][nnsight.modeling.tp.interleaver.SHARDED_SIDES]
+        are a claim about a transformers version, and most of them were settled by
+        reading its source rather than by running a model. This is what turns a
+        wrong claim from silent into loud.
+
+        The check is cheap and total: a side listed as sharded must actually grow
+        by ``world_size`` when gathered. A rule that named a whole value leaves
+        the width unchanged after the collective — which is precisely the shape of
+        the failure that motivated
+        [`MINIMUM_TRANSFORMERS`][nnsight.modeling.tp.interleaver.MINIMUM_TRANSFORMERS]:
+        a value already made whole by the model's own hook, gathered a second time
+        and handed back ``tp_size`` times too wide with a plausible first copy.
+        A version floor catches that for one known version; this catches it for
+        every version, including the one after next.
+
+        Once per location per run, not per visit — the answer is a property of
+        the rule, and a generation loop revisits the same location hundreds of
+        times.
+
+        Raises:
+            UnsupportedParallelStyle: if the gather did not widen the value.
+        """
+        gathered = _gather(value, mesh)
+
+        if provider in self._checked:
+            return gathered
+        self._checked.add(provider)
+
+        before, after = _last_dim(value), _last_dim(gathered)
+        if before is None or after is None:
+            return gathered
+
+        expected = before * mesh.size()
+        if after != expected:
+            raise UnsupportedParallelStyle(
+                f"'{provider}' is listed as carrying this rank's shard, but "
+                f"gathering it across {mesh.size()} ranks gave a last dimension "
+                f"of {after} where {expected} was expected (it was {before} "
+                "before). Either this transformers version already makes the "
+                "value whole — in which case gathering it hands out a tensor "
+                f"{mesh.size()} times too wide — or it is split on an axis these "
+                "rules don't describe. Refusing rather than returning it."
+            )
+        return gathered
 
     def _warn_source(self, provider: str) -> None:
         """Warn that a ``.source`` read is this rank's shard, and hand it over.

--- a/src/nnsight/modeling/tp/interleaver.py
+++ b/src/nnsight/modeling/tp/interleaver.py
@@ -108,6 +108,56 @@ UNSUPPORTED: Dict[str, str] = {
     "mla_kv_a_proj": "MLA split kv projection",
 }
 
+# The oldest transformers whose tensor parallelism produces correct activations.
+#
+# 5.14.1 shards a tied LM head's *hook* but not its weight, so on a checkpoint
+# with `tie_word_embeddings=True` the head keeps its full weight while
+# `colwise_gather_output` all-gathers the result anyway: logits come back
+# `tp_size` times too wide, inside transformers, before nnsight sees anything.
+# Nothing downstream looks wrong — the argmax still lands inside the first copy —
+# so it survives every casual check. Measured on Llama-3.2-3B at tp=4: width
+# 513024 against a vocabulary of 128256 on 5.14.1, correct on 5.15.0.
+MINIMUM_TRANSFORMERS = "5.15.0"
+
+
+class UnsupportedTransformersVersion(RuntimeError):
+    """transformers is too old to shard a model correctly."""
+
+
+def _check_transformers_version() -> None:
+    """Refuse to trace a sharded model on a transformers known to mis-shard.
+
+    Called once, the first time a genuinely sharded module is seen, so an
+    unsharded model on an old transformers is unaffected.
+    """
+    global _version_checked
+    if _version_checked:
+        return
+    _version_checked = True
+
+    import transformers
+    from packaging.version import Version
+
+    installed = transformers.__version__
+    # Compared on the release numbers alone, so a `5.15.0.dev0` — which a plain
+    # `>=` sorts *below* 5.15.0, pre-releases coming first — counts as 5.15. A
+    # dev build of the fixed series is the normal way to be running it early;
+    # refusing those would make an editable transformers checkout unusable.
+    if Version(installed).release >= Version(MINIMUM_TRANSFORMERS).release:
+        return
+
+    raise UnsupportedTransformersVersion(
+        f"tensor parallelism needs transformers >= {MINIMUM_TRANSFORMERS}, but "
+        f"{installed} is installed. Older versions do not shard a tied LM head's "
+        "weight while still gathering its output, so a model with "
+        "`tie_word_embeddings=True` returns logits `tp_size` times too wide — "
+        "wrong in a way that still produces a plausible argmax. Upgrade "
+        "transformers, or load this model on one GPU."
+    )
+
+
+_version_checked = False
+
 
 class UnsupportedParallelStyle(Exception):
     """The model shards something interventions can't be shown whole."""
@@ -251,6 +301,11 @@ class TPInterleaver(Interleaver):
             # Stamped but not actually split (a degenerate 1-rank mesh) — nothing
             # to gather, and a collective over a 1-rank group is pure overhead.
             return
+
+        # The first genuinely sharded module: past here the weights are already
+        # split, so this is the last point at which refusing is still cheaper
+        # than returning wrong numbers.
+        _check_transformers_version()
 
         self.enabled = True
         for side in SHARDED_SIDES[style]:

--- a/src/nnsight/modeling/tp/plan.py
+++ b/src/nnsight/modeling/tp/plan.py
@@ -76,3 +76,67 @@ def max_tp_size(config: Any) -> Optional[int]:
     # so the gcd *is* the largest workable degree and its divisors are the rest.
     limit = gcd(*dimensions) if len(dimensions) > 1 else dimensions[0]
     return limit if limit > 1 else None
+
+
+class UnshardableCheckpoint(ValueError):
+    """A tensor-parallel degree was asked for that this checkpoint cannot serve."""
+
+
+def requested_tp_size(distributed_config: Any) -> Optional[int]:
+    """The degree a ``distributed_config`` asks for, or ``None`` if it asks for none.
+
+    Accepts the dataclass or a plain dict, because transformers does.
+    """
+    if distributed_config is None:
+        return None
+
+    if isinstance(distributed_config, dict):
+        size = distributed_config.get("tp_size")
+    else:
+        size = getattr(distributed_config, "tp_size", None)
+
+    return size if isinstance(size, int) and size > 1 else None
+
+
+def check_tp_request(config: Any, tp_size: Optional[int]) -> None:
+    """Raise unless ``tp_size`` is a degree ``config``'s model can really be split into.
+
+    transformers does not check this. Asked to shard a checkpoint with no plan it
+    shards *nothing*: ``verify_tp_plan`` returns early on a ``None`` plan and
+    ``apply_tensor_parallelism`` installs no hooks, so every rank quietly loads a
+    complete copy of the weights. Nothing errors and nothing warns — the model
+    answers correctly off one rank while the other cards hold redundant copies,
+    so the only symptom is *n* times the memory for one model's worth of work.
+
+    That is worth refusing rather than reporting, because there is no reading of
+    "shard this over 4 GPUs" that is served by putting the whole thing on each of
+    them. Raising here also puts the failure before the weights are fetched,
+    where the message can still say what to do about it.
+
+    Raises:
+        UnshardableCheckpoint: if the model cannot be split at all, or not into
+            exactly ``tp_size`` pieces.
+    """
+    if tp_size is None:
+        return
+
+    limit = max_tp_size(config)
+    if limit is None:
+        raise UnshardableCheckpoint(
+            f"this checkpoint cannot be split tensor-parallel, so tp_size={tp_size} "
+            "would load a whole copy of it onto every rank rather than a shard. "
+            "Either it publishes no `base_model_tp_plan`, its plan uses a style "
+            "nnsight cannot gather, or its dimensions divide no degree above 1. "
+            "Load it without `distributed_config` — on one GPU, or spread over "
+            "several with `device_map`."
+        )
+
+    if limit % tp_size:
+        workable = sorted(size for size in range(2, limit + 1) if limit % size == 0)
+        raise UnshardableCheckpoint(
+            f"this checkpoint splits at most {limit} ways and not into {tp_size} "
+            f"pieces: a degree has to divide the dimensions evenly, so the ones "
+            f"that work are {workable}. transformers would shard what it could and "
+            "gather as though every rank held an equal piece, which does not fail "
+            "so much as return the wrong shape."
+        )

--- a/src/nnsight/modeling/tp/plan.py
+++ b/src/nnsight/modeling/tp/plan.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from math import gcd
 from typing import Any, Optional
 
-from .interleaver import SHARDED_SIDES
+from .fragments import SHARDED_SIDES
 
 #: Config fields a tensor-parallel degree has to divide. Attention is split by
 #: head, so both head counts must divide; the MLP is split along its intermediate
@@ -44,13 +44,13 @@ def max_tp_size(config: Any) -> Optional[int]:
     """The largest tensor-parallel degree ``config``'s model supports.
 
     ``None`` when it cannot be split at all: no plan to shard by, or a plan
-    containing a style [`TPInterleaver.instrument`][nnsight.modeling.tp.interleaver.TPInterleaver.instrument]
+    containing a style [`TPFragments.instrument`][nnsight.modeling.tp.fragments.TPFragments.instrument]
     will refuse. Refusing here keeps a model that would fail at load from being
     *placed* as though it could be split.
 
     The two must refuse **the same set**, which is why this asks
-    [`SHARDED_SIDES`][nnsight.modeling.tp.interleaver.SHARDED_SIDES] rather than
-    only [`UNSUPPORTED`][nnsight.modeling.tp.interleaver.UNSUPPORTED]. A style in
+    [`SHARDED_SIDES`][nnsight.modeling.tp.fragments.SHARDED_SIDES] rather than
+    only [`UNSUPPORTED`][nnsight.modeling.tp.fragments.UNSUPPORTED]. A style in
     neither — one transformers added, or one it never registered in
     ``ALL_PARALLEL_STYLES`` — used to pass here and raise there, so a server
     would allocate the cards, load the weights across them, and only then find

--- a/src/nnsight/modeling/tp/plan.py
+++ b/src/nnsight/modeling/tp/plan.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from math import gcd
 from typing import Any, Optional
 
-from .interleaver import UNSUPPORTED
+from .interleaver import SHARDED_SIDES
 
 #: Config fields a tensor-parallel degree has to divide. Attention is split by
 #: head, so both head counts must divide; the MLP is split along its intermediate
@@ -43,17 +43,25 @@ def _text_config(config: Any) -> Any:
 def max_tp_size(config: Any) -> Optional[int]:
     """The largest tensor-parallel degree ``config``'s model supports.
 
-    ``None`` when it cannot be split at all: no plan to shard by, or a plan that
-    shards in a way interventions can't be shown whole (see
-    [`UNSUPPORTED`][nnsight.modeling.tp.interleaver.UNSUPPORTED] — the
-    expert-parallel family, which slices by expert). Refusing here keeps a model
-    that would fail at load from being *placed* as though it could be split.
+    ``None`` when it cannot be split at all: no plan to shard by, or a plan
+    containing a style [`TPInterleaver.instrument`][nnsight.modeling.tp.interleaver.TPInterleaver.instrument]
+    will refuse. Refusing here keeps a model that would fail at load from being
+    *placed* as though it could be split.
+
+    The two must refuse **the same set**, which is why this asks
+    [`SHARDED_SIDES`][nnsight.modeling.tp.interleaver.SHARDED_SIDES] rather than
+    only [`UNSUPPORTED`][nnsight.modeling.tp.interleaver.UNSUPPORTED]. A style in
+    neither — one transformers added, or one it never registered in
+    ``ALL_PARALLEL_STYLES`` — used to pass here and raise there, so a server
+    would allocate the cards, load the weights across them, and only then find
+    out. ``Llama4Config`` does exactly this: its plan is ``colwise_rep``, which
+    is in no list and no registry.
     """
     plan = getattr(config, "base_model_tp_plan", None)
     if not plan:
         return None
 
-    if any(style in UNSUPPORTED for style in plan.values()):
+    if any(style not in SHARDED_SIDES for style in plan.values()):
         return None
 
     dimensions = [

--- a/src/nnsight/modeling/tp/plan.py
+++ b/src/nnsight/modeling/tp/plan.py
@@ -1,0 +1,70 @@
+"""How many ways a checkpoint's weights can be split, read from its config.
+
+Answered before anything is loaded, because a server placing a model has to
+decide how many cards to give it *first*. The whole question is divisibility:
+transformers shards attention by head and the MLP by its intermediate
+dimension, and its all-gather assumes every rank holds an equal piece, so a
+degree that doesn't divide those evenly is not a slower option — it fails.
+
+The answer is a single number, the largest degree that works. Every degree that
+works is a divisor of it, so a caller wanting *n* ranks takes the smallest
+divisor ``>= n``; if there is none the model has to be spread another way.
+"""
+
+from __future__ import annotations
+
+from math import gcd
+from typing import Any, Optional
+
+from .interleaver import UNSUPPORTED
+
+#: Config fields a tensor-parallel degree has to divide. Attention is split by
+#: head, so both head counts must divide; the MLP is split along its intermediate
+#: dimension. A field a config doesn't have is not a constraint — a model with no
+#: separate key/value head count shards its attention by ``num_attention_heads``
+#: alone.
+_DIVIDES: tuple[str, ...] = (
+    "num_attention_heads",
+    "num_key_value_heads",
+    "intermediate_size",
+)
+
+
+def _text_config(config: Any) -> Any:
+    """The config carrying the transformer dimensions.
+
+    A multimodal checkpoint keeps them on a nested ``text_config`` while the
+    outer config holds the composition, so reading the outer one finds nothing
+    to divide and would call every degree workable.
+    """
+    return getattr(config, "text_config", None) or config
+
+
+def max_tp_size(config: Any) -> Optional[int]:
+    """The largest tensor-parallel degree ``config``'s model supports.
+
+    ``None`` when it cannot be split at all: no plan to shard by, or a plan that
+    shards in a way interventions can't be shown whole (see
+    [`UNSUPPORTED`][nnsight.modeling.tp.interleaver.UNSUPPORTED] — the
+    expert-parallel family, which slices by expert). Refusing here keeps a model
+    that would fail at load from being *placed* as though it could be split.
+    """
+    plan = getattr(config, "base_model_tp_plan", None)
+    if not plan:
+        return None
+
+    if any(style in UNSUPPORTED for style in plan.values()):
+        return None
+
+    dimensions = [
+        value
+        for name in _DIVIDES
+        if isinstance(value := getattr(_text_config(config), name, None), int) and value
+    ]
+    if not dimensions:
+        return None
+
+    # Every degree that divides all of them divides their gcd, and vice versa,
+    # so the gcd *is* the largest workable degree and its divisors are the rest.
+    limit = gcd(*dimensions) if len(dimensions) > 1 else dimensions[0]
+    return limit if limit > 1 else None

--- a/src/nnsight/modeling/transformers.py
+++ b/src/nnsight/modeling/transformers.py
@@ -390,6 +390,11 @@ class TransformersModel(HuggingFaceModel):
     def _load(self, repo_id: str, *args: Any, **kwargs: Any) -> torch.nn.Module:
         from transformers import pipeline
 
+        # Before the split, and before the pipeline fetches anything. This path
+        # does not reach the base's `_load`, so the check has to be repeated
+        # here -- the tensor-parallel server loads through *this* class.
+        self._refuse_impossible_tp(repo_id, kwargs)
+
         top_level, model_kwargs = _split_pipeline_kwargs(kwargs)
         # The pipeline loads the model and infers every preprocessor; only
         # forward the ones the user explicitly supplied.

--- a/src/nnsight/modeling/vllm/batching.py
+++ b/src/nnsight/modeling/vllm/batching.py
@@ -12,45 +12,27 @@ rather than assigned once up front. The row math itself is unchanged from
 [`Batcher`][nnsight.intervention.batching.Batcher]: dim 0 is the token axis, so
 narrowing to ``[start, size]`` selects exactly a request's tokens.
 
-Under tensor parallelism a second correction is needed. vLLM splits its linear
-layers across ranks, so the value at a ``ColumnParallelLinear`` or
-``RowParallelLinear`` is one rank's shard of the real tensor. A user asked for the
-layer, not a shard of it, so those values are gathered before a worker sees them
-and re-split before vLLM's own forward carries on.
-
-A ``FusedMoE`` layer needs the same correction for a different reason: an MoE block
-that defers the combine (``reduce_results=False`` — Qwen-MoE, DeepSeek) returns
-per-rank partial sums that the *outer block* all-reduces afterwards, so the value at
-the experts module is a partial too. It is gathered and re-split on the same terms,
-with the group size taken from the expert layout rather than ``tp_size`` alone.
+Gathering a sharded value is *not* here — see
+[`fragments`][nnsight.modeling.vllm.fragments]. It used to be, and the split is
+the point: narrowing happens once per parked worker, while a collective must
+happen once per value however many workers read it.
 """
 
 from __future__ import annotations
 
-from typing import Any, Optional
-
-import torch
+from typing import Optional
 
 from ...intervention.batching import Batcher
-from ...util import apply
 
 
 class VLLMBatcher(Batcher):
-    """A [`Batcher`][nnsight.intervention.batching.Batcher] over vLLM's flat token axis.
-
-    Attributes:
-        module: The parallel linear currently running, or None outside one.
-        type: Whether ``module``'s input or output is being served.
-        parallel: Whether ``module``'s value is really a shard.
-        gathered: The whole tensor, once assembled from every rank's shard, or None.
-    """
+    """A [`Batcher`][nnsight.intervention.batching.Batcher] over vLLM's flat token axis."""
 
     def __init__(self, envoy: Optional[object] = None) -> None:
+        # The envoy is optional here alone: the model runner constructs this
+        # before there is a tree to hand it, and nothing in the row math needs
+        # one — the spans come from the scheduler, not from an invoke.
         super().__init__(envoy)
-        self.module: Any = None
-        self.type: Optional[str] = None
-        self.parallel: bool = False
-        self.gathered: Any = None
 
     @property
     def batching(self) -> bool:
@@ -64,147 +46,3 @@ class VLLMBatcher(Batcher):
         handing it the whole slab is right.
         """
         return True
-
-    def narrow(self, value: Any, group: Any) -> Any:
-        return super().narrow(self._whole(value), group)
-
-    def widen(self, full: Any, group: Any, edited: Any) -> Any:
-        whole = super().widen(self._whole(full), group, edited)
-        # An edit produces a fresh whole; keep it so a later worker in the same
-        # module turn reads the edit, and so release re-shards the edited value
-        # rather than the pre-edit gather.
-        if self.parallel and self.gathered is not None:
-            self.gathered = whole
-        return whole
-
-    def _whole(self, value: Any) -> Any:
-        """The real tensor behind ``value``, assembled from every rank's shard.
-
-        Only the parallel linears shard anything, so everywhere else this is the
-        value itself. The result is kept for the rest of the module's turn: workers
-        read and edit this one tensor in place, and [`release`][nnsight.modeling.vllm.batching.VLLMBatcher.release] reshards it back
-        to the model afterwards. Keeping it also means each rank takes part in the
-        gather collective once per value rather than once per worker — several
-        workers reading the same value would otherwise deadlock the ranks.
-        """
-        if not self.parallel:
-            return value
-        if self.gathered is not None:
-            return self.gathered
-
-        from vllm.model_executor.layers.fused_moe import FusedMoE
-        from vllm.model_executor.layers.linear import (
-            ColumnParallelLinear,
-            RowParallelLinear,
-        )
-        from vllm.distributed.communication_op import (
-            tensor_model_parallel_all_gather,
-            tensor_model_parallel_all_reduce,
-        )
-
-        if isinstance(self.module, ColumnParallelLinear):
-            # Column sharding splits the output features, so the ranks hold
-            # different columns of the same rows.
-            collective = tensor_model_parallel_all_gather
-        elif self.type == "input":
-            # A row-parallel layer takes its input already split by feature.
-            collective = tensor_model_parallel_all_gather
-        elif isinstance(self.module, FusedMoE):
-            # Each rank holds a partial sum of the experts' combined output —
-            # the same collective the outer block runs right afterwards.
-            collective = tensor_model_parallel_all_reduce
-        else:
-            # Row sharding splits the summed terms, so each rank holds a partial
-            # sum and the whole is their total.
-            collective = tensor_model_parallel_all_reduce
-
-        self.gathered = apply(value, collective, torch.Tensor)
-        return self.gathered
-
-    def _shard(self, value: Any) -> Any:
-        """This rank's piece of ``value``, as vLLM's own forward expects it."""
-        from vllm.model_executor.layers.fused_moe import FusedMoE
-        from vllm.model_executor.layers.linear import (
-            ColumnParallelLinear,
-            split_tensor_along_last_dim,
-        )
-
-        module = self.module
-
-        if isinstance(module, FusedMoE):
-            # The block all-reduces this right after the module returns, so hand
-            # back an equal share rather than the whole: dividing by the
-            # collective's group size gives partials the block's own reduce sums
-            # back to the value exactly once instead of double-counting it.
-            # Expert parallelism reassigns the same ranks (the module-internal
-            # tp_size becomes 1 and ep_size becomes the group), so the product is
-            # the group size under both layouts.
-            group_size = module.tp_size * module.ep_size
-            return apply(value, lambda tensor: tensor / group_size, torch.Tensor)
-
-        if isinstance(module, ColumnParallelLinear) or self.type == "input":
-            return apply(
-                value,
-                lambda tensor: split_tensor_along_last_dim(
-                    tensor, num_partitions=module.tp_size
-                )[module.tp_rank].contiguous(),
-                torch.Tensor,
-            )
-        # An all-reduce summed every rank's partial; dividing evenly gives a set of
-        # partials that sums back to it.
-        return apply(value, lambda tensor: tensor / module.tp_size, torch.Tensor)
-
-    def watch(self, module: torch.nn.Module, kind: str) -> None:
-        """Note that ``module``'s ``kind`` is about to be served to workers."""
-        from vllm.model_executor.layers.fused_moe import FusedMoE
-        from vllm.model_executor.layers.linear import (
-            ColumnParallelLinear,
-            RowParallelLinear,
-        )
-
-        self.module = module
-        self.type = kind
-        self.gathered = None
-
-        if isinstance(module, ColumnParallelLinear):
-            # vLLM gathers this itself when asked to, and then it isn't a shard.
-            self.parallel = not module.gather_output if kind == "output" else False
-        elif isinstance(module, RowParallelLinear):
-            if kind == "input":
-                self.parallel = module.input_is_parallel
-            else:
-                self.parallel = not module.reduce_results
-        elif isinstance(module, FusedMoE):
-            # Only the output is ever a shard: the inputs (hidden states, router
-            # logits) are full replicated tensors under both expert layouts.
-            # `reduce_results=True` (Mixtral) reduces inside forward, and a combine
-            # kernel that already reduced across ranks
-            # (must_reduce_shared_expert_outputs) leaves nothing to gather —
-            # neither was ever exposed as a partial.
-            self.parallel = (
-                kind == "output"
-                and not module.reduce_results
-                and module.tp_size * module.ep_size > 1
-                and not module.must_reduce_shared_expert_outputs()
-            )
-        else:
-            self.parallel = False
-
-    def release(self, value: Any) -> Any:
-        """Hand vLLM back what it should carry on with, and stop watching.
-
-        If the value was gathered, the workers read and edited *that* whole tensor,
-        so what vLLM continues from is a fresh shard of it — not the shard it
-        produced, which the workers never saw. An edit rebuilds the whole through
-        `widen`, which writes it back onto ``gathered``, so re-sharding
-        ``gathered`` carries the edit; a read leaves ``gathered`` as the plain
-        assembly. When nothing gathered (the common, unsharded case) the value
-        passes straight through.
-        """
-        if self.parallel and self.gathered is not None:
-            value = self._shard(self.gathered)
-        self.module = None
-        self.type = None
-        self.parallel = False
-        self.gathered = None
-        return value

--- a/src/nnsight/modeling/vllm/fragments.py
+++ b/src/nnsight/modeling/vllm/fragments.py
@@ -1,0 +1,196 @@
+"""Which values a vLLM engine splits across ranks, and how to reassemble them.
+
+vLLM shards its linear layers under tensor parallelism, so the value at a
+``ColumnParallelLinear`` or ``RowParallelLinear`` is one rank's piece of the real
+tensor. A user asked for the layer, not a piece of it, so those are gathered
+before a worker sees them and re-split before vLLM's own forward carries on.
+
+A ``FusedMoE`` layer needs the same correction for a different reason: an MoE
+block that defers the combine (``reduce_results=False`` — Qwen-MoE, DeepSeek)
+returns per-rank partial sums that the *outer block* all-reduces afterwards, so
+the value at the experts module is a partial too. It is gathered and re-split on
+the same terms, with the group size taken from the expert layout rather than
+``tp_size`` alone.
+
+Everything about *when* — once per visit, only when something is waiting, put
+back on the way out — belongs to
+[`Interleaver.handle`][nnsight.intervention.interleaver.Interleaver.handle] and is
+shared with every other distributed runtime; see
+[`nnsight.intervention.fragments`][nnsight.intervention.fragments].
+
+That sharing is what this module is. The same job used to be done by
+[`VLLMBatcher`][nnsight.modeling.vllm.batching.VLLMBatcher] with two extra pairs
+of forward hooks per parallel layer, installed by the model runner either side of
+building the Envoy tree so they bracketed the interleaver's own. It needed them
+because ``Batcher.narrow`` runs once per *parked worker*, so the gather had to be
+memoized and explicitly released — several workers reading one value would
+otherwise have run several collectives and deadlocked the ranks. Sitting on the
+interleaver instead, the bracket is already once-per-visit and none of that is
+needed: no memo, no ``watch``/``release``, no extra hooks.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Tuple
+
+import torch
+
+from ...intervention.fragments import Fragments
+from ...util import apply
+
+
+def _tp_world_size() -> int:
+    """How many ranks this engine's tensor-parallel group spans.
+
+    ``1`` when there is no group yet — a client building a meta tree has vLLM's
+    single-rank gloo group and nothing model-parallel — which is also the answer
+    that means "nothing here is a fragment".
+    """
+    try:
+        from vllm.distributed.parallel_state import get_tp_group
+
+        return get_tp_group().world_size
+    except Exception:
+        return 1
+
+
+class VLLMFragments(Fragments):
+    """Records which of an engine's locations hold one rank's piece.
+
+    Attributes:
+        enabled: Whether this engine is sharded at all. False on one rank, and
+            then this costs one attribute check per handled location.
+        rules: Location -> the module that produced it and which side it is.
+            The module is kept because the collective to run and the arithmetic
+            to undo it both depend on its type and its ``tp_size``/``tp_rank``.
+    """
+
+    def __init__(self) -> None:
+        self.enabled = False
+        self.rules: Dict[str, Tuple[torch.nn.Module, str]] = {}
+
+    def instrument(self, envoy: Any) -> None:
+        """Record whether either side of this envoy's module is a piece.
+
+        Called for every envoy as the tree is built, which is the one moment both
+        the module and its path are in hand. Holding onto the module is safe for
+        the same reason the previous hook-based version was: vLLM builds the tree
+        once, after ``load_model``, and does not swap modules under it — a hook
+        registered on a swapped-out module would have gone just as dead.
+        """
+        world_size = _tp_world_size()
+        if world_size < 2:
+            return
+
+        module = envoy._module
+        for side in ("input", "output"):
+            if _is_piece(module, side):
+                self.rules[f"{envoy.path}.{side}"] = (module, side)
+                self.enabled = True
+
+    def fragmented(self, location: str) -> bool:
+        return location in self.rules
+
+    def whole(self, location: str, value: Any) -> Any:
+        """The real tensor behind ``value``, assembled from every rank's piece."""
+        from vllm.distributed.communication_op import (
+            tensor_model_parallel_all_gather,
+            tensor_model_parallel_all_reduce,
+        )
+        from vllm.model_executor.layers.fused_moe import FusedMoE
+        from vllm.model_executor.layers.linear import ColumnParallelLinear
+
+        module, side = self.rules[location]
+
+        if isinstance(module, ColumnParallelLinear):
+            # Column sharding splits the output features, so the ranks hold
+            # different columns of the same rows.
+            collective = tensor_model_parallel_all_gather
+        elif side == "input":
+            # A row-parallel layer takes its input already split by feature.
+            collective = tensor_model_parallel_all_gather
+        elif isinstance(module, FusedMoE):
+            # Each rank holds a partial sum of the experts' combined output —
+            # the same collective the outer block runs right afterwards.
+            collective = tensor_model_parallel_all_reduce
+        else:
+            # Row sharding splits the summed terms, so each rank holds a partial
+            # sum and the whole is their total.
+            collective = tensor_model_parallel_all_reduce
+
+        return apply(value, collective, torch.Tensor)
+
+    def fragment(self, location: str, whole: Any) -> Any:
+        """This rank's piece of ``whole``, as vLLM's own forward expects it.
+
+        Applied to whatever intervention code left behind, so an edit made to the
+        assembled tensor is carried back into the model rather than dropped.
+        """
+        from vllm.model_executor.layers.fused_moe import FusedMoE
+        from vllm.model_executor.layers.linear import (
+            ColumnParallelLinear,
+            split_tensor_along_last_dim,
+        )
+
+        module, side = self.rules[location]
+
+        if isinstance(module, FusedMoE):
+            # The block all-reduces this right after the module returns, so hand
+            # back an equal share rather than the whole: dividing by the
+            # collective's group size gives partials the block's own reduce sums
+            # back to the value exactly once instead of double-counting it.
+            # Expert parallelism reassigns the same ranks (the module-internal
+            # tp_size becomes 1 and ep_size becomes the group), so the product is
+            # the group size under both layouts.
+            group_size = module.tp_size * module.ep_size
+            return apply(whole, lambda tensor: tensor / group_size, torch.Tensor)
+
+        if isinstance(module, ColumnParallelLinear) or side == "input":
+            return apply(
+                whole,
+                lambda tensor: split_tensor_along_last_dim(
+                    tensor, num_partitions=module.tp_size
+                )[module.tp_rank].contiguous(),
+                torch.Tensor,
+            )
+        # An all-reduce summed every rank's partial; dividing evenly gives a set of
+        # partials that sums back to it.
+        return apply(whole, lambda tensor: tensor / module.tp_size, torch.Tensor)
+
+
+def _is_piece(module: torch.nn.Module, side: str) -> bool:
+    """Whether ``module``'s ``side`` really holds one rank's piece.
+
+    Asked once per module at load rather than on every forward, so it may be as
+    particular as it likes about the cases vLLM already handles itself.
+    """
+    from vllm.model_executor.layers.fused_moe import FusedMoE
+    from vllm.model_executor.layers.linear import (
+        ColumnParallelLinear,
+        RowParallelLinear,
+    )
+
+    if isinstance(module, ColumnParallelLinear):
+        # vLLM gathers this itself when asked to, and then it isn't a piece.
+        return not module.gather_output if side == "output" else False
+
+    if isinstance(module, RowParallelLinear):
+        if side == "input":
+            return module.input_is_parallel
+        return not module.reduce_results
+
+    if isinstance(module, FusedMoE):
+        # Only the output is ever a piece: the inputs (hidden states, router
+        # logits) are full replicated tensors under both expert layouts.
+        # `reduce_results=True` (Mixtral) reduces inside forward, and a combine
+        # kernel that already reduced across ranks
+        # (must_reduce_shared_expert_outputs) leaves nothing to gather — neither
+        # was ever exposed as a partial.
+        return (
+            side == "output"
+            and not module.reduce_results
+            and module.tp_size * module.ep_size > 1
+            and not module.must_reduce_shared_expert_outputs()
+        )
+
+    return False

--- a/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
+++ b/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
@@ -30,71 +30,20 @@ import warnings
 from typing import TYPE_CHECKING, Any, Optional
 
 import torch
-from vllm.distributed.parallel_state import get_pp_group, get_tp_group
+from vllm.distributed.parallel_state import get_pp_group
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
+from ....intervention.interleaver import Interleaver
 from ....intervention.serialization import loads
 from ....tracing.tracer import _local, _saves, inc
 from ..batching import VLLMBatcher
+from ..fragments import VLLMFragments
 
 if TYPE_CHECKING:
     from vllm.sequence import IntermediateTensors
     from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
 
     from ..vllm import VLLM
-
-
-def _parallel_linears(module: torch.nn.Module) -> list[torch.nn.Module]:
-    """Every tensor-parallel linear in ``module``'s tree."""
-    from vllm.model_executor.layers.linear import (
-        ColumnParallelLinear,
-        RowParallelLinear,
-    )
-
-    return [
-        child
-        for child in module.modules()
-        if isinstance(child, (ColumnParallelLinear, RowParallelLinear))
-    ]
-
-
-def _watch_parallel_linears(module: torch.nn.Module, batcher: VLLMBatcher) -> None:
-    """Have the batcher note each parallel linear's value *before* workers see it.
-
-    Registered before the interleaver's hooks, so — pre-forward and forward hooks
-    both firing in registration order — these run first: the value is gathered by
-    the time a worker reads it. There is no ordered-hook machinery to arrange this;
-    it falls out of building the Envoy tree (which registers the interleaver's
-    hooks) after this call and before `_release_parallel_linears`.
-    """
-    for linear in _parallel_linears(module):
-        linear.register_forward_pre_hook(
-            lambda mod, args, kwargs, batcher=batcher: batcher.watch(mod, "input"),
-            with_kwargs=True,
-        )
-        linear.register_forward_hook(
-            lambda mod, args, kwargs, out, batcher=batcher: batcher.watch(mod, "output"),
-            with_kwargs=True,
-        )
-
-
-def _release_parallel_linears(module: torch.nn.Module, batcher: VLLMBatcher) -> None:
-    """Have the batcher re-shard each parallel linear's value *after* workers edit it.
-
-    Registered after the interleaver's hooks so they run last, handing vLLM back a
-    shard of whatever the workers left — the reduced form its own forward expects.
-    """
-    for linear in _parallel_linears(module):
-        # The interleaver serves a module's input as the whole (args, kwargs), so a
-        # pre-hook returning that pair replaces both — hand back the resharded pair.
-        linear.register_forward_pre_hook(
-            lambda mod, args, kwargs, batcher=batcher: batcher.release((args, kwargs)),
-            with_kwargs=True,
-        )
-        linear.register_forward_hook(
-            lambda mod, args, kwargs, out, batcher=batcher: batcher.release(out),
-            with_kwargs=True,
-        )
 
 
 class Requests:
@@ -354,20 +303,17 @@ class NNsightGPUModelRunner(GPUModelRunner):
         super().load_model(*args, **kwargs)
 
         batcher = VLLMBatcher()
-        # With one rank nothing is sharded, so there is nothing to gather.
-        sharded = get_tp_group().world_size > 1
-        if sharded:
-            _watch_parallel_linears(self.model, batcher)
 
         # An Envoy tree over the real module. Passing a loaded module builds it
         # directly, so no weights are read twice and the paths match the ones the
-        # client's meta tree gave the user. Building it here also registers the
-        # interleaver's hooks, which is what brackets the gather (see below).
-        self.nnsight_model: VLLM = VLLM(self.model)
+        # client's meta tree gave the user. Building it here is also what walks
+        # every module past `VLLMFragments.instrument`, so the tree comes back
+        # already knowing which of its values are one rank's piece — on one rank
+        # it finds nothing and stays inert.
+        self.nnsight_model: VLLM = VLLM(
+            self.model, interleaver=Interleaver(fragments=VLLMFragments())
+        )
         self.nnsight_model.tokenizer = cached_tokenizer_from_config(self.model_config)
-
-        if sharded:
-            _release_parallel_linears(self.model, batcher)
 
         interleaver = self.nnsight_model.interleaver
         interleaver.mediators = []

--- a/tests/test_fragments.py
+++ b/tests/test_fragments.py
@@ -1,0 +1,153 @@
+"""The seam a distributed runtime hangs its gather on.
+
+`Fragments` says *what* is a piece of a larger value and how to reassemble it;
+`Interleaver.handle` decides *when*. These pin the second half — the part every
+runtime shares and none of them should have to reimplement — using a recording
+stub rather than a real sharded model, so the ordering and the gating are
+checkable without GPUs.
+
+The real collectives are covered by `tests/tp` (transformers) and `tests/vllm`
+(vLLM), both of which need several GPUs.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from nnsight import NNsight
+from nnsight.intervention.fragments import Fragments
+from nnsight.intervention.interleaver import Interleaver
+
+
+class Recorder(Fragments):
+    """Fragments that record what they were asked, and fake a 2x gather."""
+
+    def __init__(self, locations=(), enabled=True):
+        self.enabled = enabled
+        self.locations = set(locations)
+        self.calls: list[tuple[str, str]] = []
+        self.instrumented: list[str] = []
+        self.runs = 0
+
+    def begin(self):
+        self.runs += 1
+
+    def instrument(self, envoy):
+        self.instrumented.append(envoy.path)
+
+    def fragmented(self, location):
+        return location in self.locations
+
+    def read(self, location):
+        self.calls.append(("read", location))
+
+    def whole(self, location, value):
+        self.calls.append(("whole", location))
+        return torch.cat([value, value], dim=-1)
+
+    def fragment(self, location, whole):
+        self.calls.append(("fragment", location))
+        return whole[..., : whole.shape[-1] // 2]
+
+
+@pytest.fixture
+def model():
+    torch.manual_seed(0)
+    return NNsight(torch.nn.Linear(4, 4))
+
+
+def _traced(model, fragments, read: bool):
+    model.interleaver.fragments = fragments
+    captured = None
+    with model.trace(torch.randn(1, 4)):
+        if read:
+            captured = model.output.save()
+    return captured
+
+
+class TestTheBracket:
+    """A fragment is made whole before workers, and put back after."""
+
+    def test_whole_then_fragment_in_that_order(self, model):
+        fragments = Recorder(locations={"model.output"})
+        _traced(model, fragments, read=True)
+
+        kinds = [kind for kind, _ in fragments.calls if kind in ("whole", "fragment")]
+        assert kinds == ["whole", "fragment"]
+
+    def test_a_worker_sees_the_whole_value(self, model):
+        fragments = Recorder(locations={"model.output"})
+        captured = _traced(model, fragments, read=True)
+
+        # The stub doubles the last dim; a worker reading the location gets that.
+        assert captured.shape[-1] == 8
+
+    def test_the_model_carries_on_with_a_fragment(self, model):
+        fragments = Recorder(locations={"model.output"})
+        _traced(model, fragments, read=True)
+
+        assert ("fragment", "model.output") in fragments.calls
+
+
+class TestGating:
+    """Nothing happens unless something is actually waiting for the value."""
+
+    def test_an_unread_location_is_not_gathered(self, model):
+        fragments = Recorder(locations={"model.output"})
+        _traced(model, fragments, read=False)
+
+        assert not [c for c in fragments.calls if c[0] == "whole"]
+
+    def test_a_disabled_runtime_is_never_asked(self, model):
+        fragments = Recorder(locations={"model.output"}, enabled=False)
+        _traced(model, fragments, read=True)
+
+        assert fragments.calls == []
+
+    def test_a_location_that_is_not_a_fragment_is_left_alone(self, model):
+        fragments = Recorder(locations=set())
+        captured = _traced(model, fragments, read=True)
+
+        assert not [c for c in fragments.calls if c[0] == "whole"]
+        assert captured.shape[-1] == 4
+
+    def test_a_read_is_announced_even_when_it_is_not_a_fragment(self, model):
+        # What lets a runtime say something about a value it *cannot* make whole
+        # -- nnsight's `.source` reads under tensor parallelism, for one.
+        fragments = Recorder(locations=set())
+        _traced(model, fragments, read=True)
+
+        assert ("read", "model.output") in fragments.calls
+
+
+class TestLifecycle:
+    def test_the_tree_is_walked_past_instrument(self, model):
+        fragments = Recorder()
+        interleaver = Interleaver(fragments=fragments)
+        NNsight(torch.nn.Linear(4, 4), interleaver=interleaver)
+
+        assert fragments.instrumented, "no envoy reached the fragments"
+
+    def test_each_run_is_announced(self, model):
+        fragments = Recorder(locations={"model.output"})
+        model.interleaver.fragments = fragments
+
+        for _ in range(3):
+            with model.trace(torch.randn(1, 4)):
+                model.output.save()
+
+        assert fragments.runs == 3
+
+
+class TestTheDefault:
+    """The base is the identity, so an ordinary model pays nothing."""
+
+    def test_nothing_is_a_fragment(self):
+        assert Fragments().fragmented("anything") is False
+
+    def test_it_starts_disabled(self):
+        assert Fragments().enabled is False
+
+    def test_an_ordinary_model_has_none_at_all(self):
+        assert NNsight(torch.nn.Linear(4, 4)).interleaver.fragments is None

--- a/tests/test_tensor_parallel_rules.py
+++ b/tests/test_tensor_parallel_rules.py
@@ -348,3 +348,237 @@ class TestTransformersVersionFloor:
         interleaver._check_transformers_version()
         monkeypatch.setattr(transformers, "__version__", "0.1.0")
         interleaver._check_transformers_version()  # would raise if re-checked
+
+
+class TestTheTwoGatesAgree:
+    """Placement and load must refuse the same set of models.
+
+    `max_tp_size` decides whether a model is *placed* tensor-parallel;
+    `instrument` decides whether it can be *traced* that way. They ran different
+    predicates -- one checked UNSUPPORTED, the other checked SHARDED_SIDES -- so a
+    style in neither list passed placement and raised at load, after a server had
+    already allocated the cards and read the weights onto them.
+    """
+
+    def _config(self, plan):
+        class Config:
+            base_model_tp_plan = plan
+            num_attention_heads = 32
+            num_key_value_heads = 8
+            intermediate_size = 14336
+
+        return Config()
+
+    def test_a_style_in_neither_list_is_refused(self):
+        from nnsight.modeling.tp import SHARDED_SIDES, UNSUPPORTED, max_tp_size
+
+        # Llama-4's actual plan. transformers does not register it in
+        # ALL_PARALLEL_STYLES either, so the drift test below cannot see it.
+        assert "colwise_rep" not in SHARDED_SIDES
+        assert "colwise_rep" not in UNSUPPORTED
+        assert max_tp_size(self._config({"layer.q_proj": "colwise_rep"})) is None
+
+    def test_a_refused_style_is_still_refused(self):
+        from nnsight.modeling.tp import max_tp_size
+
+        assert max_tp_size(self._config({"layer.experts": "grouped_gemm"})) is None
+
+    def test_a_known_style_still_places(self):
+        from nnsight.modeling.tp import max_tp_size
+
+        assert max_tp_size(self._config({"layer.q_proj": "colwise"})) == 8
+
+    def test_every_placeable_plan_is_instrumentable(self):
+        # The property, stated directly: anything max_tp_size accepts, instrument
+        # must not raise on. Both now read SHARDED_SIDES, so this holds by
+        # construction -- it is here to fail if they ever diverge again.
+        from nnsight.modeling.tp import SHARDED_SIDES, max_tp_size
+
+        for style in SHARDED_SIDES:
+            assert max_tp_size(self._config({"layer.x": style})) == 8, style
+
+
+class TestExpertParallelIsNotAutomaticallyRefused:
+    """`moe_tp_experts` needs no gather, and refusing it cost the MoE models.
+
+    It is expert-parallel, which is why it was refused on sight. But its forward
+    all-reduces -- `_prepare_input_fn` applies only `all_reduce_backward`, which
+    is identity going forwards -- so both sides arrive whole, exactly like
+    `all_reduce`. 26 of the configs shipped with transformers 5.15 (Mixtral,
+    DeepSeek-V3, Qwen3-MoE, ...) were refused for this and nothing else.
+    """
+
+    def test_it_is_no_longer_refused(self):
+        from nnsight.modeling.tp import UNSUPPORTED
+
+        assert "moe_tp_experts" not in UNSUPPORTED
+
+    def test_neither_side_is_gathered(self):
+        from nnsight.modeling.tp import SHARDED_SIDES
+
+        assert SHARDED_SIDES["moe_tp_experts"] == ()
+
+    def test_an_moe_plan_can_now_be_placed(self):
+        from nnsight.modeling.tp import max_tp_size
+
+        class Config:
+            base_model_tp_plan = {
+                "layers.*.self_attn.q_proj": "colwise",
+                "layers.*.mlp.experts": "moe_tp_experts",
+            }
+            num_attention_heads = 32
+            num_key_value_heads = 8
+            intermediate_size = 14336
+
+        assert max_tp_size(Config()) == 8
+
+    def test_a_style_that_really_slices_by_expert_is_still_refused(self):
+        from nnsight.modeling.tp import UNSUPPORTED
+
+        assert "grouped_gemm" in UNSUPPORTED
+        assert "mla_kv_a_proj" in UNSUPPORTED
+
+
+class TestEmbeddingColwiseIsWhole:
+    """`embedding_colwise` all-reduces its output despite the name.
+
+    `EmbeddingParallel._prepare_output_fn` ends in an unconditional
+    `all_reduce_forward`; the `embedding_dim_sharding == 0` branch above it guards
+    only the vocab masking. Gathering it again would hand users a tensor tp_size
+    times too wide with a plausible first copy -- the tied-LM-head bug that
+    MINIMUM_TRANSFORMERS exists for, reintroduced by this table.
+    """
+
+    def test_its_output_is_not_gathered(self):
+        from nnsight.modeling.tp import SHARDED_SIDES
+
+        assert SHARDED_SIDES["embedding_colwise"] == ()
+
+
+class FakeMesh:
+    """Just enough device mesh for the pure-tensor helpers."""
+
+    def __init__(self, size: int):
+        self._size = size
+
+    def size(self) -> int:
+        return self._size
+
+
+class TestReshardGuard:
+    """What goes back to the model must be guarded like what came out of it.
+
+    `_reshard`'s output is consumed by the model's own forward, so splitting a
+    value that was never a fragment hands every rank a slice of something whole.
+    Divisibility alone cannot tell the two apart: an integer `position_ids` of
+    width 8 at tp=4 divides perfectly, and the result is wrong answers on every
+    rank identically -- not a hang, and nothing to notice.
+    """
+
+    def _split_calls(self, monkeypatch):
+        import transformers.integrations.tensor_parallel as tp
+
+        seen = []
+
+        def fake_split(tensor, mesh):
+            seen.append(tensor)
+            return tensor
+
+        monkeypatch.setattr(tp, "split", fake_split)
+        return seen
+
+    @pytest.mark.parametrize(
+        "tensor,why",
+        [
+            (torch.arange(8).reshape(1, 8), "integer position_ids"),
+            (torch.zeros(1, 1, 8, 8, dtype=torch.bool), "a boolean mask"),
+            (torch.tensor(1.0), "a 0-dim scalar"),
+        ],
+    )
+    def test_a_value_the_gather_skipped_is_not_split(self, monkeypatch, tensor, why):
+        from nnsight.modeling.tp.interleaver import _gather, _reshard
+
+        gather_seen = self._split_calls(monkeypatch)
+        import transformers.integrations.tensor_parallel as tp
+
+        monkeypatch.setattr(tp, "all_gather", lambda t, m: gather_seen.append(t) or t)
+        mesh = FakeMesh(4)
+
+        _gather(tensor, mesh)
+        assert not gather_seen, f"{why} should not have been gathered"
+
+        split_seen = self._split_calls(monkeypatch)
+        _reshard(tensor, mesh)
+        assert not split_seen, f"{why} was split though it was never gathered"
+
+    def test_a_real_shard_still_round_trips(self, monkeypatch):
+        from nnsight.modeling.tp.interleaver import _reshard
+
+        split_seen = self._split_calls(monkeypatch)
+        _reshard(torch.randn(1, 4, 8), FakeMesh(4))
+        assert len(split_seen) == 1
+
+
+class TestGatherShapeCheck:
+    """A rule that names a whole value is caught the first time it fires.
+
+    The rules are a claim about a transformers version, and most were settled by
+    reading its source. This is what makes a wrong one loud: a side listed as
+    sharded must actually widen by `world_size` when gathered. A value the model
+    already made whole doesn't -- which is exactly the failure MINIMUM_TRANSFORMERS
+    exists for, caught here for every version rather than one known one.
+    """
+
+    def _interleaver(self, monkeypatch, gathered):
+        import transformers.integrations.tensor_parallel as tp
+
+        from nnsight.modeling.tp import TPInterleaver
+
+        monkeypatch.setattr(tp, "all_gather", lambda tensor, mesh: gathered)
+        interleaver = TPInterleaver()
+        interleaver.enabled = True
+        # Stand in for the mediator machinery: the check runs before any of it.
+        monkeypatch.setattr(type(interleaver), "observed", lambda self, p: True)
+        return interleaver
+
+    def test_a_value_that_did_not_widen_is_refused(self, monkeypatch):
+        from nnsight.modeling.tp import UnsupportedParallelStyle
+
+        mesh = FakeMesh(4)
+        # The model's own hook already made it whole; gathering returns the same
+        # width. Left unchecked, the user gets 4x the real tensor.
+        value = torch.randn(1, 4, 2048)
+        interleaver = self._interleaver(monkeypatch, torch.randn(1, 4, 2048))
+
+        with pytest.raises(UnsupportedParallelStyle, match="times too wide|expected"):
+            interleaver._gather_whole("model.layer.output", value, mesh)
+
+    def test_a_real_shard_passes(self, monkeypatch):
+        mesh = FakeMesh(4)
+        value = torch.randn(1, 4, 2048)
+        interleaver = self._interleaver(monkeypatch, torch.randn(1, 4, 8192))
+
+        whole = interleaver._gather_whole("model.layer.output", value, mesh)
+        assert whole.shape[-1] == 8192
+
+    def test_it_checks_once_per_location(self, monkeypatch):
+        # A generation loop revisits a location hundreds of times; the rule is a
+        # property of the model, not of the visit.
+        mesh = FakeMesh(4)
+        interleaver = self._interleaver(monkeypatch, torch.randn(1, 4, 8192))
+        interleaver._gather_whole("model.layer.output", torch.randn(1, 4, 2048), mesh)
+
+        import transformers.integrations.tensor_parallel as tp
+
+        monkeypatch.setattr(tp, "all_gather", lambda t, m: torch.randn(1, 4, 2048))
+        # Would raise if re-checked; the second visit is not checked.
+        interleaver._gather_whole("model.layer.output", torch.randn(1, 4, 2048), mesh)
+
+    def test_an_ambiguous_value_is_not_judged(self, monkeypatch):
+        # Two float tensors of different widths: nothing to compare, so the check
+        # abstains rather than guessing which one the rule meant.
+        mesh = FakeMesh(4)
+        interleaver = self._interleaver(monkeypatch, torch.randn(1, 4, 2048))
+        value = (torch.randn(1, 4, 2048), torch.randn(1, 4, 512))
+
+        interleaver._gather_whole("model.layer.output", value, mesh)

--- a/tests/test_tensor_parallel_rules.py
+++ b/tests/test_tensor_parallel_rules.py
@@ -23,7 +23,7 @@ from nnsight.intervention.interleaver import Interleaver
 from nnsight.modeling.tp import (
     SHARDED_SIDES,
     UNSUPPORTED,
-    TPInterleaver,
+    TPFragments,
     UnsupportedParallelStyle,
 )
 
@@ -92,13 +92,12 @@ class TestInstrument:
     """What the interleaver does as the Envoy tree is built."""
 
     def test_starts_inert(self):
-        interleaver = TPInterleaver()
+        interleaver = TPFragments()
         assert not interleaver.enabled
         assert not interleaver.tp_rules
 
     def test_an_unsharded_module_records_nothing(self, monkeypatch):
-        interleaver = TPInterleaver()
-        monkeypatch.setattr(Interleaver, "instrument", lambda self, envoy: None)
+        interleaver = TPFragments()
 
         interleaver.instrument(_FakeEnvoy(_module(None)))
 
@@ -106,8 +105,7 @@ class TestInstrument:
         assert not interleaver.tp_rules
 
     def test_a_sharded_module_records_its_side_and_enables(self, monkeypatch):
-        interleaver = TPInterleaver()
-        monkeypatch.setattr(Interleaver, "instrument", lambda self, envoy: None)
+        interleaver = TPFragments()
 
         interleaver.instrument(_FakeEnvoy(_module("colwise"), path="model.q_proj"))
 
@@ -115,8 +113,7 @@ class TestInstrument:
         assert "model.q_proj.output" in interleaver.tp_rules
 
     def test_a_row_parallel_module_records_its_input(self, monkeypatch):
-        interleaver = TPInterleaver()
-        monkeypatch.setattr(Interleaver, "instrument", lambda self, envoy: None)
+        interleaver = TPFragments()
 
         interleaver.instrument(_FakeEnvoy(_module("rowwise"), path="model.o_proj"))
 
@@ -125,15 +122,13 @@ class TestInstrument:
 
     @pytest.mark.parametrize("style", sorted(UNSUPPORTED))
     def test_a_refused_style_raises(self, style, monkeypatch):
-        interleaver = TPInterleaver()
-        monkeypatch.setattr(Interleaver, "instrument", lambda self, envoy: None)
+        interleaver = TPFragments()
 
         with pytest.raises(UnsupportedParallelStyle, match=style):
             interleaver.instrument(_FakeEnvoy(_module(style)))
 
     def test_an_unknown_style_raises(self, monkeypatch):
-        interleaver = TPInterleaver()
-        monkeypatch.setattr(Interleaver, "instrument", lambda self, envoy: None)
+        interleaver = TPFragments()
 
         with pytest.raises(UnsupportedParallelStyle, match="not a parallel style"):
             interleaver.instrument(_FakeEnvoy(_module("something_new_upstream")))
@@ -145,72 +140,70 @@ class TestSourceWarns:
     They cannot be gathered — the split axis moves through the forward — but
     plenty of them are whole anyway (anything past the layer that all-reduces),
     so refusing them all would block correct work. See
-    `TPInterleaver._warn_source`.
+    `TPFragments.read`.
     """
 
     def _sharded(self, monkeypatch):
-        interleaver = TPInterleaver()
-        monkeypatch.setattr(Interleaver, "instrument", lambda self, envoy: None)
-        monkeypatch.setattr(Interleaver, "handle", lambda self, provider, value: value)
-        interleaver.instrument(
+        fragments = TPFragments()
+        fragments.instrument(
             _FakeEnvoy(_module("colwise"), path="model.layers.0.mlp.gate_proj")
         )
-        return interleaver
+        return fragments
 
-    def test_a_source_read_warns_and_returns_the_value(self, monkeypatch):
-        interleaver = self._sharded(monkeypatch)
-        monkeypatch.setattr(TPInterleaver, "observed", lambda self, provider: True)
+    def test_a_source_read_warns(self, monkeypatch):
+        fragments = self._sharded(monkeypatch)
 
         with pytest.warns(UserWarning, match="split across ranks"):
-            value = interleaver.handle(
-                "model.layers.0.mlp.source.self_gate_proj_0.output", 7
-            )
-        assert value == 7
+            fragments.read("model.layers.0.mlp.source.self_gate_proj_0.output")
+
+    def test_a_source_location_is_not_treated_as_a_fragment(self, monkeypatch):
+        # The warning exists *because* it cannot be gathered: which axis a
+        # `.source` value is split on changes through the forward.
+        fragments = self._sharded(monkeypatch)
+
+        assert not fragments.fragmented(
+            "model.layers.0.mlp.source.self_gate_proj_0.output"
+        )
 
     def test_it_warns_once_per_location_per_run(self, monkeypatch):
         # A read inside a generation loop fires every token; one caveat is a
         # caveat, hundreds are noise.
-        interleaver = self._sharded(monkeypatch)
-        monkeypatch.setattr(TPInterleaver, "observed", lambda self, provider: True)
+        fragments = self._sharded(monkeypatch)
         location = "model.layers.0.mlp.source.self_gate_proj_0.output"
 
         with pytest.warns(UserWarning):
-            interleaver.handle(location, 7)
+            fragments.read(location)
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            interleaver.handle(location, 7)
+            fragments.read(location)
         assert not caught
 
     def test_a_new_run_warns_again(self, monkeypatch):
         # A long-lived model actor serves request after request; the second
         # user deserves the same caveat as the first.
-        interleaver = self._sharded(monkeypatch)
-        monkeypatch.setattr(TPInterleaver, "observed", lambda self, provider: True)
+        fragments = self._sharded(monkeypatch)
         location = "model.layers.0.mlp.source.self_gate_proj_0.output"
 
         with pytest.warns(UserWarning):
-            interleaver.handle(location, 7)
-        interleaver._warned.clear()  # what __enter__ does at the start of a run
+            fragments.read(location)
+        fragments.begin()  # what Interleaver.__enter__ does at the start of a run
         with pytest.warns(UserWarning):
-            interleaver.handle(location, 7)
+            fragments.read(location)
 
     def test_a_plain_module_read_does_not_warn(self, monkeypatch):
-        interleaver = self._sharded(monkeypatch)
-        monkeypatch.setattr(TPInterleaver, "observed", lambda self, provider: True)
+        fragments = self._sharded(monkeypatch)
 
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            assert interleaver.handle("model.layers.0.mlp.output", 7) == 7
+            fragments.read("model.layers.0.mlp.output")
         assert not caught
 
-    def test_an_unsharded_model_never_warns(self, monkeypatch):
-        interleaver = TPInterleaver()
-        monkeypatch.setattr(Interleaver, "handle", lambda self, provider, value: value)
+    def test_an_unsharded_model_is_never_asked(self, monkeypatch):
+        # The interleaver checks `enabled` before anything else, so an unsharded
+        # model never reaches `read` at all.
+        from nnsight.modeling.tp import TPFragments
 
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            assert interleaver.handle("model.mlp.source.self_gate_proj_0.output", 7) == 7
-        assert not caught
+        assert TPFragments().enabled is False
 
 
 class TestMaxTpSize:
@@ -316,11 +309,11 @@ class TestTransformersVersionFloor:
     def _check(self, monkeypatch, version: str):
         import transformers
 
-        from nnsight.modeling.tp import interleaver
+        from nnsight.modeling.tp import fragments as tp_fragments
 
         monkeypatch.setattr(transformers, "__version__", version)
-        monkeypatch.setattr(interleaver, "_version_checked", False)
-        interleaver._check_transformers_version()
+        monkeypatch.setattr(tp_fragments, "_version_checked", False)
+        tp_fragments._check_transformers_version()
 
     def test_an_older_transformers_is_refused(self, monkeypatch):
         from nnsight.modeling.tp import UnsupportedTransformersVersion
@@ -341,13 +334,13 @@ class TestTransformersVersionFloor:
         # -- so the import and version parse have to happen once, not per call.
         import transformers
 
-        from nnsight.modeling.tp import interleaver
+        from nnsight.modeling.tp import fragments as tp_fragments
 
         monkeypatch.setattr(transformers, "__version__", "5.15.0")
-        monkeypatch.setattr(interleaver, "_version_checked", False)
-        interleaver._check_transformers_version()
+        monkeypatch.setattr(tp_fragments, "_version_checked", False)
+        tp_fragments._check_transformers_version()
         monkeypatch.setattr(transformers, "__version__", "0.1.0")
-        interleaver._check_transformers_version()  # would raise if re-checked
+        tp_fragments._check_transformers_version()  # would raise if re-checked
 
 
 class TestTheTwoGatesAgree:
@@ -496,7 +489,7 @@ class TestReshardGuard:
         ],
     )
     def test_a_value_the_gather_skipped_is_not_split(self, monkeypatch, tensor, why):
-        from nnsight.modeling.tp.interleaver import _gather, _reshard
+        from nnsight.modeling.tp.fragments import _gather, _reshard
 
         gather_seen = self._split_calls(monkeypatch)
         import transformers.integrations.tensor_parallel as tp
@@ -512,7 +505,7 @@ class TestReshardGuard:
         assert not split_seen, f"{why} was split though it was never gathered"
 
     def test_a_real_shard_still_round_trips(self, monkeypatch):
-        from nnsight.modeling.tp.interleaver import _reshard
+        from nnsight.modeling.tp.fragments import _reshard
 
         split_seen = self._split_calls(monkeypatch)
         _reshard(torch.randn(1, 4, 8), FakeMesh(4))
@@ -529,17 +522,15 @@ class TestGatherShapeCheck:
     exists for, caught here for every version rather than one known one.
     """
 
-    def _interleaver(self, monkeypatch, gathered):
+    def _fragments(self, monkeypatch, gathered):
         import transformers.integrations.tensor_parallel as tp
 
-        from nnsight.modeling.tp import TPInterleaver
+        from nnsight.modeling.tp import TPFragments
 
         monkeypatch.setattr(tp, "all_gather", lambda tensor, mesh: gathered)
-        interleaver = TPInterleaver()
-        interleaver.enabled = True
-        # Stand in for the mediator machinery: the check runs before any of it.
-        monkeypatch.setattr(type(interleaver), "observed", lambda self, p: True)
-        return interleaver
+        fragments = TPFragments()
+        fragments.enabled = True
+        return fragments
 
     def test_a_value_that_did_not_widen_is_refused(self, monkeypatch):
         from nnsight.modeling.tp import UnsupportedParallelStyle
@@ -548,37 +539,287 @@ class TestGatherShapeCheck:
         # The model's own hook already made it whole; gathering returns the same
         # width. Left unchecked, the user gets 4x the real tensor.
         value = torch.randn(1, 4, 2048)
-        interleaver = self._interleaver(monkeypatch, torch.randn(1, 4, 2048))
+        fragments = self._fragments(monkeypatch, torch.randn(1, 4, 2048))
 
         with pytest.raises(UnsupportedParallelStyle, match="times too wide|expected"):
-            interleaver._gather_whole("model.layer.output", value, mesh)
+            fragments._gather_whole("model.layer.output", value, mesh)
 
     def test_a_real_shard_passes(self, monkeypatch):
         mesh = FakeMesh(4)
         value = torch.randn(1, 4, 2048)
-        interleaver = self._interleaver(monkeypatch, torch.randn(1, 4, 8192))
+        fragments = self._fragments(monkeypatch, torch.randn(1, 4, 8192))
 
-        whole = interleaver._gather_whole("model.layer.output", value, mesh)
+        whole = fragments._gather_whole("model.layer.output", value, mesh)
         assert whole.shape[-1] == 8192
 
     def test_it_checks_once_per_location(self, monkeypatch):
         # A generation loop revisits a location hundreds of times; the rule is a
         # property of the model, not of the visit.
         mesh = FakeMesh(4)
-        interleaver = self._interleaver(monkeypatch, torch.randn(1, 4, 8192))
-        interleaver._gather_whole("model.layer.output", torch.randn(1, 4, 2048), mesh)
+        fragments = self._fragments(monkeypatch, torch.randn(1, 4, 8192))
+        fragments._gather_whole("model.layer.output", torch.randn(1, 4, 2048), mesh)
 
         import transformers.integrations.tensor_parallel as tp
 
         monkeypatch.setattr(tp, "all_gather", lambda t, m: torch.randn(1, 4, 2048))
         # Would raise if re-checked; the second visit is not checked.
-        interleaver._gather_whole("model.layer.output", torch.randn(1, 4, 2048), mesh)
+        fragments._gather_whole("model.layer.output", torch.randn(1, 4, 2048), mesh)
 
     def test_an_ambiguous_value_is_not_judged(self, monkeypatch):
         # Two float tensors of different widths: nothing to compare, so the check
         # abstains rather than guessing which one the rule meant.
         mesh = FakeMesh(4)
-        interleaver = self._interleaver(monkeypatch, torch.randn(1, 4, 2048))
+        fragments = self._fragments(monkeypatch, torch.randn(1, 4, 2048))
         value = (torch.randn(1, 4, 2048), torch.randn(1, 4, 512))
 
-        interleaver._gather_whole("model.layer.output", value, mesh)
+        fragments._gather_whole("model.layer.output", value, mesh)
+
+
+class TestHubFailuresAreDistinguishable:
+    """"Couldn't read it" must not be reported as "there's nothing to read".
+
+    Every reader on the placement path returns None to mean a real absence -- no
+    published parameter count, no config, no sharding plan. None is also what
+    `max_tp_size` returns to mean "this model cannot be split at all". So a
+    config that failed to download used to become a fact about the architecture,
+    and a perfectly shardable model was placed layer-by-layer with a debug line
+    as the only trace.
+    """
+
+    def _http(self, error_class, status):
+        # These carry the response they were built from; a 4xx is the Hub
+        # answering and a 5xx is the Hub failing, which is the distinction.
+        import requests
+        from huggingface_hub.errors import HfHubHTTPError  # noqa: F401
+
+        response = requests.Response()
+        response.status_code = status
+        return error_class("boom", response=response)
+
+    def test_a_missing_repo_is_an_absence(self):
+        from huggingface_hub.errors import RepositoryNotFoundError
+
+        from nnsight.modeling.huggingface import _unreachable
+
+        assert _unreachable(self._http(RepositoryNotFoundError, 404)) is False
+
+    def test_the_hub_failing_is_a_failure_to_read(self):
+        from huggingface_hub.errors import HfHubHTTPError
+
+        from nnsight.modeling.huggingface import _unreachable
+
+        assert _unreachable(self._http(HfHubHTTPError, 503)) is True
+
+    def test_the_hub_refusing_is_an_answer(self):
+        from huggingface_hub.errors import HfHubHTTPError
+
+        from nnsight.modeling.huggingface import _unreachable
+
+        assert _unreachable(self._http(HfHubHTTPError, 401)) is False
+
+    def test_no_network_and_no_cache_is_a_failure_to_read(self):
+        # Reads backwards, which is the whole reason this function exists: the
+        # Hub raises LocalEntryNotFoundError when it could not reach the network
+        # *and* found nothing cached. It is connectivity, not a missing file.
+        from huggingface_hub.errors import LocalEntryNotFoundError
+
+        from nnsight.modeling.huggingface import _unreachable
+
+        assert _unreachable(LocalEntryNotFoundError("offline")) is True
+
+    def test_offline_mode_is_a_failure_to_read(self):
+        from huggingface_hub.errors import OfflineModeIsEnabled
+
+        from nnsight.modeling.huggingface import _unreachable
+
+        assert _unreachable(OfflineModeIsEnabled("offline")) is True
+
+    def test_a_socket_error_is_a_failure_to_read(self):
+        from nnsight.modeling.huggingface import _unreachable
+
+        assert _unreachable(OSError("connection reset")) is True
+
+    def test_an_unrelated_error_is_not(self):
+        from nnsight.modeling.huggingface import _unreachable
+
+        assert _unreachable(ValueError("bad config")) is False
+
+
+class TestHubCallsAreBounded:
+    """A slow Hub gives up rather than parking whoever asked.
+
+    Mostly not this code's doing, which is worth recording because it looked like
+    a gap: `AutoConfig.from_pretrained` takes no timeout argument, but everything
+    huggingface_hub fetches is bounded by `HF_HUB_ETAG_TIMEOUT` and
+    `HF_HUB_DOWNLOAD_TIMEOUT`, both 10s by default. So the config read is bounded
+    per request whether or not nnsight says so, and the only call that needed a
+    timeout passed explicitly is `model_info`, which accepts one.
+
+    An earlier version of this ran the read on an abandoned daemon thread to
+    bound it. That is worse than the problem: a thread left blocked in an
+    uninterruptible wait stops the *process* exiting -- verified, the interpreter
+    hangs -- which in a model actor means one that will not shut down when told.
+    """
+
+    def test_the_transport_is_bounded_by_default(self):
+        import huggingface_hub.constants as constants
+
+        assert constants.HF_HUB_ETAG_TIMEOUT > 0
+        assert constants.HF_HUB_DOWNLOAD_TIMEOUT > 0
+
+    def test_the_hub_api_call_is_given_a_timeout(self):
+        import inspect
+
+        from nnsight.modeling.huggingface import HUB_TIMEOUT_SECONDS, HuggingFaceModel
+
+        source = inspect.getsource(HuggingFaceModel._hub_parameter_count)
+        assert "timeout=HUB_TIMEOUT_SECONDS" in source
+        assert HUB_TIMEOUT_SECONDS > 0
+
+    def test_nothing_here_abandons_a_thread(self):
+        # The regression guard for the above: no background thread on this path.
+        import inspect
+
+        import nnsight.modeling.huggingface as hf
+
+        source = inspect.getsource(hf)
+        assert "ThreadPoolExecutor" not in source
+        assert "daemon=True" not in source
+
+
+class TestConfigIsReadOnce:
+    """Several questions are answered from one config; it is fetched once.
+
+    Sizing a model, working out how it shards, and reporting it in a status all
+    read the same object, and each used to fetch it again -- two network round
+    trips per cold entry, on the path that was already blocking the event loop.
+    """
+
+    def test_a_second_read_does_not_hit_the_network(self, monkeypatch):
+        import nnsight.modeling.huggingface as hf
+
+        calls = []
+
+        class Config:
+            base_model_tp_plan = {"layers.*.q_proj": "colwise"}
+            num_attention_heads = 32
+            num_key_value_heads = 8
+            intermediate_size = 14336
+
+        def counted(*args, **kwargs):
+            calls.append(1)
+            return Config()
+
+        import transformers
+
+        monkeypatch.setattr(transformers.AutoConfig, "from_pretrained", counted)
+
+        key = '{"repo_id": "x", "revision": null}'
+        hf._CONFIG_CACHE.pop((key, False), None)
+        first = hf.HuggingFaceModel._config(key, False)
+        second = hf.HuggingFaceModel._config(key, False)
+
+        assert first is second
+        assert len(calls) == 1, f"the config was fetched {len(calls)} times"
+
+    def test_the_two_questions_that_need_it_share_one_read(self, monkeypatch):
+        import nnsight.modeling.huggingface as hf
+
+        calls = []
+
+        class Config:
+            base_model_tp_plan = {"layers.*.q_proj": "colwise"}
+            num_attention_heads = 32
+            num_key_value_heads = 8
+            intermediate_size = 14336
+
+        def counted(*args, **kwargs):
+            calls.append(1)
+            return Config()
+
+        key = '{"repo_id": "shared", "revision": null}'
+        hf._CONFIG_CACHE.pop((key, False), None)
+
+        import transformers
+
+        monkeypatch.setattr(transformers.AutoConfig, "from_pretrained", counted)
+        # Not what this is about: stub the Hub record so only the config read is
+        # being counted.
+        monkeypatch.setattr(
+            hf.HuggingFaceModel, "_hub_parameter_count", staticmethod(lambda *a: 1_000)
+        )
+
+        assert hf.HuggingFaceModel._remoteable_max_tp_size(key) == 8
+        described = hf.HuggingFaceModel._remoteable_describe_checkpoint(key, "bfloat16")
+        assert described.config is not None
+        assert len(calls) == 1, f"the config was fetched {len(calls)} times"
+
+
+class TestDescribeCheckpoint:
+    """One call for what a checkpoint is; a separate one for what a runtime can
+    do with it.
+
+    The split is the point. `max_tp_size` is not a property of the files -- the
+    same weights shard eight ways under transformers tensor parallelism and not
+    at all under something else -- so folding it into a description of the
+    checkpoint would make it read as one.
+    """
+
+    def test_it_is_not_a_field_of_the_description(self):
+        from nnsight.modeling.mixins.remotable import CheckpointInfo
+
+        assert not hasattr(CheckpointInfo(), "max_tp_size")
+
+    def test_every_field_defaults_to_not_knowing(self):
+        from nnsight.modeling.mixins.remotable import CheckpointInfo
+
+        info = CheckpointInfo()
+        assert (info.size_bytes, info.n_params, info.config, info.revision) == (
+            None,
+            None,
+            None,
+            None,
+        )
+
+    def test_the_base_wrapper_answers_only_the_size(self, monkeypatch):
+        from nnsight.modeling.mixins.remotable import CheckpointInfo, Remotable
+
+        monkeypatch.setattr(
+            Remotable, "_remoteable_estimate_bytes", classmethod(lambda cls, *a, **k: 42)
+        )
+        info = Remotable._remoteable_describe_checkpoint("k", "bfloat16")
+
+        assert isinstance(info, CheckpointInfo)
+        assert info.size_bytes == 42
+        assert info.config is None and info.revision is None
+
+    def test_a_huggingface_key_reports_its_revision(self, monkeypatch):
+        import nnsight.modeling.huggingface as hf
+
+        key = '{"repo_id": "r", "revision": "abc123"}'
+        hf._CONFIG_CACHE[(key, False)] = None
+        monkeypatch.setattr(
+            hf.HuggingFaceModel, "_hub_parameter_count", staticmethod(lambda *a: 1_000)
+        )
+
+        info = hf.HuggingFaceModel._remoteable_describe_checkpoint(key, "bfloat16")
+
+        assert info.revision == "abc123"
+        assert info.n_params == 1_000
+        assert info.size_bytes == 2_000  # bfloat16
+
+    def test_sizing_and_describing_cannot_disagree(self, monkeypatch):
+        # One of these decides where a model goes. Two implementations of "how
+        # big is it" could drift; there is only one.
+        import nnsight.modeling.huggingface as hf
+
+        key = '{"repo_id": "r2", "revision": null}'
+        hf._CONFIG_CACHE[(key, False)] = None
+        monkeypatch.setattr(
+            hf.HuggingFaceModel, "_hub_parameter_count", staticmethod(lambda *a: 7_777)
+        )
+
+        described = hf.HuggingFaceModel._remoteable_describe_checkpoint(key, "float32")
+        estimated = hf.HuggingFaceModel._remoteable_estimate_bytes(key, "float32")
+
+        assert described.size_bytes == estimated

--- a/tests/test_tensor_parallel_rules.py
+++ b/tests/test_tensor_parallel_rules.py
@@ -931,3 +931,96 @@ class TestRequestedTpSize:
 
         assert requested_tp_size(type("D", (), {"tp_size": 4})()) == 4
         assert requested_tp_size({"tp_size": 4}) == 4
+
+
+class TestEveryLoadPathChecks:
+    """The check has to sit on every `_load`, not only the base's.
+
+    `TransformersModel` builds its model through `transformers.pipeline` and
+    never calls `super()._load`, so a guard written once in `HuggingFaceModel`
+    is dead for the class the tensor-parallel server actually loads through.
+    That is exactly how this was first written, and a forced gpt2 deployment
+    came up "tensor-parallel" across two cards regardless.
+    """
+
+    #: Loads that do not go through transformers, so a transformers tensor-parallel
+    #: degree cannot reach them and cannot silently replicate. `DiffusionModel`
+    #: builds a `diffusers` pipeline, which has no `base_model_tp_plan` and no
+    #: `distributed_config` to honour.
+    NOT_TRANSFORMERS = {"DiffusionModel"}
+
+    def _overrides(self):
+        import inspect
+
+        # Imported explicitly: a subclass only exists once its module is, so a
+        # sweep over `__subclasses__` otherwise passes by finding nothing --
+        # which is the failure mode a coverage test can least afford.
+        import nnsight.modeling.diffusion  # noqa: F401
+        import nnsight.modeling.transformers  # noqa: F401
+        from nnsight.modeling.huggingface import HuggingFaceModel
+
+        subclasses, seen = [HuggingFaceModel], set()
+        while subclasses:
+            cls = subclasses.pop()
+            if cls in seen:
+                continue
+            seen.add(cls)
+            subclasses.extend(cls.__subclasses__())
+        return {
+            cls: inspect.getsource(cls.__dict__["_load"])
+            for cls in seen
+            if "_load" in cls.__dict__ and cls.__name__ not in self.NOT_TRANSFORMERS
+        }
+
+    def test_the_sweep_finds_the_overrides(self):
+        # Guards the guard: if `_overrides` ever returns nothing, the assertion
+        # below passes while checking nothing at all.
+        names = {cls.__name__ for cls in self._overrides()}
+
+        assert {"HuggingFaceModel", "TransformersModel"} <= names, names
+
+    def test_every_load_override_refuses_an_impossible_degree(self):
+        # Either it calls the shared check itself, or it delegates to a `_load`
+        # that does. Anything else fetches the weights unchecked.
+        unguarded = [
+            cls.__name__
+            for cls, source in self._overrides().items()
+            if "_refuse_impossible_tp" not in source and "super()._load" not in source
+        ]
+
+        assert not unguarded, (
+            f"these _load overrides never check the tensor-parallel degree: "
+            f"{unguarded}. transformers will not check it either."
+        )
+
+    def test_the_class_the_server_loads_through_is_covered(self):
+        # Stated separately from the sweep above because it is the specific one
+        # that was missed, and a sweep can be quietly narrowed.
+        import inspect
+
+        from nnsight.modeling.transformers import TransformersModel
+
+        assert "_refuse_impossible_tp" in inspect.getsource(TransformersModel._load)
+
+    def test_a_load_with_no_degree_reads_no_config(self):
+        # The check must cost the ordinary single-GPU path nothing: it runs on
+        # every load, and a config read per load would be a real regression.
+        from nnsight.modeling.huggingface import HuggingFaceModel
+
+        read = []
+
+        class Probe(HuggingFaceModel):
+            def __init__(self):  # bypass Envoy construction; only the check matters
+                self.revision = None
+
+        import transformers
+
+        original = transformers.AutoConfig.from_pretrained
+        transformers.AutoConfig.from_pretrained = lambda *a, **k: read.append(a) or original(*a, **k)
+        try:
+            Probe()._refuse_impossible_tp("openai-community/gpt2", {})
+            Probe()._refuse_impossible_tp("openai-community/gpt2", {"distributed_config": None})
+        finally:
+            transformers.AutoConfig.from_pretrained = original
+
+        assert read == [], "the no-tensor-parallel path read a config it did not need"

--- a/tests/test_tensor_parallel_rules.py
+++ b/tests/test_tensor_parallel_rules.py
@@ -211,3 +211,140 @@ class TestSourceWarns:
             warnings.simplefilter("always")
             assert interleaver.handle("model.mlp.source.self_gate_proj_0.output", 7) == 7
         assert not caught
+
+
+class TestMaxTpSize:
+    """The largest degree a checkpoint's config says it splits into.
+
+    Divisibility is the whole constraint: transformers shards attention by head
+    and the MLP by its intermediate dimension, and its all-gather assumes equal
+    pieces — an uneven degree does not run slower, it does not run.
+    """
+
+    def _config(self, **fields):
+        plan = fields.pop("plan", {"layers.*.self_attn.q_proj": "colwise"})
+        config = type("Config", (), {})()
+        config.base_model_tp_plan = plan
+        for name, value in fields.items():
+            setattr(config, name, value)
+        return config
+
+    def test_the_gcd_of_the_dimensions_it_must_divide(self):
+        from nnsight.modeling.tp import max_tp_size
+
+        # 24 heads, 8 kv heads, 8192 intermediate -> 8.
+        assert max_tp_size(self._config(
+            num_attention_heads=24, num_key_value_heads=8, intermediate_size=8192
+        )) == 8
+
+    def test_a_low_key_value_head_count_caps_it(self):
+        from nnsight.modeling.tp import max_tp_size
+
+        # Qwen2.5-0.5B's shape: plenty of heads, but 2 kv heads stops it at 2.
+        assert max_tp_size(self._config(
+            num_attention_heads=14, num_key_value_heads=2, intermediate_size=4864
+        )) == 2
+
+    def test_no_plan_means_it_cannot_be_split(self):
+        from nnsight.modeling.tp import max_tp_size
+
+        assert max_tp_size(self._config(plan=None, num_attention_heads=12)) is None
+
+    def test_an_unsupported_style_in_the_plan_refuses(self):
+        from nnsight.modeling.tp import max_tp_size
+
+        # An expert-parallel model would fail at load; it must not be *placed*
+        # as though it could be split.
+        assert max_tp_size(self._config(
+            plan={"layers.*.mlp.experts": "grouped_gemm"},
+            num_attention_heads=16, num_key_value_heads=16, intermediate_size=4096,
+        )) is None
+
+    def test_an_odd_dimension_leaves_nothing_to_split(self):
+        from nnsight.modeling.tp import max_tp_size
+
+        assert max_tp_size(self._config(
+            num_attention_heads=3, num_key_value_heads=1, intermediate_size=11
+        )) is None
+
+    def test_dimensions_are_read_from_a_nested_text_config(self):
+        from nnsight.modeling.tp import max_tp_size
+
+        # A multimodal config keeps the transformer dims one level down; reading
+        # the outer one finds nothing to divide and would call every degree fine.
+        outer = self._config()
+        outer.text_config = self._config(
+            num_attention_heads=32, num_key_value_heads=8, intermediate_size=14336
+        )
+        assert max_tp_size(outer) == 8
+
+
+class TestBytesPerElement:
+    """Sizing a checkpoint by the dtype it will be held in."""
+
+    def test_torch_dtypes(self):
+        from nnsight.modeling.mixins.remotable import bytes_per_element
+
+        assert bytes_per_element("bfloat16") == 2
+        assert bytes_per_element("torch.float32") == 4
+        assert bytes_per_element("float64") == 8
+
+    def test_sub_byte_quantizations_beat_torchs_rounding(self):
+        from nnsight.modeling.mixins.remotable import bytes_per_element
+
+        # torch.int4 exists and reports itemsize 1 -- the smallest it can
+        # address -- so trusting it would size 4-bit weights at twice reality.
+        assert bytes_per_element("int4") == 0.5
+        assert bytes_per_element("nf4") == 0.5
+        assert bytes_per_element("int8") == 1
+
+    def test_an_unknown_name_raises_rather_than_guessing(self):
+        from nnsight.modeling.mixins.remotable import bytes_per_element
+
+        with pytest.raises(ValueError, match="Unknown dtype"):
+            bytes_per_element("float3")
+
+
+class TestTransformersVersionFloor:
+    """Sharding is refused on a transformers that shards incorrectly.
+
+    Caught on a live deployment: the container ran 5.14.1 and a tied-embedding
+    model came back with logits four times the vocabulary width, while the argmax
+    — and so every eyeball check — stayed right.
+    """
+
+    def _check(self, monkeypatch, version: str):
+        import transformers
+
+        from nnsight.modeling.tp import interleaver
+
+        monkeypatch.setattr(transformers, "__version__", version)
+        monkeypatch.setattr(interleaver, "_version_checked", False)
+        interleaver._check_transformers_version()
+
+    def test_an_older_transformers_is_refused(self, monkeypatch):
+        from nnsight.modeling.tp import UnsupportedTransformersVersion
+
+        with pytest.raises(UnsupportedTransformersVersion, match="tie_word_embeddings"):
+            self._check(monkeypatch, "5.14.1")
+
+    @pytest.mark.parametrize(
+        "version", ["5.15.0", "5.15.1", "6.0.0", "5.15.0.dev0", "5.16.0rc1"]
+    )
+    def test_the_floor_and_above_are_allowed(self, monkeypatch, version):
+        # Including pre-releases of the fixed series: an editable transformers
+        # checkout reports 5.15.0.dev0, which a plain >= would reject.
+        self._check(monkeypatch, version)
+
+    def test_it_only_runs_once(self, monkeypatch):
+        # instrument() calls this per sharded module -- hundreds on a real model
+        # -- so the import and version parse have to happen once, not per call.
+        import transformers
+
+        from nnsight.modeling.tp import interleaver
+
+        monkeypatch.setattr(transformers, "__version__", "5.15.0")
+        monkeypatch.setattr(interleaver, "_version_checked", False)
+        interleaver._check_transformers_version()
+        monkeypatch.setattr(transformers, "__version__", "0.1.0")
+        interleaver._check_transformers_version()  # would raise if re-checked

--- a/tests/test_tensor_parallel_rules.py
+++ b/tests/test_tensor_parallel_rules.py
@@ -1,0 +1,213 @@
+"""The tensor-parallel rule table, checked without a GPU.
+
+`tests/test_transformers_tensor_parallel.py` proves the gather is *correct*, but
+it needs two GPUs and so does not run everywhere. These tests cover the part that
+goes wrong quietly and can be checked anywhere: whether the table still describes
+the transformers it is running against, and whether the cases it refuses actually
+raise.
+
+The failure they exist for is version drift. transformers owns the list of
+parallel styles; nnsight's table has to keep up with it, and a style that appears
+upstream without a rule here is only discovered when someone deploys a model that
+uses it.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+import torch
+
+from nnsight.intervention.interleaver import Interleaver
+from nnsight.modeling.tp import (
+    SHARDED_SIDES,
+    UNSUPPORTED,
+    TPInterleaver,
+    UnsupportedParallelStyle,
+)
+
+
+def _upstream_styles() -> set:
+    from transformers.integrations.tensor_parallel import ALL_PARALLEL_STYLES
+
+    return set(ALL_PARALLEL_STYLES._global_mapping)
+
+
+class _FakeMesh:
+    def __init__(self, size: int = 2) -> None:
+        self._size = size
+
+    def size(self) -> int:
+        return self._size
+
+
+class _FakeEnvoy:
+    """The two things `instrument` reads off an envoy."""
+
+    def __init__(self, module: torch.nn.Module, path: str = "model.thing") -> None:
+        self._module = module
+        self.path = path
+
+
+def _module(style: str | None, **attrs) -> torch.nn.Module:
+    module = torch.nn.Identity()
+    if style is not None:
+        module._hf_tp_plan = style
+        module._hf_device_mesh = _FakeMesh()
+    for name, value in attrs.items():
+        setattr(module, name, value)
+    return module
+
+
+class TestStyleCoverage:
+    """Every style transformers knows about has a rule here, and vice versa."""
+
+    def test_no_upstream_style_is_unaccounted_for(self):
+        # The one that matters: a new style upstream with no rule here is a model
+        # nnsight will refuse at deploy time. Better to find out at test time.
+        missing = _upstream_styles() - (set(SHARDED_SIDES) | set(UNSUPPORTED))
+        assert not missing, (
+            f"transformers has parallel styles this version has no rule for: "
+            f"{sorted(missing)}. Add each to SHARDED_SIDES (with the sides that "
+            f"carry a shard) or to UNSUPPORTED."
+        )
+
+    def test_no_rule_names_a_style_that_no_longer_exists(self):
+        stale = (set(SHARDED_SIDES) | set(UNSUPPORTED)) - _upstream_styles()
+        assert not stale, (
+            f"rules name parallel styles transformers no longer has: "
+            f"{sorted(stale)} — probably renamed upstream."
+        )
+
+    def test_a_style_is_either_handled_or_refused_never_both(self):
+        assert not (set(SHARDED_SIDES) & set(UNSUPPORTED))
+
+    @pytest.mark.parametrize("sides", SHARDED_SIDES.values())
+    def test_sides_are_input_or_output(self, sides):
+        assert set(sides) <= {"input", "output"}
+
+
+class TestInstrument:
+    """What the interleaver does as the Envoy tree is built."""
+
+    def test_starts_inert(self):
+        interleaver = TPInterleaver()
+        assert not interleaver.enabled
+        assert not interleaver.tp_rules
+
+    def test_an_unsharded_module_records_nothing(self, monkeypatch):
+        interleaver = TPInterleaver()
+        monkeypatch.setattr(Interleaver, "instrument", lambda self, envoy: None)
+
+        interleaver.instrument(_FakeEnvoy(_module(None)))
+
+        assert not interleaver.enabled
+        assert not interleaver.tp_rules
+
+    def test_a_sharded_module_records_its_side_and_enables(self, monkeypatch):
+        interleaver = TPInterleaver()
+        monkeypatch.setattr(Interleaver, "instrument", lambda self, envoy: None)
+
+        interleaver.instrument(_FakeEnvoy(_module("colwise"), path="model.q_proj"))
+
+        assert interleaver.enabled
+        assert "model.q_proj.output" in interleaver.tp_rules
+
+    def test_a_row_parallel_module_records_its_input(self, monkeypatch):
+        interleaver = TPInterleaver()
+        monkeypatch.setattr(Interleaver, "instrument", lambda self, envoy: None)
+
+        interleaver.instrument(_FakeEnvoy(_module("rowwise"), path="model.o_proj"))
+
+        assert "model.o_proj.input" in interleaver.tp_rules
+        assert "model.o_proj.output" not in interleaver.tp_rules
+
+    @pytest.mark.parametrize("style", sorted(UNSUPPORTED))
+    def test_a_refused_style_raises(self, style, monkeypatch):
+        interleaver = TPInterleaver()
+        monkeypatch.setattr(Interleaver, "instrument", lambda self, envoy: None)
+
+        with pytest.raises(UnsupportedParallelStyle, match=style):
+            interleaver.instrument(_FakeEnvoy(_module(style)))
+
+    def test_an_unknown_style_raises(self, monkeypatch):
+        interleaver = TPInterleaver()
+        monkeypatch.setattr(Interleaver, "instrument", lambda self, envoy: None)
+
+        with pytest.raises(UnsupportedParallelStyle, match="not a parallel style"):
+            interleaver.instrument(_FakeEnvoy(_module("something_new_upstream")))
+
+
+class TestSourceWarns:
+    """`.source` reads under a sharded model warn and hand the value over.
+
+    They cannot be gathered — the split axis moves through the forward — but
+    plenty of them are whole anyway (anything past the layer that all-reduces),
+    so refusing them all would block correct work. See
+    `TPInterleaver._warn_source`.
+    """
+
+    def _sharded(self, monkeypatch):
+        interleaver = TPInterleaver()
+        monkeypatch.setattr(Interleaver, "instrument", lambda self, envoy: None)
+        monkeypatch.setattr(Interleaver, "handle", lambda self, provider, value: value)
+        interleaver.instrument(
+            _FakeEnvoy(_module("colwise"), path="model.layers.0.mlp.gate_proj")
+        )
+        return interleaver
+
+    def test_a_source_read_warns_and_returns_the_value(self, monkeypatch):
+        interleaver = self._sharded(monkeypatch)
+        monkeypatch.setattr(TPInterleaver, "observed", lambda self, provider: True)
+
+        with pytest.warns(UserWarning, match="split across ranks"):
+            value = interleaver.handle(
+                "model.layers.0.mlp.source.self_gate_proj_0.output", 7
+            )
+        assert value == 7
+
+    def test_it_warns_once_per_location_per_run(self, monkeypatch):
+        # A read inside a generation loop fires every token; one caveat is a
+        # caveat, hundreds are noise.
+        interleaver = self._sharded(monkeypatch)
+        monkeypatch.setattr(TPInterleaver, "observed", lambda self, provider: True)
+        location = "model.layers.0.mlp.source.self_gate_proj_0.output"
+
+        with pytest.warns(UserWarning):
+            interleaver.handle(location, 7)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            interleaver.handle(location, 7)
+        assert not caught
+
+    def test_a_new_run_warns_again(self, monkeypatch):
+        # A long-lived model actor serves request after request; the second
+        # user deserves the same caveat as the first.
+        interleaver = self._sharded(monkeypatch)
+        monkeypatch.setattr(TPInterleaver, "observed", lambda self, provider: True)
+        location = "model.layers.0.mlp.source.self_gate_proj_0.output"
+
+        with pytest.warns(UserWarning):
+            interleaver.handle(location, 7)
+        interleaver._warned.clear()  # what __enter__ does at the start of a run
+        with pytest.warns(UserWarning):
+            interleaver.handle(location, 7)
+
+    def test_a_plain_module_read_does_not_warn(self, monkeypatch):
+        interleaver = self._sharded(monkeypatch)
+        monkeypatch.setattr(TPInterleaver, "observed", lambda self, provider: True)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            assert interleaver.handle("model.layers.0.mlp.output", 7) == 7
+        assert not caught
+
+    def test_an_unsharded_model_never_warns(self, monkeypatch):
+        interleaver = TPInterleaver()
+        monkeypatch.setattr(Interleaver, "handle", lambda self, provider, value: value)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            assert interleaver.handle("model.mlp.source.self_gate_proj_0.output", 7) == 7
+        assert not caught

--- a/tests/test_tensor_parallel_rules.py
+++ b/tests/test_tensor_parallel_rules.py
@@ -823,3 +823,111 @@ class TestDescribeCheckpoint:
         estimated = hf.HuggingFaceModel._remoteable_estimate_bytes(key, "float32")
 
         assert described.size_bytes == estimated
+
+
+class TestCheckTpRequest:
+    """Refusing a degree the checkpoint cannot actually be split into.
+
+    transformers does not check this and does not fail. Asked to shard a model
+    with no plan it shards *nothing*: `verify_tp_plan` returns early on a `None`
+    plan and `apply_tensor_parallelism` installs no hooks, so every rank loads a
+    complete copy of the weights, nothing warns, and the model answers correctly
+    off one rank while the other cards hold redundant copies. The only symptom is
+    n times the memory for one model's worth of work, which is why this refuses
+    rather than reports.
+    """
+
+    def _config(self, **fields):
+        plan = fields.pop("plan", {"layers.*.self_attn.q_proj": "colwise"})
+        config = type("Config", (), {})()
+        config.base_model_tp_plan = plan
+        for name, value in fields.items():
+            setattr(config, name, value)
+        return config
+
+    def _shardable(self):
+        # 24 heads, 8 kv heads, 8192 intermediate -> splits 8 ways.
+        return self._config(
+            num_attention_heads=24, num_key_value_heads=8, intermediate_size=8192
+        )
+
+    def test_asking_for_no_degree_checks_nothing(self):
+        # The ordinary single-GPU path reaches this on every load; it must not
+        # even look at the config.
+        from nnsight.modeling.tp import check_tp_request
+
+        check_tp_request(None, None)
+
+    def test_a_checkpoint_with_no_plan_is_refused(self):
+        # gpt2's shape, and the case this exists for.
+        from nnsight.modeling.tp import UnshardableCheckpoint, check_tp_request
+
+        with pytest.raises(UnshardableCheckpoint, match="cannot be split"):
+            check_tp_request(self._config(plan=None, num_attention_heads=12), 2)
+
+    def test_the_refusal_says_what_would_have_happened(self):
+        # A message that only says "unsupported" leaves the operator to discover
+        # that it *would* have loaded, wrongly. This is the part worth keeping.
+        from nnsight.modeling.tp import UnshardableCheckpoint, check_tp_request
+
+        with pytest.raises(UnshardableCheckpoint, match="whole copy of it onto every rank"):
+            check_tp_request(self._config(plan=None, num_attention_heads=12), 4)
+
+    def test_a_workable_degree_is_allowed(self):
+        from nnsight.modeling.tp import check_tp_request
+
+        for degree in (2, 4, 8):
+            check_tp_request(self._shardable(), degree)
+
+    def test_a_degree_that_does_not_divide_is_refused(self):
+        # Not a slower option: the all-gather assumes equal pieces, so an uneven
+        # degree returns the wrong shape rather than failing outright.
+        from nnsight.modeling.tp import UnshardableCheckpoint, check_tp_request
+
+        with pytest.raises(UnshardableCheckpoint, match="splits at most 8 ways"):
+            check_tp_request(self._shardable(), 3)
+
+    def test_it_lists_the_degrees_that_would_work(self):
+        from nnsight.modeling.tp import UnshardableCheckpoint, check_tp_request
+
+        with pytest.raises(UnshardableCheckpoint, match=r"\[2, 4, 8\]"):
+            check_tp_request(self._shardable(), 6)
+
+    def test_it_agrees_with_max_tp_size(self):
+        # The two must refuse the same set. `max_tp_size` is what a server places
+        # from; this is what a load refuses on. A model placed on cards it then
+        # refuses to load onto is the failure this pairing prevents.
+        from nnsight.modeling.tp import UnshardableCheckpoint, check_tp_request, max_tp_size
+
+        for config in (self._shardable(), self._config(plan=None, num_attention_heads=12)):
+            limit = max_tp_size(config)
+            for degree in range(2, 10):
+                allowed = limit is not None and limit % degree == 0
+                try:
+                    check_tp_request(config, degree)
+                except UnshardableCheckpoint:
+                    assert not allowed, f"refused tp_size={degree} though the limit is {limit}"
+                else:
+                    assert allowed, f"allowed tp_size={degree} though the limit is {limit}"
+
+
+class TestRequestedTpSize:
+    """Reading the degree off whatever transformers would accept."""
+
+    def test_no_config_asks_for_nothing(self):
+        from nnsight.modeling.tp import requested_tp_size
+
+        assert requested_tp_size(None) is None
+
+    def test_a_degree_of_one_is_not_a_request(self):
+        # tp_size=1 is the ordinary single-process case, not a split.
+        from nnsight.modeling.tp import requested_tp_size
+
+        assert requested_tp_size(type("D", (), {"tp_size": 1})()) is None
+
+    def test_a_dataclass_and_a_dict_read_the_same(self):
+        # transformers takes either, so the check has to see either.
+        from nnsight.modeling.tp import requested_tp_size
+
+        assert requested_tp_size(type("D", (), {"tp_size": 4})()) == 4
+        assert requested_tp_size({"tp_size": 4}) == 4

--- a/tests/tp/test_real_model.py
+++ b/tests/tp/test_real_model.py
@@ -57,6 +57,14 @@ INTERMEDIATE = 8192
 DRIFT = 5e-2
 
 
+def _visible_devices(tp: int) -> str:
+    """Which cards the ranks use: whatever was set, else the first ``tp``."""
+    inherited = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if inherited:
+        return ",".join(inherited.split(",")[:tp])
+    return ",".join(str(index) for index in range(tp))
+
+
 def _free_port() -> int:
     with socket.socket() as sock:
         sock.bind(("", 0))
@@ -67,7 +75,7 @@ def _run(tp: int, out: str) -> None:
     env = {
         **os.environ,
         "PYTHONPATH": os.pathsep.join(filter(None, [SRC, os.environ.get("PYTHONPATH")])),
-        "CUDA_VISIBLE_DEVICES": ",".join(str(i) for i in range(tp)),
+        "CUDA_VISIBLE_DEVICES": _visible_devices(tp),
     }
     command = [sys.executable]
     if tp > 1:

--- a/tests/tp/test_real_model.py
+++ b/tests/tp/test_real_model.py
@@ -1,0 +1,173 @@
+"""Tensor parallelism against a real checkpoint, not a random tiny one.
+
+`test_sharded_tracing.py` proves the mechanics on
+``tiny-random-LlamaForCausalLM`` — 16 hidden units, untied embeddings, float32.
+That is enough for the row math and fast enough to run often, and it is *not*
+enough to trust a deployment, because the things production models do differently
+are exactly the things that have broken:
+
+* **Tied embeddings.** A checkpoint with ``tie_word_embeddings=True`` shares the
+  LM head's weight with the embedding. On a transformers whose plan shards the
+  head but not the embedding it is tied to, the head keeps its full weight while
+  its ``colwise_gather_output`` hook still fires, and logits come back
+  ``tp_size`` times too wide — inside transformers, before nnsight sees anything.
+  The tiny model has this flag off, so only a real one catches it. Asserting the
+  logits width here is the regression test for that.
+* **Real head counts.** ``num_key_value_heads`` is what actually limits the
+  degree a model shards into (Llama-3.2-3B has 8, so it divides by 4; a model
+  with 2 would not). The tiny model's heads all equal each other.
+* **bfloat16.** What deployments serve, and where the drift between a one-rank
+  and an N-rank run shows up.
+
+Gated on 4 GPUs and skipped by CI along with the rest of this directory. Reaching
+for a ~6.4GB checkpoint means this is a deliberate, occasional run:
+
+    python -m pytest tests/tp/test_real_model.py
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.skipif(
+    torch.cuda.device_count() < 4,
+    reason="a real tensor-parallel model needs >=4 GPUs",
+)
+
+WORKER = os.path.join(os.path.dirname(os.path.abspath(__file__)), "worker.py")
+SRC = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "src")
+
+# Divides cleanly by 4 on every axis that matters: 24 attention heads, 8
+# key/value heads, 8192 intermediate. And it ties its embeddings.
+REPO = "meta-llama/Llama-3.2-3B"
+TP_SIZE = 4
+VOCAB = 128256
+HIDDEN = 3072
+INTERMEDIATE = 8192
+
+# bfloat16 across a 28-layer model drifts further than the tiny float32 one, and
+# an all-reduce sums in a different order than a single matmul. Order 1 would
+# mean a layout error; this is arithmetic.
+DRIFT = 5e-2
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("", 0))
+        return sock.getsockname()[1]
+
+
+def _run(tp: int, out: str) -> None:
+    env = {
+        **os.environ,
+        "PYTHONPATH": os.pathsep.join(filter(None, [SRC, os.environ.get("PYTHONPATH")])),
+        "CUDA_VISIBLE_DEVICES": ",".join(str(i) for i in range(tp)),
+    }
+    command = [sys.executable]
+    if tp > 1:
+        command += [
+            "-m", "torch.distributed.run",
+            f"--nproc_per_node={tp}",
+            f"--master_port={_free_port()}",
+        ]
+    command += [
+        WORKER, "--tp", str(tp), "--repo", REPO, "--out", out, "--dtype", "bfloat16",
+    ]
+
+    completed = subprocess.run(command, env=env, capture_output=True, text=True)
+    if completed.returncode != 0:
+        pytest.fail(
+            f"tp={tp} worker failed ({completed.returncode})\n"
+            f"--- stdout ---\n{completed.stdout[-4000:]}\n"
+            f"--- stderr ---\n{completed.stderr[-4000:]}"
+        )
+
+
+def _rel(actual: torch.Tensor, expected: torch.Tensor) -> float:
+    if actual.shape != expected.shape:
+        return float("inf")
+    scale = expected.abs().max().item()
+    return (actual - expected).abs().max().item() / (scale if scale else 1.0)
+
+
+@pytest.fixture(scope="module")
+def runs(tmp_path_factory) -> tuple[dict, list[dict]]:
+    reference_dir = tmp_path_factory.mktemp("real_tp1")
+    sharded_dir = tmp_path_factory.mktemp(f"real_tp{TP_SIZE}")
+
+    _run(1, str(reference_dir))
+    _run(TP_SIZE, str(sharded_dir))
+
+    reference = torch.load(reference_dir / "rank0.pt", weights_only=False)
+    sharded = [
+        torch.load(sharded_dir / f"rank{rank}.pt", weights_only=False)
+        for rank in range(TP_SIZE)
+    ]
+    return reference, sharded
+
+
+class TestWidths:
+    """Every value arrives at the width the architecture says, not a fraction of
+    it — and not a multiple, which is the tied-embedding failure."""
+
+    def test_logits_are_not_a_multiple_of_the_vocabulary(self, runs):
+        # The regression test for the tied-embedding gather. A head whose weight
+        # was never sharded yields tp_size * VOCAB, and nothing downstream looks
+        # wrong: the argmax still lands inside the first copy.
+        _, sharded = runs
+        assert sharded[0]["baseline_logits"].shape[-1] == VOCAB
+
+    def test_a_column_parallel_output_is_whole(self, runs):
+        _, sharded = runs
+        assert sharded[0]["gate_proj_out"].shape[-1] == INTERMEDIATE
+
+    def test_a_row_parallel_input_is_whole(self, runs):
+        _, sharded = runs
+        assert sharded[0]["down_proj_in"].shape[-1] == INTERMEDIATE
+
+    def test_a_layer_output_is_whole(self, runs):
+        _, sharded = runs
+        assert sharded[0]["layer_out"].shape[-1] == HIDDEN
+
+
+VALUES = [
+    "gate_proj_out",
+    "down_proj_in",
+    "layer_out",
+    "baseline_logits",
+    "partial_edit_logits",
+    "cached_gate_out",
+    "generated",
+    "batched_first",
+    "batched_edited_logits",
+    "generated_steps",
+]
+
+
+@pytest.mark.parametrize("name", VALUES)
+def test_ranks_agree(runs, name):
+    _, sharded = runs
+    first = sharded[0][name]
+    for rank, results in enumerate(sharded[1:], start=1):
+        assert results[name].shape == first.shape, f"rank {rank} shape differs"
+        assert torch.equal(results[name], first), f"rank {rank} diverged on {name}"
+
+
+@pytest.mark.parametrize("name", VALUES)
+def test_matches_single_gpu(runs, name):
+    reference, sharded = runs
+    expected, actual = reference[name], sharded[0][name]
+    assert actual.shape == expected.shape
+    assert _rel(actual, expected) < DRIFT
+
+
+def test_generation_is_identical(runs):
+    """Exact token ids: bf16 drift never changed a choice."""
+    reference, sharded = runs
+    assert torch.equal(sharded[0]["generated"], reference["generated"])

--- a/tests/tp/test_sharded_tracing.py
+++ b/tests/tp/test_sharded_tracing.py
@@ -57,6 +57,14 @@ TP_SIZE = 2
 DRIFT = 1e-3
 
 
+def _visible_devices(tp: int) -> str:
+    """Which cards the ranks use: whatever was set, else the first ``tp``."""
+    inherited = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if inherited:
+        return ",".join(inherited.split(",")[:tp])
+    return ",".join(str(index) for index in range(tp))
+
+
 def _free_port() -> int:
     with socket.socket() as sock:
         sock.bind(("", 0))
@@ -70,8 +78,9 @@ def _run(tp: int, out: str) -> None:
         "PYTHONPATH": os.pathsep.join(filter(None, [SRC, os.environ.get("PYTHONPATH")])),
         # Rank i must land on the i-th visible device; see
         # transformers.integrations.tensor_parallel.initialize_tensor_parallelism,
-        # which uses LOCAL_RANK directly as a CUDA index.
-        "CUDA_VISIBLE_DEVICES": ",".join(str(i) for i in range(tp)),
+        # which uses LOCAL_RANK directly as a CUDA index. An inherited setting
+        # wins, so a shared machine can be pointed at the cards that are free.
+        "CUDA_VISIBLE_DEVICES": _visible_devices(tp),
     }
     command = [sys.executable]
     if tp > 1:

--- a/tests/tp/test_sharded_tracing.py
+++ b/tests/tp/test_sharded_tracing.py
@@ -1,0 +1,171 @@
+"""Tensor parallelism: sharded activations read and edit as whole tensors.
+
+A model loaded with ``distributed_config=DistributedConfig(tp_size=N)`` has its
+linears split across ranks, so the value at a column-parallel *output* or a
+row-parallel *input* is only that rank's slice.
+[`TPInterleaver`][nnsight.modeling.tp.interleaver.TPInterleaver] gathers those
+before a worker sees them and re-splits whatever the worker leaves, so a trace is
+written exactly as it would be against one GPU.
+
+These tests pin that down by running the identical block twice — once on a single
+GPU for the reference, once across N ranks — and comparing. Each run is a
+subprocess, because transformers tensor parallelism requires the *calling* process
+to be a rank; the sibling `tests/vllm/test_tensor_parallel.py` can stay in-process
+only because vLLM spawns its own workers.
+
+This whole directory needs hardware, so CI ignores it (`--ignore=tests/tp`,
+alongside `tests/vllm`). Run it by hand on a multi-GPU box:
+
+    python -m pytest tests/tp
+
+Two independent things are checked, because they fail differently:
+
+* **the ranks agree** — bit-for-bit. A failure here means the ranks diverged,
+  which is the deadlock/corruption class of bug.
+* **rank 0 matches the single-GPU run** — within a relative tolerance, since an
+  all-reduce sums in a different order than one big matmul and float arithmetic
+  does not associate. A mismatch of order 1 means the gather or the re-split is
+  wrong; 1e-3 is drift.
+
+Skipped unless the machine has >=2 GPUs.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.skipif(
+    torch.cuda.device_count() < 2,
+    reason="transformers tensor parallelism needs >=2 GPUs",
+)
+
+WORKER = os.path.join(os.path.dirname(os.path.abspath(__file__)), "worker.py")
+SRC = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "src")
+
+# Tiny, and shards cleanly: its head counts and intermediate size all divide by 2.
+REPO = "hf-internal-testing/tiny-random-LlamaForCausalLM"
+TP_SIZE = 2
+
+# Relative error below this is float non-associativity between a 1-rank and an
+# N-rank run, not a layout error (which shows up at order 1).
+DRIFT = 1e-3
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("", 0))
+        return sock.getsockname()[1]
+
+
+def _run(tp: int, out: str) -> None:
+    """Run the worker at ``tp`` ranks, writing one file per rank into ``out``."""
+    env = {
+        **os.environ,
+        "PYTHONPATH": os.pathsep.join(filter(None, [SRC, os.environ.get("PYTHONPATH")])),
+        # Rank i must land on the i-th visible device; see
+        # transformers.integrations.tensor_parallel.initialize_tensor_parallelism,
+        # which uses LOCAL_RANK directly as a CUDA index.
+        "CUDA_VISIBLE_DEVICES": ",".join(str(i) for i in range(tp)),
+    }
+    command = [sys.executable]
+    if tp > 1:
+        command += [
+            "-m", "torch.distributed.run",
+            f"--nproc_per_node={tp}",
+            f"--master_port={_free_port()}",
+        ]
+    command += [WORKER, "--tp", str(tp), "--repo", REPO, "--out", out]
+
+    completed = subprocess.run(command, env=env, capture_output=True, text=True)
+    if completed.returncode != 0:
+        pytest.fail(
+            f"tp={tp} worker failed ({completed.returncode})\n"
+            f"--- stdout ---\n{completed.stdout[-4000:]}\n"
+            f"--- stderr ---\n{completed.stderr[-4000:]}"
+        )
+
+
+def _rel(actual: torch.Tensor, expected: torch.Tensor) -> float:
+    """max|a-b| / max|b| — scale-free, so it reads the same at any layer."""
+    if actual.shape != expected.shape:
+        return float("inf")
+    scale = expected.abs().max().item()
+    return (actual - expected).abs().max().item() / (scale if scale else 1.0)
+
+
+@pytest.fixture(scope="module")
+def runs(tmp_path_factory) -> tuple[dict, list[dict]]:
+    """``(reference, [per-rank sharded results])`` from two subprocess runs."""
+    reference_dir = tmp_path_factory.mktemp("tp1")
+    sharded_dir = tmp_path_factory.mktemp(f"tp{TP_SIZE}")
+
+    _run(1, str(reference_dir))
+    _run(TP_SIZE, str(sharded_dir))
+
+    reference = torch.load(reference_dir / "rank0.pt", weights_only=False)
+    sharded = [
+        torch.load(sharded_dir / f"rank{rank}.pt", weights_only=False)
+        for rank in range(TP_SIZE)
+    ]
+    return reference, sharded
+
+
+# Every value the worker records: a sharded read, a boundary-straddling edit, a
+# cached read, and a generation.
+VALUES = [
+    "gate_proj_out",
+    "down_proj_in",
+    "layer_out",
+    "baseline_logits",
+    "partial_edit_logits",
+    "cached_gate_out",
+    "generated",
+    "batched_first",
+    "batched_edited_logits",
+    "generated_steps",
+]
+
+
+@pytest.mark.parametrize("name", VALUES)
+def test_ranks_agree(runs, name):
+    """Every rank produced the same value, bit for bit."""
+    _, sharded = runs
+    first = sharded[0][name]
+    for rank, results in enumerate(sharded[1:], start=1):
+        assert results[name].shape == first.shape, f"rank {rank} shape differs"
+        assert torch.equal(results[name], first), f"rank {rank} diverged on {name}"
+
+
+@pytest.mark.parametrize("name", VALUES)
+def test_matches_single_gpu(runs, name):
+    """The sharded run reproduces the single-GPU run."""
+    reference, sharded = runs
+    expected, actual = reference[name], sharded[0][name]
+
+    # Full width, not this rank's slice — the gather's whole point.
+    assert actual.shape == expected.shape
+    assert _rel(actual, expected) < DRIFT
+
+
+def test_generation_is_identical(runs):
+    """Token ids are exact, so any drift in the logits never changed a choice."""
+    reference, sharded = runs
+    assert torch.equal(sharded[0]["generated"], reference["generated"])
+
+
+def test_edit_actually_changed_the_output(runs):
+    """The edit case isn't passing vacuously by leaving the model untouched.
+
+    Without this, an intervention that silently did nothing would still agree
+    across ranks and still match the reference — every other test would pass.
+    """
+    reference, sharded = runs
+    for results, label in ((reference, "tp=1"), (sharded[0], "sharded")):
+        moved = _rel(results["partial_edit_logits"], results["baseline_logits"])
+        assert moved > DRIFT, f"{label}: zeroing half of gate_proj changed nothing"

--- a/tests/tp/test_sharded_tracing.py
+++ b/tests/tp/test_sharded_tracing.py
@@ -3,7 +3,7 @@
 A model loaded with ``distributed_config=DistributedConfig(tp_size=N)`` has its
 linears split across ranks, so the value at a column-parallel *output* or a
 row-parallel *input* is only that rank's slice.
-[`TPInterleaver`][nnsight.modeling.tp.interleaver.TPInterleaver] gathers those
+[`TPInterleaver`][nnsight.modeling.tp.fragments.TPInterleaver] gathers those
 before a worker sees them and re-splits whatever the worker leaves, so a trace is
 written exactly as it would be against one GPU.
 

--- a/tests/tp/worker.py
+++ b/tests/tp/worker.py
@@ -29,7 +29,7 @@ LAYER = 1
 
 
 def build(repo_id: str, tp: int, dtype: torch.dtype):
-    from nnsight.modeling.tp import TPInterleaver
+    from nnsight.modeling.tp import TPFragments
     from nnsight.modeling.transformers import TransformersModel
 
     if tp > 1:
@@ -46,18 +46,20 @@ def build(repo_id: str, tp: int, dtype: torch.dtype):
         )
 
     # Nothing installs or enables anything: every HuggingFace model is built with
-    # a TPInterleaver, which works out for itself whether it has a job to do.
+    # an ordinary interleaver carrying TPFragments, which work out for itself
+    # whether they have a job to do.
     interleaver = model.interleaver
-    assert isinstance(interleaver, TPInterleaver), type(interleaver)
+    fragments = interleaver.fragments
+    assert isinstance(fragments, TPFragments), type(fragments)
     if tp > 1:
-        assert interleaver.enabled, "sharded model did not enable the TP path"
-        assert interleaver.tp_rules, "sharded model recorded no rules"
+        assert fragments.enabled, "sharded model did not enable the TP path"
+        assert fragments.tp_rules, "sharded model recorded no rules"
         # One interleaver serves the whole tree, including standalone children
         # outside named_children() — strand one and its values reach nothing.
         assert model.generator.interleaver is interleaver
     else:
-        assert not interleaver.enabled, "unsharded model enabled the TP path"
-        assert not interleaver.tp_rules
+        assert not fragments.enabled, "unsharded model enabled the TP path"
+        assert not fragments.tp_rules
 
     return model
 
@@ -117,7 +119,7 @@ def main() -> None:
     record("generated_steps", torch.stack([s.reshape(()) for s in steps]))
 
     # Greedy so the ranks cannot diverge on sampling; see the module docstring of
-    # nnsight/modeling/tp/interleaver.py for why that would be a correctness bug.
+    # nnsight/modeling/tp/fragments.py for why that would be a correctness bug.
     with model.generate(PROMPT, max_new_tokens=3, do_sample=False) as tracer:
         record("generated", tracer.result.save().float())
 

--- a/tests/tp/worker.py
+++ b/tests/tp/worker.py
@@ -1,0 +1,128 @@
+"""One rank of the tensor-parallel test, run under ``torch.distributed.run``.
+
+Not a test module (no ``test_`` prefix, so pytest does not collect it):
+``test_sharded_tracing.py`` launches this, once on a single GPU for
+the reference and once across N ranks, then compares what each run wrote.
+
+It has to be a separate process because transformers tensor parallelism needs the
+*calling* process to be a rank — unlike vLLM, which spawns its own workers, so
+``tests/vllm/test_tensor_parallel.py`` can stay in-process.
+
+Every rank runs the identical block. That is the whole premise of the design, so
+nothing here may branch on rank.
+
+    python -m torch.distributed.run --nproc_per_node=2 worker.py --tp 2 --out DIR
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import torch
+
+import nnsight
+
+PROMPT = "The Eiffel Tower is in the city of"
+SECOND_PROMPT = "The capital of Japan is the city of"
+LAYER = 1
+
+
+def build(repo_id: str, tp: int, dtype: torch.dtype):
+    from nnsight.modeling.tp import TPInterleaver
+    from nnsight.modeling.transformers import TransformersModel
+
+    if tp > 1:
+        from transformers.distributed import DistributedConfig
+
+        model = TransformersModel(
+            repo_id, task="text-generation", dispatch=True, dtype=dtype,
+            distributed_config=DistributedConfig(tp_size=tp),
+        )
+    else:
+        model = TransformersModel(
+            repo_id, task="text-generation", dispatch=True, dtype=dtype,
+            device_map={"": 0},
+        )
+
+    # Nothing installs or enables anything: every HuggingFace model is built with
+    # a TPInterleaver, which works out for itself whether it has a job to do.
+    interleaver = model.interleaver
+    assert isinstance(interleaver, TPInterleaver), type(interleaver)
+    if tp > 1:
+        assert interleaver.enabled, "sharded model did not enable the TP path"
+        assert interleaver.tp_rules, "sharded model recorded no rules"
+        # One interleaver serves the whole tree, including standalone children
+        # outside named_children() — strand one and its values reach nothing.
+        assert model.generator.interleaver is interleaver
+    else:
+        assert not interleaver.enabled, "unsharded model enabled the TP path"
+        assert not interleaver.tp_rules
+
+    return model
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tp", type=int, default=1)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--dtype", default="float32")
+    args = parser.parse_args()
+
+    rank = int(os.environ.get("RANK", 0))
+    model = build(args.repo, args.tp, getattr(torch, args.dtype))
+
+    layer = model.model.layers[LAYER]
+    results: dict[str, torch.Tensor] = {}
+
+    def record(name: str, tensor: torch.Tensor) -> None:
+        results[name] = tensor.detach().float().cpu()
+
+    # A column-parallel output and a row-parallel input are the two sides that
+    # actually carry a shard; both must arrive at full width.
+    with model.trace(PROMPT):
+        record("gate_proj_out", layer.mlp.gate_proj.output.save())
+        record("down_proj_in", layer.mlp.down_proj.input.save())
+        record("layer_out", layer.output[0].save())
+        record("baseline_logits", model.lm_head.output.save())
+
+    # An edit straddling rank boundaries: only correct if the gather assembled in
+    # true rank order and the re-split put the edit back where it came from.
+    width = results["gate_proj_out"].shape[-1]
+    with model.trace(PROMPT):
+        layer.mlp.gate_proj.output[..., : width // 2 + 1] = 0
+        record("partial_edit_logits", model.lm_head.output.save())
+
+    # A cache must record whole tensors too, and only for what it selects.
+    with model.trace(PROMPT) as tracer:
+        cache = tracer.cache(modules=[layer.mlp.gate_proj], include_inputs=True).save()
+    record("cached_gate_out", cache[f"model.model.layers.{LAYER}.mlp.gate_proj"].output)
+
+    # Several invokes: the feature-dim gather has to compose with the batcher's
+    # dim-0 row narrowing, which happens inside it.
+    with model.trace() as tracer:
+        with tracer.invoke(PROMPT):
+            record("batched_first", layer.mlp.gate_proj.output.save())
+        with tracer.invoke(SECOND_PROMPT):
+            layer.mlp.gate_proj.output[:] = 0
+            record("batched_edited_logits", model.lm_head.output.save())
+
+    # The same sharded location revisited on every step: the occurrence tagging
+    # and the gather have to stay in step across many visits.
+    with model.generate(PROMPT, max_new_tokens=3, do_sample=False) as tracer:
+        steps = nnsight.save([])
+        for _ in tracer.iter[:3]:
+            steps.append(layer.mlp.gate_proj.output[:, -1].mean())
+    record("generated_steps", torch.stack([s.reshape(()) for s in steps]))
+
+    # Greedy so the ranks cannot diverge on sampling; see the module docstring of
+    # nnsight/modeling/tp/interleaver.py for why that would be a correctness bug.
+    with model.generate(PROMPT, max_new_tokens=3, do_sample=False) as tracer:
+        record("generated", tracer.result.save().float())
+
+    torch.save(results, os.path.join(args.out, f"rank{rank}.pt"))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/vllm/test_moe_batching.py
+++ b/tests/vllm/test_moe_batching.py
@@ -159,13 +159,13 @@ def test_swapped_experts_output_reaches_the_block_once(vllm_moe_tp):
     )
 
 
-class TestBatcherPolicy:
-    """Which MoE values count as shards, and what a write-back is divided by.
+class TestFragmentPolicy:
+    """Which MoE values count as pieces, and what a write-back is divided by.
 
-    Runs without GPUs: the decisions in `VLLMBatcher.watch` and the divisor in
-    `VLLMBatcher._shard` are pure functions of the module's parallel config, so a
-    stub with that config pins them. The end-to-end tests above check the numbers
-    these decisions produce; these check the decisions.
+    Runs without GPUs: the decision in `_is_piece` and the divisor in
+    `VLLMFragments.fragment` are pure functions of the module's parallel config,
+    so a stub with that config pins them. The end-to-end tests above check the
+    numbers these decisions produce; these check the decisions.
     """
 
     @staticmethod
@@ -212,21 +212,19 @@ class TestBatcherPolicy:
             (dict(tp=2, ep=1, must_reduce=True), "output", False),
         ],
     )
-    def test_only_deferred_reduce_outputs_are_shards(self, config, kind, expected):
-        from nnsight.modeling.vllm.batching import VLLMBatcher
+    def test_only_deferred_reduce_outputs_are_pieces(self, config, kind, expected):
+        from nnsight.modeling.vllm.fragments import _is_piece
 
-        batcher = VLLMBatcher()
-        batcher.watch(self._stub(**config), kind)
-        assert batcher.parallel is expected
+        assert _is_piece(self._stub(**config), kind) is expected
 
     @pytest.mark.parametrize("tp, ep", [(2, 1), (1, 2), (2, 4)])
     def test_write_back_divides_by_the_group_size(self, tp, ep):
         # The block all-reduces over tp*ep ranks right after, so an equal share
         # is what sums back to the whole exactly once.
-        from nnsight.modeling.vllm.batching import VLLMBatcher
+        from nnsight.modeling.vllm.fragments import VLLMFragments
 
-        batcher = VLLMBatcher()
-        batcher.watch(self._stub(tp=tp, ep=ep), "output")
-        sharded = batcher._shard(torch.full((2, 4), 6.0))
+        fragments = VLLMFragments()
+        fragments.rules["m.output"] = (self._stub(tp=tp, ep=ep), "output")
+        sharded = fragments.fragment("m.output", torch.full((2, 4), 6.0))
 
         assert torch.allclose(sharded, torch.full((2, 4), 6.0 / (tp * ep)))


### PR DESCRIPTION
Lets a model too big for one GPU be traced: loaded with
`distributed_config=DistributedConfig(tp_size=N)` under `torchrun`, with sharded
activations gathered so intervention code reads and edits whole tensors exactly
as it would on a single GPU.

Base is `0.8`, not `dev`.

## What's here

**Tracing a sharded model** (`modeling/tp/`). transformers stamps every module it
shards with `_hf_tp_plan` and `_hf_device_mesh`, so which side of which module
holds a fragment is read off the module rather than guessed. `SHARDED_SIDES` maps
a parallel style to the sides that need gathering; a style with no rule is refused
at load rather than handed to a user as a fragment of a tensor.

**One seam for distributed values** (`intervention/fragments.py`). vLLM and
transformers TP both answer the same three questions at a location — is this a
piece of a larger value, make it whole, put it back — and did so in unrelated
subclasses of unrelated base classes. `Fragments` is that question as a
collaborator; `Interleaver.handle` brackets it. `TPInterleaver` is gone, and
`VLLMBatcher` is down to row scoping, losing `watch`/`release`, its memo, and both
hook installers in `GPUModelRunner`.

It belongs on the interleaver rather than the batcher because of *call
granularity*: `Batcher.narrow` runs once per parked worker, so a batcher that
gathered would fire one collective per reader and ranks would disagree on how many
to run. `Interleaver.handle` is already the once-per-visit bracket.

**Describing a checkpoint** (`mixins/remotable.py`). A server placing a model has
to know its size, parameter count, config and revision before loading it.
`describe_checkpoint` answers all of them from one read — a HuggingFace model uses
the Hub's published parameter count rather than building the architecture to count
it. `max_tp_size` stays a separate question on purpose: how many ways weights split
is a property of the *runtime*, not the files.

## Requires transformers >= 5.15

Below it a tied LM head is gathered but never sharded, so any model with
`tie_word_embeddings=True` returns logits `tp_size` times too wide — with a correct
argmax inside the first copy, so nothing downstream looks wrong. Reproduced on a
live deployment at degree 4: width 513024 against a vocabulary of 128256. nnsight
refuses to shard below that version.

## Two rules SPMD imposes on intervention code

Both are documented in `docs/models/tensor-parallel.md`:

- **No rank-dependent control flow.** Every rank runs the block; a branch that
  differs deadlocks the group.
- **Seed before sampling.** Ranks that sample differently don't merely disagree —
  they go on to all-reduce activations computed from different tokens. Many
  checkpoints ship `do_sample=true`, so it bites without being asked for.

## Testing

- **129** on 4×A100 (`tests/tp` + the rules suite), including a real Llama-3.2-3B
  at tp=4 against a single-GPU reference — exact token ids, widths whole.
- **831** CPU suite.
- vLLM: **17/17** tensor-parallel before and after the `Fragments` port, MoE
  alongside; full suite 112 passed with one pre-existing failure
  (`test_temperature_changes_samples`, confirmed identical with the change
  reverted, on a single-rank fixture where the new code is inert).

`tests/tp/` and `tests/vllm/` are excluded from CI — both need GPUs.

## Known limits

- Expert-parallel styles that slice by expert (`grouped_gemm`, `ep_router`,
  `megamoe_*`, `moe_identity_expert`) and MLA's split kv projection are refused.
  Most MoE checkpoints are fine: `moe_tp_experts` all-reduces in its own forward,
  so Mixtral, DeepSeek-V3 and Qwen3-MoE need no gather.
- `.source` values are handed over as this rank's fragment with a warning — the
  split axis moves through a forward and isn't recoverable at runtime. Don't branch
  on one.

`docs/developing/fragments-proposal.md` records the seam's design and what the
port cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)