### PR TITLE
Name a quantization where you would name a dtype

### DIFF
--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -2,7 +2,7 @@
 title: Model Classes
 one_liner: Decision tree for picking the right nnsight model wrapper.
 tags: [models, index]
-related: [docs/models/transformers-model.md, docs/models/tensor-parallel.md, docs/models/nnsight-base.md, docs/models/diffusion-model.md, docs/models/vllm.md, docs/models/language-model.md, docs/models/vision-language-model.md]
+related: [docs/models/transformers-model.md, docs/models/tensor-parallel.md, docs/models/quantization.md, docs/models/nnsight-base.md, docs/models/diffusion-model.md, docs/models/vllm.md, docs/models/language-model.md, docs/models/vision-language-model.md]
 sources: [src/nnsight/__init__.py:53, src/nnsight/modeling/base.py:6, src/nnsight/modeling/transformers.py:161, src/nnsight/modeling/diffusion.py:38, src/nnsight/modeling/vllm/vllm.py:36, src/nnsight/modeling/language.py:19, src/nnsight/modeling/vlm.py:29]
 ---
 
@@ -29,6 +29,9 @@ Pick the model wrapper that matches what you have. All wrappers expose the same 
 - Your model is **too big for one GPU** and you want to trace it split across several with `transformers` tensor parallelism (one process per GPU, launched with `torchrun`).
   - See [docs/models/tensor-parallel.md](tensor-parallel.md). Still `TransformersModel` — pass `distributed_config=DistributedConfig(tp_size=N)`; sharded activations are gathered for you.
 
+- Your model is **too big for one GPU** and you would rather narrow it than split it.
+  - See [docs/models/quantization.md](quantization.md). Still `TransformersModel` — pass `dtype="nf4"` (or `int8`, `fp8`, ...) where you would pass a torch dtype. Module paths and activations are unchanged.
+
 ### Deprecated aliases
 
 - `nnsight.LanguageModel` — DEPRECATED thin alias for `TransformersModel(repo_id, task="text-generation")`. Warns on construction. See [docs/models/language-model.md](language-model.md).
@@ -43,6 +46,7 @@ Pick the model wrapper that matches what you have. All wrappers expose the same 
 | `DiffusionModel` | `nnsight` | diffusers pipelines | `diffusers.DiffusionPipeline` |
 | `VLLM` | `nnsight.modeling.vllm` | High-throughput serving with interventions | `vllm.LLM` (sync) / `vllm.v1.engine.async_llm.AsyncLLM` (async) |
 | `TransformersModel` + `DistributedConfig` | `nnsight` + `transformers.distributed` | A model sharded across GPUs (tensor parallel) | `transformers.pipeline` |
+| `TransformersModel` + `dtype="nf4"` | `nnsight` | A model held in 4 or 8 bits | `transformers.pipeline` |
 | `LanguageModel` *(deprecated)* | `nnsight` | → `TransformersModel(task="text-generation")` | `transformers.pipeline` |
 | `VisionLanguageModel` *(deprecated)* | `nnsight` | → `TransformersModel(task="image-text-to-text")` | `transformers.pipeline` |
 

--- a/docs/models/quantization.md
+++ b/docs/models/quantization.md
@@ -1,0 +1,131 @@
+---
+title: Quantization
+one_liner: Hold a model's weights in 4 or 8 bits by naming the format where you would name a dtype — activations, module paths, and traces are unchanged.
+tags: [models, transformers, quantization, bitsandbytes, memory, 4-bit, 8-bit]
+related: [docs/models/transformers-model.md, docs/models/tensor-parallel.md, docs/models/index.md, docs/remote/index.md]
+sources: [src/nnsight/modeling/quantization.py, src/nnsight/modeling/mixins/remotable.py, tests/test_quantization.py]
+---
+
+# Quantization
+
+## What this is for
+
+A model too big for the GPU you have can be held in **fewer bits per weight**.
+That normally means building a quantizer config and knowing which of
+transformers' several backends your format belongs to — a lot of ceremony for a
+choice that is really just *how wide is a weight*. So it goes in the dtype slot,
+next to the widths torch does have:
+
+```python
+from nnsight import TransformersModel
+
+model = TransformersModel(
+    "meta-llama/Llama-3.2-3B",
+    task="text-generation",
+    dtype="nf4",          # <- where you would write "bfloat16"
+    dispatch=True,
+)
+```
+
+Nothing else changes. There is nothing to import and no config to build.
+
+## The names
+
+| Name | What you get | Bytes/weight |
+|---|---|---|
+| `nf4`, `int4`, `4bit` | bitsandbytes 4-bit, NF4 | 0.5 |
+| `fp4` | bitsandbytes 4-bit, FP4 | 0.5 |
+| `int8`, `8bit` | bitsandbytes LLM.int8() | 1.0 |
+| `fp8` | transformers block-wise FP8 (H100+) | 1.0 |
+
+Several names for one thing on purpose: someone reaching for 4-bit writes
+whichever of `int4` / `4bit` / `nf4` they last read about, and there is nothing
+gained by making two of the three an error. The unqualified names mean **NF4**,
+which is what bitsandbytes recommends; `fp4` is reached only by asking for it.
+
+## What a trace sees
+
+**The module tree is identical.** A quantized linear is a different class holding
+a differently-shaped weight, but it sits at the same path with the same children,
+so every intervention, envoy and remote request naming a module is unaffected.
+
+**Activations are ordinary 16-bit tensors.** The weights are narrow; what flows
+between modules is not. `layers[5].mlp.gate_proj.output` comes back the same
+shape and dtype it would from a `bfloat16` model.
+
+```python
+with model.trace("The Eiffel Tower is in the city of"):
+    gate = model.model.layers[5].mlp.gate_proj.output.save()
+    logits = model.lm_head.output.save()
+
+print(gate.shape, gate.dtype)   # (1, 11, 8192) torch.bfloat16 — as if unquantized
+```
+
+**Raw weights are the exception.** `gate_proj.weight` under 4-bit is a packed
+`uint8` blob — `(8388608, 1)` where the real matrix is `(8192, 2048)` — because
+that is genuinely how it is stored. Read activations, not weights, or load
+unquantized when the weights are the object of study.
+
+## What it costs
+
+Measured on Llama-3.2-1B, layer-5 hidden-state norm against the unquantized run:
+
+| dtype | GPU | norm | next token |
+|---|---|---|---|
+| `bfloat16` | 2.47 GB | 422.17 | ` Paris` |
+| `int8` | 1.50 GB | 422.07 | ` Paris` |
+| `nf4` | 1.07 GB | 408.76 | ` Paris` |
+| `fp4` | 1.07 GB | 384.41 | ` Paris` |
+
+4-bit is a real perturbation — a few percent on hidden-state norms, growing with
+depth — so treat a quantized run as a different model rather than a cheaper copy
+of the same one, and do not compare activations across widths.
+
+> **Sizing runs low.** A model does not shrink by the ratio in the table: the
+> format leaves embeddings, norms and the LM head in 16 bits and stores a scale
+> per block. Llama-3.2-1B at `nf4` really takes 1.07 GB where 0.5 bytes/weight
+> predicts 0.62. Budget from measurement, not arithmetic.
+
+## Compute dtype
+
+Everything the format does not quantize — norms, embeddings, the LM head — and
+everything the model computes in is `bfloat16`, with one exception: **`int8`
+computes in `float16`**, because bitsandbytes implements LLM.int8() that way and
+casts anything else on the way in, warning once per matmul as it does. So an
+`int8` model's activations arrive as `float16`.
+
+Override it if you need to:
+
+```python
+TransformersModel(repo_id, task="text-generation", dtype="nf4", compute_dtype="float32")
+```
+
+## Requires a GPU and the backend
+
+bitsandbytes needs a CUDA device — a quantized model cannot be loaded on CPU or
+built on meta. `dispatch=False` is still fine: the **meta build ignores the
+quantization** and builds the architecture at the compute dtype, which is what
+makes the lazy path work and what lets a client model a checkpoint a server holds
+quantized. The weights are only quantized when they are actually loaded.
+
+`fp8` is not bitsandbytes at all — it is transformers' own quantizer and needs
+H100-or-later hardware, which transformers checks for.
+
+## On NDIF
+
+The same names are what a deployment is configured with, so a server can hold a
+model 4-bit without anything client-side changing:
+
+```
+ndif deploy meta-llama/Llama-3.3-70B --dtype nf4
+```
+
+A **client cannot ask for a quantization**, though — a remote model key is the
+repo id and revision, and says nothing about how the weights are held. The
+deployment decides; a client-side `dtype=` only shapes its own meta build.
+
+## Related
+
+- [transformers-model.md](transformers-model.md) — the wrapper being quantized.
+- [tensor-parallel.md](tensor-parallel.md) — the other way to fit a model that
+  does not fit, by splitting it across GPUs rather than narrowing it.

--- a/src/nnsight/modeling/huggingface.py
+++ b/src/nnsight/modeling/huggingface.py
@@ -161,7 +161,12 @@ class HuggingFaceModel(Remotable):
         )
 
     def _load(self, repo_id: str, *args: Any, **kwargs: Any) -> torch.nn.Module:
+        from .quantization import resolve_load_kwargs
+
         self._refuse_impossible_tp(repo_id, kwargs)
+        # A `dtype=` naming a quantization becomes a quantizer config plus the
+        # compute dtype; an ordinary dtype passes through untouched.
+        kwargs = resolve_load_kwargs(kwargs)
         return self._auto().from_pretrained(repo_id, revision=self.revision, **kwargs)
 
     def _remoteable_model_key(self) -> str:

--- a/src/nnsight/modeling/mixins/remotable.py
+++ b/src/nnsight/modeling/mixins/remotable.py
@@ -69,26 +69,6 @@ class CheckpointInfo:
     revision: Optional[str] = None
 
 
-#: Bytes per stored element for names that aren't torch dtypes — quantizations,
-#: which are how a checkpoint is *held* rather than a type torch has. A caller
-#: sizing a deployment names these as plainly as it names ``"bfloat16"``.
-#:
-#: These are the nominal widths and they under-count real footprint:
-#: bitsandbytes leaves the LM head (usually the embeddings and norms too) in 16
-#: bits and stores an absmax/scale tensor per block, none of which is in the
-#: parameter count. `accelerate`'s memory estimator makes the same simplification.
-#: Anything placing a model on this number should pad it.
-_QUANTIZED_BYTES: dict[str, float] = {
-    "int4": 0.5,
-    "nf4": 0.5,
-    "fp4": 0.5,
-    "4bit": 0.5,
-    "int8": 1.0,
-    "fp8": 1.0,
-    "8bit": 1.0,
-}
-
-
 def bytes_per_element(dtype: str) -> float:
     """How many bytes one weight occupies when held as ``dtype``.
 
@@ -97,28 +77,72 @@ def bytes_per_element(dtype: str) -> float:
     (``"int4"``, ``"nf4"``, ``"fp8"``). Fractional for sub-byte formats, so the
     result is a float — round the product, not this.
 
+    The quantization names come from
+    [`QUANTIZATIONS`][nnsight.modeling.quantization.QUANTIZATIONS], which is the
+    same table the loader builds from. Sizing a checkpoint and loading it must
+    accept exactly the same set: a name only one side knows is a deployment that
+    is placed and then cannot load, or loads having never been placed. See there
+    for why these widths are nominal and a caller has to pad.
+
     Raises:
         ValueError: for a name that is neither, rather than defaulting to a
             plausible width: a wrong guess here silently mis-sizes a deployment.
     """
     import torch
 
+    from ..quantization import QUANTIZATIONS
+
     name = dtype.removeprefix("torch.").lower()
 
     # The table wins over torch, which reports sub-byte dtypes as one byte
     # because that is the smallest thing it can address: `torch.int4.itemsize`
     # is 1, and sizing 4-bit weights by it would ask for twice the memory.
-    if name in _QUANTIZED_BYTES:
-        return _QUANTIZED_BYTES[name]
+    if name in QUANTIZATIONS:
+        return QUANTIZATIONS[name].bytes_per_element
 
     resolved = getattr(torch, name, None)
     if isinstance(resolved, torch.dtype):
-        return float(resolved.itemsize)
+        if _addressable(resolved):
+            return float(resolved.itemsize)
+
+        # torch carries `int1` through `int7` (and the unsigned ones), all
+        # reporting an itemsize of 1. Sizing weights by that asks for up to eight
+        # times the memory they take, and nothing here can load them anyway:
+        # the sub-byte formats a checkpoint is really held in are in
+        # QUANTIZATIONS under their own names, with a quantizer behind each.
+        raise ValueError(
+            f"Cannot size a checkpoint held as {dtype!r}: torch reports it as one "
+            "byte per element regardless of how narrow it is. The sub-byte formats "
+            f"that can be loaded are {sorted(QUANTIZATIONS)}."
+        )
 
     raise ValueError(
         f"Unknown dtype {dtype!r}: not a torch dtype and not one of "
-        f"{sorted(_QUANTIZED_BYTES)}."
+        f"{sorted(QUANTIZATIONS)}."
     )
+
+
+def _addressable(dtype: Any) -> bool:
+    """Whether ``dtype.itemsize`` is really how much one element occupies.
+
+    True for every dtype that occupies whole bytes. False for torch's sub-byte
+    integer dtypes, which round their itemsize up to 1 — and which are exactly
+    the ones neither ``iinfo`` nor ``finfo`` will describe, so that is the test.
+    Only an itemsize of 1 is in doubt; anything wider cannot have been rounded up
+    to a whole byte, and asking about it would get ``complex64`` wrong (32-bit
+    components, 8 bytes stored).
+    """
+    import torch
+
+    if dtype.itemsize > 1:
+        return True
+
+    for info in (torch.iinfo, torch.finfo):
+        try:
+            return info(dtype).bits == 8
+        except TypeError:
+            continue
+    return False
 
 
 class Remotable(Meta):

--- a/src/nnsight/modeling/quantization.py
+++ b/src/nnsight/modeling/quantization.py
@@ -1,0 +1,255 @@
+"""Loading a checkpoint in a format that isn't a torch dtype.
+
+A model too big for the GPU you have can be held in fewer bits per weight than
+any ``torch.dtype`` offers — 4-bit through bitsandbytes, 8-bit through either
+bitsandbytes or transformers' own FP8. Doing that normally means building a
+quantizer config object and knowing which of transformers' several quantizer
+backends the format belongs to, which is a lot of ceremony for a choice that is
+really just *how wide is a weight*.
+
+So it goes in the dtype slot, next to the widths torch does have::
+
+    LanguageModel("meta-llama/Llama-3.2-3B", dtype="nf4", dispatch=True)
+
+``dtype`` here is what the weights are **held** as. Everything the format leaves
+alone — norms, embeddings, the LM head — and everything the model *computes* in
+stays [`DEFAULT_COMPUTE_DTYPE`][nnsight.modeling.quantization.DEFAULT_COMPUTE_DTYPE],
+so activations come out of a quantized model in the same dtype they would come
+out of a ``bfloat16`` one and a trace reads the same either way.
+
+The table below is the single place these names are defined, and it is read from
+two directions that must not disagree: **loading** a checkpoint (here) and
+**sizing** one before it is loaded
+([`bytes_per_element`][nnsight.modeling.mixins.remotable.bytes_per_element],
+which a server uses to decide how many GPUs a deployment gets). A name one side
+accepts and the other rejects is a deployment that is placed and then fails to
+load, or loads and was never placed.
+
+What is *not* affected is the module tree: a quantized linear is a different
+class holding a differently-shaped weight, but it sits at the same path with the
+same children, so module paths — and therefore interventions, envoys, and remote
+requests naming them — are unchanged. Reading a raw ``.weight`` is the exception;
+see [`Quantization`][nnsight.modeling.quantization.Quantization].
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+#: What a quantized model computes in, and what it holds the weights the format
+#: does not touch in. Not a torch dtype at module scope on purpose — resolved on
+#: use, so importing this module does not import torch.
+DEFAULT_COMPUTE_DTYPE = "bfloat16"
+
+#: Kwarg names carrying the dtype. transformers 5 renamed ``torch_dtype`` to
+#: ``dtype`` and still accepts both, and callers reach for either, so a
+#: quantization name has to be recognized under both.
+_DTYPE_KEYS = ("dtype", "torch_dtype")
+
+#: Kwarg names overriding a format's own
+#: [`compute_dtype`][nnsight.modeling.quantization.Quantization]. The bnb-
+#: prefixed one is what the bitsandbytes documentation calls it, so it is what
+#: someone arriving from there writes; the bare one is what it means here, where
+#: it also applies to formats bitsandbytes has nothing to do with.
+_COMPUTE_DTYPE_KEYS = ("compute_dtype", "bnb_4bit_compute_dtype")
+
+
+def _bitsandbytes_4bit(quant_type: str) -> Callable[[Any], Any]:
+    """A 4-bit bitsandbytes config in ``quant_type`` (``"nf4"`` or ``"fp4"``)."""
+
+    def build(compute_dtype: Any) -> Any:
+        from transformers import BitsAndBytesConfig
+
+        return BitsAndBytesConfig(
+            load_in_4bit=True,
+            bnb_4bit_quant_type=quant_type,
+            bnb_4bit_compute_dtype=compute_dtype,
+        )
+
+    return build
+
+
+def _bitsandbytes_8bit(compute_dtype: Any) -> Any:
+    """LLM.int8(): 8-bit weights with outlier features kept in 16 bits.
+
+    Takes no compute dtype — the mixed-precision decomposition decides that per
+    matmul, so unlike the 4-bit path there is nothing to tell it.
+    """
+    from transformers import BitsAndBytesConfig
+
+    return BitsAndBytesConfig(load_in_8bit=True)
+
+
+def _fp8(compute_dtype: Any) -> Any:
+    """transformers' own block-wise FP8, which is not a bitsandbytes format.
+
+    Needs hardware with FP8 support (H100 and later). transformers raises on
+    anything older, which is left to it rather than duplicated here — the check
+    belongs to the backend that knows what it needs.
+    """
+    from transformers import FineGrainedFP8Config
+
+    return FineGrainedFP8Config()
+
+
+@dataclass(frozen=True)
+class Quantization:
+    """One way of holding weights that torch has no dtype for.
+
+    Args:
+        bytes_per_element: Nominal width of one stored weight. **Nominal**: the
+            formats here leave the LM head, embeddings and norms in 16 bits and
+            store a scale per block, none of which this counts, so the real
+            footprint is larger — measurably so for a model whose vocabulary is
+            a large fraction of it. Anything placing a model on this number has
+            to pad. `accelerate`'s own estimator makes the same simplification.
+        build: Takes the compute dtype and returns the transformers quantizer
+            config. Imports its backend inside, so a name nobody asks for costs
+            nothing and a missing backend fails when it is actually wanted.
+        compute_dtype: What this format computes in, and holds everything it
+            does not quantize in. Per-format rather than one constant because
+            the backends do not agree: see ``int8`` below.
+    """
+
+    bytes_per_element: float
+    build: Callable[[Any], Any]
+    compute_dtype: str = DEFAULT_COMPUTE_DTYPE
+
+
+#: Every format that can go in the dtype slot, by the name a caller writes.
+#:
+#: Several names for one thing, deliberately: someone reaching for 4-bit writes
+#: ``"int4"``, ``"4bit"`` or ``"nf4"`` depending on where they last read about
+#: it, and there is nothing to be gained by making two of the three an error.
+#: ``nf4`` is what the unqualified names mean — it is the format bitsandbytes
+#: recommends and the one that measures better than ``fp4`` at the same width —
+#: so ``fp4`` is reached only by asking for it by name.
+#: ``int8`` is the one that does not compute in the default. bitsandbytes
+#: implements LLM.int8() in float16 and casts anything else on the way in,
+#: warning once *per matmul* as it does — a hundred lines of it for a single
+#: short forward. Handing it float16 to begin with is both quieter and closer to
+#: the unquantized model (on Llama-3.2-1B, layer-5 hidden norm 422.07 against
+#: bfloat16's 422.17, where computing in bfloat16 gives 419.70). The visible
+#: consequence is that an int8 model's activations arrive as float16.
+_NF4 = Quantization(0.5, _bitsandbytes_4bit("nf4"))
+_INT8 = Quantization(1.0, _bitsandbytes_8bit, compute_dtype="float16")
+
+QUANTIZATIONS: dict[str, Quantization] = {
+    "nf4": _NF4,
+    "int4": _NF4,
+    "4bit": _NF4,
+    "fp4": Quantization(0.5, _bitsandbytes_4bit("fp4")),
+    "int8": _INT8,
+    "8bit": _INT8,
+    "fp8": Quantization(1.0, _fp8),
+}
+
+
+def quantization(dtype: Any) -> Optional[Quantization]:
+    """The format ``dtype`` names, or ``None`` if it names a torch dtype.
+
+    ``None`` is the ordinary answer and means "nothing to do" — every caller
+    here is deciding whether a load needs rewriting at all.
+    """
+    if not isinstance(dtype, str):
+        # A real torch.dtype, or None. Neither can be a quantization name.
+        return None
+
+    return QUANTIZATIONS.get(dtype.removeprefix("torch.").lower())
+
+
+def resolve_load_kwargs(kwargs: dict, *, quantize: bool = True) -> dict:
+    """Turn a quantization name in ``kwargs``' dtype into a load transformers takes.
+
+    Returns a new dict; ``kwargs`` is left alone. Kwargs whose dtype is an
+    ordinary torch dtype come back **unchanged** — not normalized, not
+    reordered — so this can sit on every load path without having an opinion
+    about the ones it has nothing to do with.
+
+    With ``quantize`` false the name is replaced by the compute dtype and no
+    quantizer config is built. That is the meta-model path: building the
+    architecture without weights has nothing to quantize, and the quantizers
+    reject a meta device outright. The resulting tree is the same either way,
+    which is what lets a client build a meta model of a checkpoint a server
+    holds quantized and have every module path line up.
+
+    Args:
+        kwargs: Load kwargs, as passed to ``from_pretrained``/``pipeline``.
+        quantize: Whether to actually build the quantizer config.
+
+    Raises:
+        ValueError: if a ``quantization_config`` was also passed. Two answers to
+            "how are these weights held" and no way to tell which was meant.
+    """
+    key = next((k for k in _DTYPE_KEYS if k in kwargs), None)
+    if key is None:
+        return kwargs
+
+    fmt = quantization(kwargs[key])
+    if fmt is None:
+        return kwargs
+
+    resolved = {
+        k: v
+        for k, v in kwargs.items()
+        if k not in _DTYPE_KEYS and k not in _COMPUTE_DTYPE_KEYS
+    }
+
+    compute_dtype = next(
+        (kwargs[k] for k in _COMPUTE_DTYPE_KEYS if k in kwargs), fmt.compute_dtype
+    )
+    # Whatever the caller wrote it under, hand transformers the modern name. The
+    # compute dtype takes the dtype slot because it is what everything the format
+    # leaves alone — norms, embeddings, the LM head — is held in.
+    resolved["dtype"] = compute_dtype
+
+    if not quantize:
+        return resolved
+
+    if resolved.get("quantization_config") is not None:
+        raise ValueError(
+            f"dtype={kwargs[key]!r} and an explicit `quantization_config` both say "
+            "how the weights are held, and they can disagree. Pass one: the dtype "
+            "name for the common case, the config to configure it in detail."
+        )
+
+    resolved["quantization_config"] = fmt.build(_torch_dtype(compute_dtype))
+    return resolved
+
+
+def _torch_dtype(dtype: Any) -> Any:
+    """``dtype`` as a real ``torch.dtype``.
+
+    The quantizer configs hold this rather than pass it on, and bitsandbytes
+    compares it against tensor dtypes at runtime, so a string that
+    ``from_pretrained`` would have resolved has to be resolved here instead.
+    """
+    import torch
+
+    if isinstance(dtype, torch.dtype):
+        return dtype
+
+    resolved = getattr(torch, str(dtype).removeprefix("torch."), None)
+    if not isinstance(resolved, torch.dtype):
+        raise ValueError(f"Unknown compute dtype: {dtype!r}")
+    return resolved
+
+
+# TODO: `bytes_per_element` under-counts, and by more than a padding factor
+# absorbs. Measured on Llama-3.2-1B (1.236B params): nf4 estimates 0.618 GB
+# against 1.073 GB really allocated (0.58x), int8 1.236 against 1.501 (0.82x),
+# where bfloat16 lands on 1.00x. The gap is the weights the format does not
+# touch — embeddings and the LM head are 21% of the parameters here, and they
+# stay 16-bit — plus a scale per block. It is derivable from the config, which
+# `_remoteable_describe_checkpoint` already holds: size
+# `vocab_size * hidden_size * (1 if tied else 2)` at 2 bytes and the rest at the
+# format's width. Until then a server placing a quantized model has to pad for
+# it, and NDIF's default 0.15 does not.
+
+# TODO: a remote model key is `{repo_id, revision}` and says nothing about how
+# the weights are held, so a client cannot ask for a quantized replica — the
+# deployment decides, and a client-side `dtype=` only shapes its own meta build.
+# Routing a request to a replica by dtype means putting it in the key (and
+# teaching the server to treat two dtypes of one checkpoint as two deployments),
+# which is a routing change, not a loading one.

--- a/src/nnsight/modeling/transformers.py
+++ b/src/nnsight/modeling/transformers.py
@@ -330,6 +330,14 @@ class TransformersModel(HuggingFaceModel):
         from transformers import AutoConfig, pipeline
         from transformers.pipelines import check_task, get_task
 
+        from .quantization import resolve_load_kwargs
+
+        # A quantization name in `dtype` becomes the compute dtype here and no
+        # quantizer config: there are no weights on meta to quantize. Done before
+        # the filter below, not after, so an explicit compute dtype (which is not
+        # an architecture kwarg and would be dropped) still reaches the build.
+        kwargs = resolve_load_kwargs(kwargs, quantize=False)
+
         # Only architecture-shaping kwargs reach the meta build (see
         # _META_MODEL_KWARGS); AutoConfig.from_pretrained tolerates extras but
         # from_config does not, and placement kwargs don't apply to meta tensors.
@@ -390,10 +398,18 @@ class TransformersModel(HuggingFaceModel):
     def _load(self, repo_id: str, *args: Any, **kwargs: Any) -> torch.nn.Module:
         from transformers import pipeline
 
+        from .quantization import resolve_load_kwargs
+
         # Before the split, and before the pipeline fetches anything. This path
         # does not reach the base's `_load`, so the check has to be repeated
         # here -- the tensor-parallel server loads through *this* class.
         self._refuse_impossible_tp(repo_id, kwargs)
+
+        # Also before the split: `dtype` is a pipeline-factory argument, so a
+        # quantization name left in it would be handed to `pipeline()` rather
+        # than to the quantizer. `quantization_config` is not a factory argument
+        # and lands in `model_kwargs`, which is where from_pretrained wants it.
+        kwargs = resolve_load_kwargs(kwargs)
 
         top_level, model_kwargs = _split_pipeline_kwargs(kwargs)
         # The pipeline loads the model and infers every preprocessor; only

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -1,0 +1,200 @@
+"""Naming a quantization in the dtype slot, checked without a GPU.
+
+Loading a checkpoint 4-bit needs a GPU and bitsandbytes, so what is checked here
+is everything up to the load: which names are recognized, what they turn a set of
+load kwargs into, and — the one that matters most — that **sizing a checkpoint
+and loading it accept exactly the same set of names**. A name only one side knows
+is a deployment that a server places and then cannot load, or one that loads
+having never been placed, and neither failure points at this table.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from nnsight.modeling.mixins.remotable import bytes_per_element
+from nnsight.modeling.quantization import (
+    QUANTIZATIONS,
+    quantization,
+    resolve_load_kwargs,
+)
+
+
+class TestNames:
+    def test_sizing_accepts_every_name_the_loader_does(self):
+        # The whole point of one table. If these ever diverge, a deployment is
+        # placed at a size nothing will load at, or refused a name that works.
+        for name in QUANTIZATIONS:
+            assert bytes_per_element(name) == QUANTIZATIONS[name].bytes_per_element
+
+    @pytest.mark.parametrize("name", ["int4", "4bit", "nf4"])
+    def test_unqualified_four_bit_names_mean_nf4(self, name):
+        # fp4 is reachable only by asking for it: nf4 is what bitsandbytes
+        # recommends and measures better at the same width.
+        assert quantization(name) is quantization("nf4")
+
+    def test_fp4_is_not_nf4(self):
+        assert quantization("fp4") is not quantization("nf4")
+        assert QUANTIZATIONS["fp4"].build(torch.bfloat16).bnb_4bit_quant_type == "fp4"
+
+    @pytest.mark.parametrize("name", ["NF4", "Int8", "torch.nf4"])
+    def test_names_are_case_and_prefix_insensitive(self, name):
+        # Matches how `bytes_per_element` reads a dtype, so a name that sizes
+        # also loads regardless of how it was spelled.
+        assert quantization(name) is not None
+
+    @pytest.mark.parametrize("dtype", ["bfloat16", "float32", torch.float16, None])
+    def test_a_real_dtype_is_not_a_quantization(self, dtype):
+        assert quantization(dtype) is None
+
+    def test_an_unknown_name_is_refused_by_sizing(self):
+        # Rather than defaulting to a plausible width, which mis-sizes silently.
+        with pytest.raises(ValueError, match="not a torch dtype"):
+            bytes_per_element("int9")
+
+    @pytest.mark.parametrize("name", ["int1", "int3", "int7", "uint4"])
+    def test_torchs_sub_byte_dtypes_are_refused_rather_than_rounded(self, name):
+        # torch carries int1..int7 and reports every one of them as itemsize 1,
+        # so sizing by that asks for up to 8x the memory — and there is no loader
+        # for them either. The real sub-byte formats are in QUANTIZATIONS.
+        assert getattr(torch, name, None) is not None, "torch dropped this dtype"
+        with pytest.raises(ValueError, match="one byte per element"):
+            bytes_per_element(name)
+
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("int8", 1.0),
+            ("float8_e4m3fn", 1.0),
+            ("bfloat16", 2.0),
+            ("float32", 4.0),
+            # 32-bit components but 8 bytes stored: the guard must not read this
+            # off `finfo`, which reports 32.
+            ("complex64", 8.0),
+        ],
+    )
+    def test_whole_byte_dtypes_keep_their_itemsize(self, name, expected):
+        assert bytes_per_element(name) == expected
+
+    def test_int8_computes_in_float16(self):
+        # bitsandbytes implements LLM.int8() in float16 and warns once per matmul
+        # when handed anything else. See the comment on QUANTIZATIONS.
+        assert QUANTIZATIONS["int8"].compute_dtype == "float16"
+        assert QUANTIZATIONS["nf4"].compute_dtype == "bfloat16"
+
+
+class TestResolveLoadKwargs:
+    def test_an_ordinary_dtype_passes_through_untouched(self):
+        # Identity, not equality: this sits on every load path and must not have
+        # an opinion about loads it has nothing to do with.
+        kwargs = {"dtype": torch.bfloat16, "device_map": "auto"}
+        assert resolve_load_kwargs(kwargs) is kwargs
+
+    def test_no_dtype_at_all_passes_through_untouched(self):
+        kwargs = {"device_map": "auto"}
+        assert resolve_load_kwargs(kwargs) is kwargs
+
+    def test_a_quantization_becomes_a_config_plus_a_compute_dtype(self):
+        resolved = resolve_load_kwargs({"dtype": "nf4", "device_map": "auto"})
+
+        assert resolved["dtype"] == "bfloat16"
+        assert resolved["device_map"] == "auto"
+        config = resolved["quantization_config"]
+        assert config.load_in_4bit
+        assert config.bnb_4bit_quant_type == "nf4"
+        assert config.bnb_4bit_compute_dtype is torch.bfloat16
+
+    def test_the_legacy_dtype_key_is_recognized_too(self):
+        # transformers 5 renamed torch_dtype to dtype and still takes both, and
+        # ndif's model actor passes the old one.
+        resolved = resolve_load_kwargs({"torch_dtype": "int8"})
+
+        assert "torch_dtype" not in resolved
+        assert resolved["dtype"] == "float16"
+        assert resolved["quantization_config"].load_in_8bit
+
+    def test_the_caller_does_not_get_mutated(self):
+        kwargs = {"dtype": "nf4"}
+        resolve_load_kwargs(kwargs)
+        assert kwargs == {"dtype": "nf4"}
+
+    @pytest.mark.parametrize("key", ["compute_dtype", "bnb_4bit_compute_dtype"])
+    def test_an_explicit_compute_dtype_wins(self, key):
+        resolved = resolve_load_kwargs({"dtype": "nf4", key: "float32"})
+
+        assert resolved["dtype"] == "float32"
+        assert resolved["quantization_config"].bnb_4bit_compute_dtype is torch.float32
+        # It is not a from_pretrained argument, so it must not survive.
+        assert key not in resolved
+
+    def test_a_conflicting_quantization_config_is_refused(self):
+        # Two answers to "how are these weights held" and no way to tell which
+        # was meant, so neither is guessed at.
+        with pytest.raises(ValueError, match="quantization_config"):
+            resolve_load_kwargs({"dtype": "nf4", "quantization_config": object()})
+
+    def test_an_explicit_config_alone_is_left_alone(self):
+        kwargs = {"dtype": torch.bfloat16, "quantization_config": object()}
+        assert resolve_load_kwargs(kwargs) is kwargs
+
+
+class TestMetaPath:
+    """``quantize=False`` — building the architecture with no weights.
+
+    The quantizers reject a meta device outright, and there is nothing on meta to
+    quantize anyway. What has to survive is the *dtype substitution*, because the
+    meta tree a client builds has to match the real tree a server holds.
+    """
+
+    def test_the_name_is_replaced_by_the_compute_dtype(self):
+        resolved = resolve_load_kwargs({"dtype": "nf4"}, quantize=False)
+
+        assert resolved == {"dtype": "bfloat16"}
+
+    def test_no_quantizer_config_is_built(self):
+        resolved = resolve_load_kwargs({"dtype": "int4"}, quantize=False)
+
+        assert "quantization_config" not in resolved
+
+    def test_an_explicit_compute_dtype_still_applies(self):
+        # It is not an architecture kwarg, so it would be filtered out before the
+        # meta build if this did not resolve it first.
+        resolved = resolve_load_kwargs(
+            {"dtype": "nf4", "compute_dtype": "float32"}, quantize=False
+        )
+
+        assert resolved == {"dtype": "float32"}
+
+    def test_a_conflicting_config_is_not_refused_here(self):
+        # The check guards building one, and nothing is built on this path.
+        resolved = resolve_load_kwargs(
+            {"dtype": "nf4", "quantization_config": "whatever"}, quantize=False
+        )
+
+        assert resolved["dtype"] == "bfloat16"
+
+
+class TestBuiltConfigs:
+    """The configs themselves, which is where a backend rename would show up."""
+
+    @pytest.mark.parametrize("name,quant_type", [("nf4", "nf4"), ("fp4", "fp4")])
+    def test_four_bit_configs(self, name, quant_type):
+        config = QUANTIZATIONS[name].build(torch.bfloat16)
+
+        assert config.load_in_4bit
+        assert not config.load_in_8bit
+        assert config.bnb_4bit_quant_type == quant_type
+
+    def test_eight_bit_config(self):
+        config = QUANTIZATIONS["int8"].build(torch.float16)
+
+        assert config.load_in_8bit
+        assert not config.load_in_4bit
+
+    def test_fp8_is_not_a_bitsandbytes_format(self):
+        # It goes to transformers' own quantizer, which is the reason this table
+        # holds a builder per name rather than a bitsandbytes flag.
+        from transformers import FineGrainedFP8Config
+
+        assert isinstance(QUANTIZATIONS["fp8"].build(torch.bfloat16), FineGrainedFP8Config)


### PR DESCRIPTION
A model too big for the GPU you have can be held in 4 or 8 bits, but doing that meant building a quantizer config and knowing which of transformers' several backends the format belongs to — ceremony for a choice that is really just *how wide is a weight*. So it goes in the dtype slot:

```python
TransformersModel("meta-llama/Llama-3.2-3B", task="text-generation", dtype="nf4", dispatch=True)
```

| Name | Backend | Bytes/weight |
|---|---|---|
| `nf4`, `int4`, `4bit` | bitsandbytes 4-bit NF4 | 0.5 |
| `fp4` | bitsandbytes 4-bit FP4 | 0.5 |
| `int8`, `8bit` | bitsandbytes LLM.int8() | 1.0 |
| `fp8` | transformers `FineGrainedFP8Config` (H100+) | 1.0 |

## One table, read from two directions

`modeling/quantization.py` holds names → (width, quantizer builder, compute dtype). It is read when **loading** a checkpoint and when **sizing** one before it loads, and those must accept exactly the same set: a name only one side knows is a deployment that gets placed and then cannot load, or one that loads having never been placed. `bytes_per_element` now reads that table rather than keeping its own copy.

## Traces are unchanged

The module tree is **identical** — only the leaf class and the packed weight differ — so every module path, intervention and remote request lines up. Activations come back the same shape and dtype they would unquantized. The meta build takes the same names and ignores the quantization, which is what lets a client model a checkpoint a server holds quantized.

Raw `.weight` is the exception: 4-bit `gate_proj.weight` is a `(8388608, 1)` uint8 blob.

## int8 computes in float16

Everything else defaults to `bfloat16`. bitsandbytes implements LLM.int8() in float16 and warns *once per matmul* when handed anything else; float16 also measures closer. Llama-3.2-1B, layer-5 hidden norm:

| dtype | GPU | norm |
|---|---|---|
| `bfloat16` | 2.47 GB | 422.17 |
| `int8` (fp16 compute) | 1.50 GB | 422.07 |
| `int8` (bf16 compute) | 1.50 GB | 419.70 |
| `nf4` | 1.07 GB | 408.76 |
| `fp4` | 1.07 GB | 384.41 |

Override with `compute_dtype=` / `bnb_4bit_compute_dtype=`.

## Also fixes a silent mis-sizing

Found while testing this: torch carries `int1` through `int7` and reports every one as itemsize 1, so `bytes_per_element("int3")` returned `1.0` — nearly 3× the real width, for a format nothing here can load anyway. Sub-byte torch dtypes are now refused, pointing at the formats that can be.

## Known gap

The estimate under-counts by more than a padding factor absorbs — nf4 predicts 0.62 GB against 1.07 GB really allocated, because embeddings and the LM head stay 16-bit. Deferred, with a TODO carrying the measured numbers and the fix (it is derivable from the config `_remoteable_describe_checkpoint` already holds).

## Testing

40 new tests in `tests/test_quantization.py`; 885 pass overall. Verified on a live GPU against Llama-3.2-1B: load, meta-then-dispatch, trace, and the exact call shape NDIF's actor uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)