### PR TITLE
vLLM edits and n>1, interleaver hot path, and fixes from an interpretability sweep

### DIFF
--- a/bench_micro.py
+++ b/bench_micro.py
@@ -1,0 +1,137 @@
+"""Isolate the interleaver's per-visit Python cost.
+
+The vLLM capture benchmark showed nnsight paying ~2.5x bare vLLM at TP=1 and
+~4.7x at TP=2 for a job vllm-lens does at 1.7x/2.2x.  The suspected cause is
+structural rather than GPU-side: nnsight installs hooks on *every* module and
+`Interleaver.handle` fans each visit out to *every* mediator, so the work per
+forward scales with modules x invokes.
+
+This reproduces that shape on CPU with tensors small enough that the Python path
+dominates, so an optimization can be measured in seconds instead of GPU-minutes.
+
+    python bench_micro.py [--layers 32] [--invokes 64] [--repeats 5]
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+
+import torch
+import torch.nn as nn
+
+import nnsight
+from nnsight import NNsight
+
+HIDDEN = 8
+
+
+class Block(nn.Module):
+    """A decoder-ish block: enough submodules to match a real model's count."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.q = nn.Linear(HIDDEN, HIDDEN)
+        self.k = nn.Linear(HIDDEN, HIDDEN)
+        self.v = nn.Linear(HIDDEN, HIDDEN)
+        self.o = nn.Linear(HIDDEN, HIDDEN)
+        self.up = nn.Linear(HIDDEN, HIDDEN)
+        self.down = nn.Linear(HIDDEN, HIDDEN)
+        self.n1 = nn.LayerNorm(HIDDEN)
+        self.n2 = nn.LayerNorm(HIDDEN)
+
+    def forward(self, x):
+        h = self.n1(x)
+        h = self.o(self.q(h) + self.k(h) + self.v(h))
+        x = x + h
+        return x + self.down(self.up(self.n2(x)))
+
+
+class Net(nn.Module):
+    def __init__(self, layers: int) -> None:
+        super().__init__()
+        self.layers = nn.ModuleList([Block() for _ in range(layers)])
+
+    def forward(self, x):
+        for layer in self.layers:
+            x = layer(x)
+        return x
+
+
+class BatchedNet(NNsight):
+    """Rows-are-invokes batching, so one forward serves many mediators.
+
+    That is the shape the vLLM runtime produces (one flat batch, one mediator
+    per request) and the shape that makes `Interleaver.handle` fan out.
+    """
+
+    def _batch_size(self, *inputs, **kwargs) -> int:
+        return inputs[0].shape[0] if inputs else 0
+
+    def _batch(self, invokes, fn):
+        rows = [inputs[0] for inputs, _ in invokes]
+        return (torch.cat(rows, dim=0),), {}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--layers", type=int, default=32)
+    ap.add_argument("--invokes", type=int, default=64)
+    ap.add_argument("--repeats", type=int, default=5)
+    ap.add_argument("--target", type=int, default=16)
+    args = ap.parse_args()
+
+    torch.set_num_threads(1)
+    net = Net(args.layers)
+    model = BatchedNet(net)
+    n_modules = sum(1 for _ in net.modules())
+
+    x = torch.randn(1, HIDDEN)
+    inputs = [x.clone() for _ in range(args.invokes)]
+    target = model.layers[args.target]
+
+    # Baseline: the *same single batched forward* the trace runs, with no trace
+    # around it, so the difference is exactly what interleaving costs.  (Running
+    # 64 separate batch-1 forwards here would compare different amounts of work.)
+    batched = torch.cat(inputs, dim=0)
+
+    def bare():
+        net(batched)
+
+    def traced():
+        with model.trace() as tracer:
+            acts = nnsight.save([None] * len(inputs))
+            for i, inp in enumerate(inputs):
+                with tracer.invoke(inp):
+                    acts[i] = target.output
+        return acts
+
+    traced()  # warm
+
+    def timeit(fn):
+        ts = []
+        for _ in range(args.repeats):
+            t = time.perf_counter()
+            fn()
+            ts.append(time.perf_counter() - t)
+        return statistics.median(ts)
+
+    b = timeit(bare)
+    t = timeit(traced)
+    got = traced()
+    assert all(a is not None for a in got), "capture did not fill every slot"
+
+    print(f"modules={n_modules}  layers={args.layers}  invokes={args.invokes}")
+    print(f"bare forwards   {b*1000:8.1f} ms")
+    print(f"traced          {t*1000:8.1f} ms   ({t/b:.1f}x bare)")
+    print(f"interleave cost {(t-b)*1000:8.1f} ms")
+    # Visits are per (module, side); the mediator loop runs once per visit per
+    # mediator, which is the quantity an optimization has to bring down.
+    visits = n_modules * 2 * args.invokes
+    print(f"handle() calls  {visits:8d}   "
+          f"-> {(t-b)/visits*1e6:.2f} us per mediator-visit")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/concepts/envoy.md
+++ b/docs/concepts/envoy.md
@@ -3,7 +3,7 @@ title: Envoy
 one_liner: Envoy wraps a torch.nn.Module and mirrors its submodule tree, exposing .input / .inputs / .output as eproperty descriptors over Mediator.value / Mediator.swap, plus .skip (method) and .source (property).
 tags: [concept, mental-model, envoy]
 related: [docs/concepts/interleaver-and-hooks.md, docs/concepts/source-tracing.md, docs/concepts/threading-and-mediators.md]
-sources: [src/nnsight/intervention/envoy.py:105, src/nnsight/intervention/envoy.py:417, src/nnsight/intervention/envoy.py:494, src/nnsight/intervention/envoy.py:612, src/nnsight/intervention/envoy.py:682, src/nnsight/modeling/base.py:6]
+sources: [src/nnsight/intervention/envoy.py:105, src/nnsight/intervention/envoy.py:417, src/nnsight/intervention/envoy.py:494, src/nnsight/intervention/envoy.py:612, src/nnsight/intervention/envoy.py:726, src/nnsight/modeling/base.py:6]
 ---
 
 # Envoy
@@ -112,7 +112,7 @@ ValueError: Cannot access `model.0.output` outside of interleaving
 
 ## Calling a module inside a trace
 
-`Envoy.__call__(*args, hook=False, **kwargs)` (`envoy.py:682`) runs a module ad hoc, out of its place in the forward pass — the logit-lens idiom:
+`Envoy.__call__(*args, hook=False, **kwargs)` (`envoy.py:726`) runs a module ad hoc, out of its place in the forward pass — the logit-lens idiom:
 
 ```python
 with model.trace("The Eiffel Tower is in"):
@@ -121,7 +121,7 @@ with model.trace("The Eiffel Tower is in"):
     tok = logits[:, -1].argmax(-1).save()            # -> [262]  (" the")
 ```
 
-- **`hook=False` (default) while interleaving:** calls `module.forward(...)` directly, skipping PyTorch's hook dispatch. This both avoids re-firing the interleaver's hooks (which would try to switch into the very worker making the call) and leaves the module's real place in the forward untouched.
+- **`hook=False` (default) while interleaving:** runs the module the ordinary way, with this trace stood down for the duration. Its own hooks still fire — a runtime that keeps collectives in them (transformers tensor parallelism) still works — while nnsight serves no value and spends no occurrence, for this module *or anything under it*, so the call leaves its real place in the forward untouched.
 - **`hook=True`:** calls the full `module(...)` so its hooks fire and its submodules become addressable at `.submodule.output`. Use it for a module *attached* to the tree that isn't part of the real forward — an adapter, LoRA, or SAE applied in an edit.
 - **Outside a trace:** always the full `module(...)`.
 

--- a/docs/developing/vllm-integration.md
+++ b/docs/developing/vllm-integration.md
@@ -203,6 +203,37 @@ This mirrors `AsyncRemoteBackend`'s await/async-iterate shape. Sync differs by
 collecting inside `NNsightLLMEngine.step()`; async has no `step()` and collects
 per-request in the stream.
 
+## Registered blocks — the `registration.py` module
+
+`model.register()` is the persistent counterpart of the per-request transport
+above: instead of a mediator per request in `extra_args`, one block is sent to
+every rank via `collective_rpc("nnsight_register", ...)` and kept there.
+
+- `RegisteringTracer` (`registration.py`) captures the block like `EditingTracer`
+  but `execute` ships it rather than storing it on the envoy — an edit is
+  replayed by the envoy that holds it, which on vLLM leaves it in the client
+  where there are no weights.
+- `Requests.register` deserializes **once** and keeps `(code, glbls, lcls,
+  presaved)`; `Requests.add` builds a fresh `Mediator` per arriving request from
+  those pieces, so the source is compiled once rather than per request. That is
+  the whole performance argument for registering.
+- Registered copies are scoped, started, unflattened and `record_saves`-ed
+  alongside traced ones (`Requests.scope` runs them *first*, so a trace on the
+  same request sees what they left).
+- `Requests.harvest` moves a finished request's saves into `harvested`, driven by
+  `scheduler_output.finished_req_ids` in `_update_states` — **not** by
+  `collect_nnsight`, because a request nobody traced never triggers a collect.
+- `Registration.collect` merges across ranks (a registered block runs wherever
+  its layers live, so under PP the values are split across stages).
+
+Worker RPCs are exposed on `NNsightGPUWorker`, not the runner —
+`collective_rpc` resolves method names on the worker.
+
+**Prefix caching.** A cached token runs no forward, so no hook fires for it. A
+trace sets `skip_reading_prefix_cache` on its own request (`_attach_mediators`);
+a registration rides requests it did not create, so it cannot, and
+`_warn_if_prefix_caching` says so at register time.
+
 ## Serving over HTTP — the `serve/` package
 
 `serve/` (new) exposes `model.trace(..., serve=url)`: a GPU-less client holds only

--- a/docs/developing/vllm-integration.md
+++ b/docs/developing/vllm-integration.md
@@ -295,6 +295,17 @@ every rank via `collective_rpc("nnsight_register", ...)` and kept there.
 Worker RPCs are exposed on `NNsightGPUWorker`, not the runner —
 `collective_rpc` resolves method names on the worker.
 
+**Which runner.** vLLM has two GPU model runners: the original
+(`vllm/v1/worker/gpu_model_runner.py`), which `NNsightGPUModelRunner` subclasses,
+and a second one (`vllm/v1/worker/gpu/model_runner.py`) added later. From 0.27 the
+worker picks the second for every non-MoE model — `use_v2_model_runner` resolves to
+`is_default_v2_architecture or not is_moe`, so the architecture allow-list only
+governs MoE. `VLLM._require_v1_model_runner` sets vLLM's own
+`VLLM_USE_V2_MODEL_RUNNER=0` before the engine is built (the worker processes
+inherit it) and refuses an explicit `1`, since the alternative is an engine with no
+instrumentation whose first collect dies on a missing `collect_nnsight`. Porting
+the subclass to the V2 runner is the way out; until then this is the seam.
+
 **Prefix caching.** A cached token runs no forward, so no hook fires for it. A
 trace sets `skip_reading_prefix_cache` on its own request (`_attach_mediators`);
 a registration rides requests it did not create, so it cannot, and

--- a/docs/developing/vllm-integration.md
+++ b/docs/developing/vllm-integration.md
@@ -31,14 +31,14 @@ runs it against the real module, and ships saved values back.
 
 ## Two-process layout
 
-`VLLM(Remotable)` (`vllm.py:36`) exists in two processes:
+`VLLM(Remotable)` (`vllm.py`) exists in two processes:
 
 - **Client process.** `VLLM("gpt2")` builds a **meta** model (via vLLM's
-  `DummyModelLoader` with `load_weights` patched to a no-op, `vllm.py:155`) plus the
+  `DummyModelLoader` with `load_weights` patched to a no-op, `vllm.py`) plus the
   tokenizer. Its Envoy tree is read only for structure — a client never runs a
   forward. Used for writing traces and serializing them.
 - **Worker process(es).** vLLM spawns these with `worker_cls =
-  "nnsight.modeling.vllm.workers.GPUWorker.NNsightGPUWorker"` (`vllm.py:189`). The
+  "nnsight.modeling.vllm.workers.GPUWorker.NNsightGPUWorker"` (`vllm.py`). The
   worker builds a *second* `VLLM` Envoy over the actually-loaded module
   (`GPUModelRunner.load_model`), which owns the `Interleaver`, its `VLLMFragments` and the `VLLMBatcher`, and
   is where interventions run.
@@ -46,15 +46,15 @@ runs it against the real module, and ships saved values back.
 Model-parallel init happens in the client process before the meta build (vLLM builds
 real rank tensors and calls `.tolist()` on them, which a meta tensor can't serve),
 then is torn down before the real engine starts (`_init_distributed`/
-`_cleanup_distributed`, `vllm.py:74`/`:96`). The engine runs `enforce_eager=True` —
+`_cleanup_distributed` in `vllm.py`). The engine runs `enforce_eager=True` —
 hooks can't fire inside a captured CUDA graph.
 
 ### `mode="sync"` vs `mode="async"`
 
 The only switch is the constructor kwarg: `VLLM(..., mode="sync")` (default) or
-`mode="async"` (`vllm.py:57`, sets `self._async_engine`). Sync builds an `LLM` whose
-engine class is rebound to `NNsightLLMEngine` (`vllm.py:205`); async builds an
-`AsyncLLM` (`vllm.py:222`) with no engine subclass — collection happens in the
+`mode="async"` (`vllm.py`, sets `self._async_engine`). Sync builds an `LLM` whose
+engine class is rebound to `NNsightLLMEngine` (`vllm.py`); async builds an
+`AsyncLLM` (`vllm.py`) with no engine subclass — collection happens in the
 streaming backend instead.
 
 ## The transport: `extra_args["nnsight_mediator"]`
@@ -63,7 +63,7 @@ The intervention is compiled in the client but must run in the worker. NNsight u
 vLLM's built-in `SamplingParams.extra_args` — a dict field that survives both Ray
 (pickle) and multiprocessing (msgpack) — so no `SamplingParams` subclass is needed.
 
-`VLLM._attach_mediators(params, **kwargs)` (`vllm.py:403`) is the serialization
+`VLLM._attach_mediators(params, **kwargs)` (`vllm.py`) is the serialization
 boundary. For each mediator with a non-`None` `batch_group`:
 
 ```python
@@ -75,31 +75,31 @@ the mediator's block recompiles against the worker's Python; its `__globals__`
 (including referenced user variables) travel with it. Trace-level sampling kwargs
 fill in any `SamplingParams` field still at its default.
 
-On the worker, `Requests.add` (`GPUModelRunner.py:115`) deserializes each new
+On the worker, `Requests.add` (`GPUModelRunner.py`) deserializes each new
 request's mediator with `loads(..., persistent_objects=model._remoteable_persistent_objects())`
 (the tokenizer resolves by persistent ID). Requests with no nnsight payload — other
 tenants sharing the engine — are skipped.
 
 ## The three interleaver entry points
 
-`NNsightGPUModelRunner(GPUModelRunner)` (`GPUModelRunner.py:324`) is installed by
+`NNsightGPUModelRunner(GPUModelRunner)` (`GPUModelRunner.py`) is installed by
 `NNsightGPUWorker`, which rebinds `gpu_model_runner.GPUModelRunner` to the nnsight
-subclass **before** `Worker.__init__` resolves it (`GPUWorker.py:24`) — vLLM's own
+subclass **before** `Worker.__init__` resolves it (`GPUWorker.py`) — vLLM's own
 startup is not patched. The runner enters the interleaver at three points:
 
-1. **Forward** — `execute_model` (`GPUModelRunner.py:378`): runs
+1. **Forward** — `execute_model` (`GPUModelRunner.py`): runs
    `super().execute_model(...)` inside `with interleaver:`, so the module's hooks
    serve parked workers. Afterward `Requests.unflatten` switches each worker's batch
    group from per-token to per-row.
-2. **Logits** — `sample_tokens` (`:437`): offers the logits via
+2. **Logits** — `sample_tokens`: offers the logits via
    `type(model).logits.provide(model, original)`; if edited, rebuilds the state with
    the new tensor. Then captures all workers' saves in one pass (`record_saves`)
    while still on the workers' own thread.
-3. **Sampling** — `_sample` (`:466`): after `super()._sample(...)`, offers
+3. **Sampling** — `_sample`: after `super()._sample(...)`, offers
    `sampler_output.sampled_token_ids = type(model).samples.provide(model, ...)`.
 
 `logits`/`samples` are surfaced with the `eproperty` extension pattern — `VLLM.logits`
-(`vllm.py:144`) is an `@eproperty(description=...)` whose stub is an identity
+(`vllm.py`) is an `@eproperty(description=...)` whose stub is an identity
 preprocess of the served value; the client reads it (parking on
 `Mediator.value("model.logits")`) and the runner's
 `type(model).logits.provide(model, original)` is the produce side, forwarding to
@@ -107,32 +107,32 @@ preprocess of the served value; the client reads it (parking on
 `description` is what makes `.logits`/`.samples` show up in the model's repr (see
 [extending-envoy.md](./extending-envoy.md)).
 
-`_still_running()` (`:458`) filters to `mediator.alive` workers so re-entering the
+`_still_running()` filters to `mediator.alive` workers so re-entering the
 interleaver after the forward doesn't restart completed blocks. Errors are deferred
 per request (`interleaver.defer_exceptions = True`) and surfaced to the client via
-`raise_deferred`; a `tracer.stop()` is silent control flow. `_finish_erred` (`:430`)
+`raise_deferred`; a `tracer.stop()` is silent control flow. `_finish_erred`
 retires an erred/stopped request by forcing its next token to EOS.
 
 ## Continuous batching & the `Requests` helper
 
 vLLM concatenates all in-flight tokens into one `[total_tokens, hidden]` slab.
-`Requests` (`GPUModelRunner.py:97`) maps each mediator onto its own token span,
+`Requests` (`GPUModelRunner.py`) maps each mediator onto its own token span,
 recomputed every step:
 
-- `add(new_reqs, model)` (`:115`) deserializes new mediators from `extra_args`.
-- `scope(model)` (`:132`) sets each scheduled worker's `batch_group = [start,
+- `add(new_requests, persistent_objects)` deserializes new mediators from `extra_args`.
+- `scope(model)` sets each scheduled worker's `batch_group = [start,
   tokens]`, `mediator.start(interleaver)` on first schedule, and keeps finished
   workers scheduled only if they still hold caches or an exception. It orders by
   `list(self.input_batch.req_ids)` — **input-batch order, not scheduler order**,
   which `condense`/reorders can diverge from.
-- `unflatten(model)` (`:188`) re-points each scheduled worker to `[row, 1]` for the
+- `unflatten(model)` re-points each scheduled worker to `[row, 1]` for the
   per-request logits/samples tensors.
-- `match(request_ids)` (`:209`) reconciles engine ids with worker ids — vLLM appends
+- `match(request_ids)` reconciles engine ids with worker ids — vLLM appends
   a content hash, so engine `"0"` maps to worker `"0-<hash>"`.
-- `record_saves()` (`:229`) / `saves`/`error` (`:308`/`:316`) capture and read back
+- `record_saves()` / `saves` / `error` capture and read back
   each worker's saved names and any error, on the workers' thread (required because
   final collection may run on a different thread under Ray).
-- `finish_dangling(worker_id)` (`:258`) throws a still-parked worker at request end
+- `finish_dangling(worker_id)` throws a still-parked worker at request end
   into a `ValueError` (barrier) or `OutOfOrderError` (the run already ran past its
   location); an over-iterated `tracer.iter` only warns.
 
@@ -165,38 +165,55 @@ so none of that is needed. See [batching-internals.md](./batching-internals.md).
 
 ## Sync result collection
 
-`NNsightLLMEngine(LLMEngine)` (`engine.py:17`) overrides only `step()`: after
+`NNsightLLMEngine(LLMEngine)` (`engines/engine.py`) overrides only `step()`: after
 `super().step()`, for any finished request it calls
-`engine_core.collective_rpc("collect_nnsight", args=(finished, finished))`, picks the
-first non-`None` payload (only rank 0 holds sampled output), `pickle.loads` it, and
-attaches `output.saves` / `output.nnsight_error` to each `RequestOutput`.
-`VLLM._collect` (`vllm.py:382`) then `mark`s each saved value and writes it into the
-mediator's locals, and `raise_deferred`s any error.
+`collective_rpc("collect_nnsight", args=(finished, finished, by_id))` — the third
+argument is the finished `RequestOutput`s, which the worker cannot build and needs
+in order to serve `tracer.result` — merges the ranks with `merge_collected`, and
+`attach`es `saves` / `nnsight_saves` / `nnsight_error` to each output.
+`VLLM._collect` then `mark`s each saved value and writes it into the mediator's
+locals, and `raise_deferred`s any error.
 
-`collect_nnsight(request_ids, finished_request_ids)` (`GPUModelRunner.py:471`) runs
-on the worker: it matches ids, drains `finish_dangling` for finished ones, builds
-`{engine_id: {"saves", "error"}}`, pops finished mediators, `torch.cuda.synchronize`s,
-and returns `pickle.dumps(collected)`. `nnsight_request_count()` (`:526`) is a leak
-gauge — it should return to 0.
+Merged, **not** first-non-empty: a trace's values come from the reporting rank
+while an installed block's come from whichever rank ran the layers it read, and
+taking one payload would silently drop the other. Where two ranks report the same
+registered name — tensor parallelism, where each gathers the same whole value —
+the earliest rank's is kept, so the value lands on the device a traced one would.
+
+`collect_nnsight(request_ids, finished_request_ids, outputs=None)` runs on the
+worker and returns `pickle.dumps({engine_id: {"saves", "registered", "error"}})`.
+It harvests what finished, takes the registered values, serves `tracer.result`,
+throws `finish_dangling` into whatever is still parked, collects the saves, and
+pops finished mediators.
+
+**Every rank winds up its own workers; only one reports.** Each rank ran the block,
+so each holds a worker, a greenlet, and whatever that greenlet captured — all of it
+has to be released. Only rank 0's values are reported, since the reads are gathered
+and every rank holds the same ones. This used to be an early `return` for
+`get_pp_group().rank != 0`, which leaked every other rank's workers for the life of
+the engine: with no pipeline, that rank is the *global* rank, so under plain tensor
+parallelism every rank but 0 skipped its own cleanup. `nnsight_request_count()` is
+the leak gauge — it should return to 0 **on every rank**, which is what
+`tests/vllm/test_tensor_parallel.py::TestEveryRankWindsUp` pins.
 
 ## Async streaming
 
-`VLLMTracer(InterleavingTracer)` (`tracer.py:24`) splits the base tracer's
-`execute` in two: `prepare(code)` (`:27`) builds the invoke workers and assembles the
+`VLLMTracer(InterleavingTracer)` (`tracer.py`) splits the base tracer's
+`execute` in two: `prepare(code)` builds the invoke workers and assembles the
 call input **without running the model**, returning `(mediators, args, kwargs)`.
 
-`AsyncVLLMBackend(Backend)` (`async_backend.py:40`), injected by `VLLM.trace` when
+`AsyncVLLMBackend(Backend)` (`async_backend.py`), injected by `VLLM.trace` when
 `mode="async"`:
 
-- `__call__(tracer)` (`:48`) runs on `__exit__` while the frame is live: dispatches,
+- `__call__(tracer)` runs on `__exit__` while the frame is live: dispatches,
   `tracer.prepare(...)`, `_attach_mediators`, then starts
   `model.vllm_entrypoint.generate(prompt, param, request_id)` and stores the async
   generator. One prompt only (`NotImplementedError` otherwise).
-- `__aiter__` (`:82`) — `async for output in tracer.backend:` yields each step's
+- `__aiter__` — `async for output in tracer.backend:` yields each step's
   `RequestOutput`; on `output.finished` it collects saves via `collective_rpc(
   "collect_nnsight", ...)`, attaches `output.saves`, and `raise_deferred`s. If the
-  consumer stops early, `_free_worker` (`:101`) frees the aborted request's worker.
-- `__await__` (`:109`) — `await tracer.backend` drains the stream and returns the last
+  consumer stops early, `_free_worker` frees the aborted request's worker.
+- `__await__` — `await tracer.backend` drains the stream and returns the last
   output.
 
 This mirrors `AsyncRemoteBackend`'s await/async-iterate shape. Sync differs by
@@ -256,9 +273,11 @@ every rank via `collective_rpc("nnsight_register", ...)` and kept there.
   thread times out, and none is exposed), hence `__aenter__`/`__aexit__` and
   `aclear`. `__aenter__` spells out `__enter__`'s body rather than calling it,
   because `capture` reads the caller's frame at a fixed depth.
-- `Registration.install`/`clear` are the transport seam. `ServeRegistration`
-  overrides them to POST instead, for `model.edit(serve=url)` from a client with
-  no engine to `collective_rpc` into.
+- `Registration.install`/`uninstall` (and their awaited forms) are the transport
+  seam. `ServeRegistration` overrides those four to POST instead, for
+  `model.edit(serve=url)` from a client with no engine to `collective_rpc` into;
+  the idempotence guard and the `_installed_edits` bookkeeping stay on the base's
+  `clear`/`aclear`, so a third transport cannot forget them.
 - `VLLM._installed_edits` holds the live handles so `clear_edits()` can reach
   them; `Registration._forget` drops one as it clears.
 
@@ -281,13 +300,18 @@ the meta model, and a server holds one dispatched async `VLLM`.
   `ndif-api-key` header, and `uvicorn.run`s the app. Default host is loopback; it
   warns on `0.0.0.0` since it runs client-sent code.
 - `serve/server.py` — a FastAPI app. `POST /v1/nnsight/generate` takes a
-  `RequestModel.serialize(tracer)` blob, `_build_tracer` deserializes it (like
-  `RequestModel.deserialize`, plus restoring `tracer.node`), calls `prepare` +
+  `RequestModel.serialize(tracer)` blob, `_build_tracer` deserializes it
+  (`RequestModel.deserialize`, plus restoring `tracer.node`), calls `prepare` +
   `_attach_mediators`, runs each invoke through the engine, collects saves via
   `collect_nnsight`, and `torch.save`s `{"saves", "error"}` back (saved values only;
   a build or runtime error rides `error` with its real type + traceback). Worker
   building is synchronous (all before the first `await`), so concurrent requests
-  never interleave on the shared interleaver. `GET /health` reports readiness.
+  never interleave on the shared interleaver. `POST /v1/nnsight/register/{id}` and
+  `.../clear` install and drop a block on the server's engine — the HTTP form of the
+  `collective_rpc` an in-process `model.edit()` makes. `GET /health` reports
+  readiness, and `_ready()` is what every endpoint calls first.
+- `serve/http.py` — the headers, timeouts, and non-200 handling both client halves
+  share: `LocalServeBackend` sending a trace and `ServeRegistration` sending a block.
 - `serve/backend.py` — `LocalServeBackend(Backend)`, the client side of `serve=url`:
   serializes the trace, POSTs it, `torch.load`s the result, `raise_deferred`s any
   error, `mark`s the saves, and `push`es them into the caller's frame — so reading a
@@ -355,16 +379,16 @@ tests, and for the mediator payload to ride Ray's transport). See
 
 ## Key files
 
-- `src/nnsight/modeling/vllm/vllm.py` — `VLLM` (`:36`), `_attach_mediators` (`:403`),
-  `_collect` (`:382`), `trace` override (`:330`), `logits`/`samples` eproperties (`:144`)
+- `src/nnsight/modeling/vllm/vllm.py` — `VLLM`, `_attach_mediators`,
+  `_collect`, `trace` override, `logits`/`samples` eproperties
 - `src/nnsight/modeling/vllm/fragments.py` — `VLLMFragments`
 - `src/nnsight/modeling/vllm/batching.py` — `VLLMBatcher` (row scoping only)
-- `src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py` — runner (`:324`),
-  `Requests` (`:97`), `collect_nnsight` (`:471`)
-- `src/nnsight/modeling/vllm/engines/engine.py:17` — `NNsightLLMEngine` (sync)
-- `src/nnsight/modeling/vllm/async_backend.py:40` — `AsyncVLLMBackend`
-- `src/nnsight/modeling/vllm/tracer.py:24` — `VLLMTracer`
-- `src/nnsight/modeling/vllm/workers/GPUWorker.py:21` — `NNsightGPUWorker`
+- `src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py` — runner,
+  `Requests`, `collect_nnsight`
+- `src/nnsight/modeling/vllm/engines/engine.py` — `NNsightLLMEngine` (sync)
+- `src/nnsight/modeling/vllm/async_backend.py` — `AsyncVLLMBackend`
+- `src/nnsight/modeling/vllm/tracer.py` — `VLLMTracer`
+- `src/nnsight/modeling/vllm/workers/GPUWorker.py` — `NNsightGPUWorker`
 - `src/nnsight/modeling/vllm/serve/` — `cli.py`, `server.py`, `backend.py`
 
 ## Related

--- a/docs/developing/vllm-integration.md
+++ b/docs/developing/vllm-integration.md
@@ -203,6 +203,26 @@ This mirrors `AsyncRemoteBackend`'s await/async-iterate shape. Sync differs by
 collecting inside `NNsightLLMEngine.step()`; async has no `step()` and collects
 per-request in the stream.
 
+## Reading a request's outputs
+
+`VLLM.generate` is `trace` when used as a `with` block and a plain run when not —
+the same test `traceable` makes, via `WithBlockNotFoundError` from a `capture()`
+that finds no block. The plain form returns vLLM's `RequestOutput`s (an awaitable
+on `mode="async"`, since the async engine has no call that runs to completion),
+and `_generate_async` does its own collect because the streaming backend only
+runs for traces nnsight submitted.
+
+`NNsightLLMEngine.step` collects for **every** finished request, not only traced
+ones, and `merge_collected` merges across ranks rather than taking the first
+answer — a trace's values come from the rank holding the sampled output, a
+registered block's from whichever rank ran the layers it read.
+
+`attach` puts both on the output: `output.saves` carries them together, while
+`output.nnsight_saves` keeps the trace's own apart. That separation is load-
+bearing — `_collect` feeds only the latter to `merge_shared_saves`, which reads a
+name saved across several requests as one shared container and would otherwise
+fold a sweep's per-request values into one.
+
 ## Registered blocks — the `registration.py` module
 
 `model.register()` is the persistent counterpart of the per-request transport
@@ -223,8 +243,19 @@ every rank via `collective_rpc("nnsight_register", ...)` and kept there.
 - `Requests.harvest` moves a finished request's saves into `harvested`, driven by
   `scheduler_output.finished_req_ids` in `_update_states` — **not** by
   `collect_nnsight`, because a request nobody traced never triggers a collect.
-- `Registration.collect` merges across ranks (a registered block runs wherever
-  its layers live, so under PP the values are split across stages).
+- Values are taken at collect, not held: `collect_nnsight` pops them from
+  `harvested` into the entry that rides home on the output. It also harvests on
+  demand, because the scheduler's own pass happens at the top of the *next* step,
+  which on the async path may come later or (for the last request in flight)
+  never.
+- The registered portion is answered from **every** rank, the traced portion only
+  from rank 0 — a registered block runs wherever its layers live, so under PP its
+  values are not on rank 0.
+- Installing is synchronous on `LLM` and a coroutine on `AsyncLLM`; the latter can
+  only be awaited from inside the engine's own loop (a foreign loop on another
+  thread times out, and none is exposed), hence `__aenter__`/`__aexit__` and
+  `aclear`. `__aenter__` spells out `__enter__`'s body rather than calling it,
+  because `capture` reads the caller's frame at a fixed depth.
 
 Worker RPCs are exposed on `NNsightGPUWorker`, not the runner —
 `collective_rpc` resolves method names on the worker.
@@ -301,9 +332,13 @@ test guarding it):
 - **`defer_exceptions` must drop a worker on all TP ranks or none**, and the lazy
   gather in `VLLMFragments` assumes every rank runs identical mediators in lockstep — a
   rank-divergent error or a rank-local read hangs the collective.
-- **`tracer.result` is not served on vLLM.** Read generated tokens via `model.logits`/
-  `model.samples` (or the streamed `RequestOutput` in async), never `tracer.result`
-  (a worker would park on it forever).
+- **`tracer.result` is served from `collect_nnsight`, not `interleave`.** The block
+  runs in the worker and the `RequestOutput` is assembled by the engine, so the
+  collect is the first moment both exist — the engine passes `{request_id: output}`
+  alongside the ids and `Requests.serve_result` hands it to a worker parked on
+  `"result"`, before `finish_dangling` would throw into it. The worker binds its
+  name *after* the run's last `record_saves`, so `serve_result` re-takes that
+  snapshot (`Requests.record`) or the value comes home unbound.
 
 ## Testing
 

--- a/docs/developing/vllm-integration.md
+++ b/docs/developing/vllm-integration.md
@@ -225,7 +225,7 @@ fold a sweep's per-request values into one.
 
 ## Registered blocks — the `registration.py` module
 
-`model.register()` is the persistent counterpart of the per-request transport
+`model.edit()` is the persistent counterpart of the per-request transport
 above: instead of a mediator per request in `extra_args`, one block is sent to
 every rank via `collective_rpc("nnsight_register", ...)` and kept there.
 
@@ -256,6 +256,11 @@ every rank via `collective_rpc("nnsight_register", ...)` and kept there.
   thread times out, and none is exposed), hence `__aenter__`/`__aexit__` and
   `aclear`. `__aenter__` spells out `__enter__`'s body rather than calling it,
   because `capture` reads the caller's frame at a fixed depth.
+- `Registration.install`/`clear` are the transport seam. `ServeRegistration`
+  overrides them to POST instead, for `model.edit(serve=url)` from a client with
+  no engine to `collective_rpc` into.
+- `VLLM._installed_edits` holds the live handles so `clear_edits()` can reach
+  them; `Registration._forget` drops one as it clears.
 
 Worker RPCs are exposed on `NNsightGPUWorker`, not the runner —
 `collective_rpc` resolves method names on the worker.

--- a/docs/developing/vllm-integration.md
+++ b/docs/developing/vllm-integration.md
@@ -181,7 +181,18 @@ registered name — tensor parallelism, where each gathers the same whole value 
 the earliest rank's is kept, so the value lands on the device a traced one would.
 
 `collect_nnsight(request_ids, finished_request_ids, outputs=None)` runs on the
-worker and returns `pickle.dumps({engine_id: {"saves", "registered", "error"}})`.
+worker and returns
+`pickle.dumps({engine_id: {"saves", "registered", "error", "sequences"}})`.
+`sequences` is keyed by sampled-sequence index: `n > 1` fans a request into a child
+per sequence (`"{index}_{parent}"`, vLLM's `ParentRequest`), each of which runs its
+own copy of the block, so each is owed values of its own. `Requests.engine_key`
+resolves a worker id to `(engine_id, index)` — taking the child reading only when
+the parent it names is one the engine asked about, so an id that merely starts with
+digits and an underscore is not mistaken for somebody's second sequence. `saves` /
+`registered` stay the primary sequence's, so nothing changes for a caller that never
+sets `n`; `attach` puts each sequence's on `output.outputs[i].saves` and the trace's
+own on `output.nnsight_sequences`, which is what `VLLM._collect` pushes back as a
+list.
 It harvests what finished, takes the registered values, serves `tracer.result`,
 throws `finish_dangling` into whatever is still parked, collects the saves, and
 pops finished mediators.

--- a/docs/gotchas/integrations.md
+++ b/docs/gotchas/integrations.md
@@ -3,7 +3,7 @@ title: Integration Pitfalls
 one_liner: Wrapper-specific traps — deprecated model aliases, .source can't drill into submodule calls, auxiliary modules need hook=True, vLLM specifics.
 tags: [gotcha, transformers, source, vllm, sae, lora]
 related: [docs/models/transformers-model.md, docs/usage/source.md, docs/models/vllm.md]
-sources: [src/nnsight/modeling/language.py:19, src/nnsight/intervention/source.py:536, src/nnsight/intervention/envoy.py:682, src/nnsight/modeling/vllm/vllm.py]
+sources: [src/nnsight/modeling/language.py:19, src/nnsight/intervention/source.py:536, src/nnsight/intervention/envoy.py:726, src/nnsight/modeling/vllm/vllm.py]
 ---
 
 # Integration Pitfalls
@@ -80,7 +80,7 @@ with model.trace("Hello world"):
 You attach an SAE/adapter, call it inside a trace, and reading `aux.submodule.output` raises `OutOfOrderError` / never fires.
 
 ### Cause
-`Envoy.__call__` defaults to `hook=False` (`src/nnsight/intervention/envoy.py:682`): while interleaving it runs `module.forward(...)` directly, skipping PyTorch's hook dispatch, so the module's submodules aren't observable. Pass `hook=True` to route through `module(...)` so its hooks fire. Apply the aux module in an `edit()` (a default intervention replayed on every trace) and observe its internals in a subsequent trace.
+`Envoy.__call__` defaults to `hook=False`: while interleaving it runs the module normally but stands the trace down, so the module's submodules aren't observable. Pass `hook=True` to let the trace watch the call. Apply the aux module in an `edit()` (a default intervention replayed on every trace) and observe its internals in a subsequent trace.
 
 ### Right code
 ```python

--- a/docs/gotchas/iteration.md
+++ b/docs/gotchas/iteration.md
@@ -12,7 +12,7 @@ sources: [src/nnsight/intervention/iterator.py, src/nnsight/intervention/interle
 - The loop form is `for step in tracer.iter[...]:` (or `for step in tracer.all():`). The old `with tracer.iter[...]:` block still works but is **deprecated** and warns.
 - **`tracer.next()` / `module.next()` do not exist.** Use `tracer.iter[i]` / `tracer.iter[[i, j]]` to target specific steps.
 - Unbounded `tracer.iter[:]` (and `tracer.all()`, which *is* `iter[:]`) runs until the model stops producing steps. The final loop iteration asks for a step the model never runs, so the worker is **unwound there** — **any code after the loop in the same block does NOT run** (a warning is emitted, not an error). This is true even inside `generate(...)`; there is no `default_all` bound.
-- To run code after the loop, either bound the loop (`tracer.iter[:N]`) or move the trailing code into a **separate empty `tracer.invoke()`**.
+- To run code after the loop, move the trailing code into a **separate empty `tracer.invoke()`**. **Bounding the loop (`tracer.iter[:N]`) is not a reliable fix**: if the model stops early — EOS, a stop string, any generation shorter than `N` — the bounded loop parks on a step that never runs and drops the trailing code exactly as the unbounded form does (it warns: `'model.output.iN' was never reached`). Since `max_new_tokens` is only ever an *upper* bound, a bound cannot guarantee the loop completes. The empty-invoke form always works.
 - Values collected *during* the loop are kept even when the loop is unbounded — only trailing code is dropped.
 - `tracer.iter[N]` targets the `(N+1)`-th **occurrence** of a location. For a top-level block (once per step) that equals "step N"; for a module called several times per step, it's the call count.
 

--- a/docs/gotchas/modification.md
+++ b/docs/gotchas/modification.md
@@ -14,6 +14,7 @@ sources: [src/nnsight/intervention/envoy.py:448, src/nnsight/intervention/eprope
 - Assigning into a tuple output — `attn.output[0] = t` — raises `TypeError` (tuples don't support item assignment). Rebuild the tuple and assign the whole thing, or edit in place: `attn.output[0][:] = ...`.
 - To keep the "before" state of a value you're about to mutate, `.clone().save()` it first — otherwise `before` and `after` alias the same modified tensor.
 - Prefer replacing a **whole** tensor over an in-place slice-assign into a *tuple element* view across a barrier — the latter can crash. Assign the whole value instead.
+- Editing an **activation** is scoped to that run; editing a **weight** is permanent, and the syntax looks identical. There is no warning.
 
 ---
 
@@ -155,6 +156,59 @@ when the replacement is a new tensor (a reshape, a stack, an arithmetic result)
 that has to take the element's place.
 
 ---
+
+## A weight edit inside a trace is permanent
+
+### Symptom
+Two edits that read almost identically behave completely differently across runs:
+
+```python
+with model.trace(ids):                       # ACTIVATION -- scoped to this run
+    model.transformer.h[5].output[:] = 0
+
+with model.trace(ids):                       # WEIGHT -- permanent
+    model.transformer.wte.weight[100] = 0.0
+```
+
+```
+activation write: run differs from base: True | NEXT run back to baseline: True
+weight write    : run differs from base: True | NEXT run back to baseline: False
+                                              | wte[100] still zero: True
+```
+
+Every later trace in the process — and anything else holding that model — now runs
+against a modified checkpoint.
+
+### Cause
+Not an nnsight behaviour: `.output` is a value the interleaver hands you for the
+duration of the run, while `.weight` is the module's real `nn.Parameter`. Writing
+to it is an ordinary in-place mutation of the loaded model, and the trace block
+does not scope it. The trap is that `with model.trace(...)` reads like a scope for
+everything inside it.
+
+### Fix
+Save and restore around the edit, or work on a copy:
+
+```python
+saved = model.transformer.wte.weight[100].clone()
+try:
+    with model.trace(ids):
+        model.transformer.wte.weight[100] = 0.0
+        out = model.lm_head.output.save()
+finally:
+    model.transformer.wte.weight.data[100] = saved
+```
+
+For a persistent-but-reversible change, prefer [`model.edit()`](../usage/edit.md),
+which stores the intervention and can be undone with `clear_edits()`. For a
+genuine weight edit (ROME-style), do it deliberately and outside a trace, so the
+permanence is visible at the call site.
+
+Reading weights is of course fine, and composes with activations inside a trace.
+One related trap: before dispatch, a model's parameters are **meta** tensors —
+correct shape and dtype, no storage. Shape-preserving arithmetic on them succeeds
+silently and fails somewhere later, in torch's words rather than nnsight's. Pass
+`dispatch=True` (or run a trace) before reading weights.
 
 ## Related
 - [docs/usage/access-and-modify.md](../usage/access-and-modify.md) — reading and writing module values.

--- a/docs/models/language-model.md
+++ b/docs/models/language-model.md
@@ -57,7 +57,7 @@ print(model.tokenizer.decode(ids[0]))   # "...the city of New York City"
 
 # trace -> one forward
 with model.trace(PROMPT):
-    hidden = model.transformer.h[-1].output[0].save()
+    hidden = model.transformer.h[-1].output.save()
 ```
 
 - `generate` returns **token ids** (old nnsight's `generate` returned decoded records — that is now `model.pipe(...)`).

--- a/docs/models/tensor-parallel.md
+++ b/docs/models/tensor-parallel.md
@@ -80,6 +80,18 @@ final norm all arrive complete. Only two kinds of value are really a slice:
 | Whole modules | no | `model.layers[i].output`, `mlp.output`, `norm.output` |
 | The LM head | no — gathered by transformers | `lm_head.output` |
 | Embeddings | no — all-reduced | `embed_tokens.output` |
+| **Parameters** | **yes — not gathered** | `q_proj.weight`, `down_proj.weight` |
+
+Calling a sharded module **ad hoc** — the logit lens, `model.lm_head(hidden)` —
+is corrected the same way its activations are, so it returns the full-width
+result it would on one GPU.
+
+Parameters are the exception, and the one place a trace does not read as it would
+on one GPU: `layer.weight` is this rank's slice, at `1/tp_size` of the real
+width. Weights are what tensor parallelism exists to split, so nnsight does not
+quietly reassemble one — that would allocate the whole tensor on every rank, in
+the situation where memory was tight enough to reach for TP. Gather it yourself
+if you need it whole, and remember every rank must do so.
 
 The gather only fires when an intervention is actually parked on that location,
 so reading a handful of locations does not pay for the hundreds you ignored. A

--- a/docs/models/transformers-model.md
+++ b/docs/models/transformers-model.md
@@ -88,7 +88,7 @@ Any of them may be `None`. `model.pipeline` is always the underlying `transforme
 model = TransformersModel("openai-community/gpt2", dispatch=True)
 
 with model.trace("The Eiffel Tower is in the city of"):
-    hidden = model.transformer.h[-1].output[0].save()
+    hidden = model.transformer.h[-1].output.save()
     logits = model.output.logits.save()
 
 print(hidden.shape)                                   # torch.Size([10, 768])
@@ -136,7 +136,7 @@ with vit.pipe(image) as tracer:
 model = TransformersModel("openai-community/gpt2")     # not dispatched (meta)
 
 with model.scan("Hello World"):
-    shape = model.transformer.h[0].output[0].shape     # torch.Size([2, 768])
+    shape = model.transformer.h[0].output.shape     # torch.Size([2, 768])
 
 assert model.dispatched is False                        # scan never loads weights
 ```
@@ -203,7 +203,7 @@ import nnsight
 with model.generate(PROMPT, max_new_tokens=3, do_sample=False) as tracer:
     per_step = nnsight.save([])
     for step in tracer.iter[:3]:
-        per_step.append(model.transformer.h[0].output[0])
+        per_step.append(model.transformer.h[0].output)
 # per_step[0] is the full prompt; per_step[1:] are one cached token each
 ```
 
@@ -212,7 +212,7 @@ with model.generate(PROMPT, max_new_tokens=3, do_sample=False) as tracer:
 ```python
 # in-place zeroing
 with model.trace(PROMPT):
-    model.transformer.h[-1].output[0][:] = 0
+    model.transformer.h[-1].output[:] = 0
     logits = model.output.logits.save()
 
 # replacement / logit lens (ad-hoc module call, out of order)

--- a/docs/models/vllm.md
+++ b/docs/models/vllm.md
@@ -274,6 +274,19 @@ The router (`mlp.gate`, a `ReplicatedLinear`) is full and identical on every ran
 
 Individual experts are **not** addressable as submodules: vLLM stacks all local experts into fused weight tensors consumed by one grouped kernel, so there is no `experts[3]` to hook at any parallelism level. To ablate an expert, mask its router logit to `-inf` in `mlp.gate.output` instead.
 
+!!! warning "This recipe is vLLM-specific"
+    On **`TransformersModel`** it is a silent no-op. A transformers MoE block calls its
+    router as `_, top_k_weights, top_k_index = self.gate(hidden_states)` — element `[0]`,
+    the logits, is **discarded**, so masking it changes nothing (setting all 64 logits to
+    `-inf` gives `max|delta| = 0.0`). There, edit the *selection* instead: write the
+    routing weights or expert indices in `mlp.gate.output[1]` / `[2]`.
+
+    Two further transformers-side traps: with `norm_topk_prob=False` masking a weight
+    rescales all surviving experts, so a never-selected expert appears to have an effect
+    larger than a real below-median one — ablate by selection, not by weight. And the
+    router's `.input`/`.output` have **no batch axis** (`(B*T, E)`), so per-token stats
+    over a padded batch silently mix in pad rows.
+
 ## Async mode
 
 Construct with `mode="async"`; a trace then streams `RequestOutput`s. Iterate `tracer.backend` (an attribute, not a call):

--- a/docs/models/vllm.md
+++ b/docs/models/vllm.md
@@ -234,6 +234,71 @@ print(last.saves["logits"].shape)
 - Errors in the block surface when you iterate the stream (a `1/0` raises `RuntimeError: ...ZeroDivisionError`).
 - `remote=True` skips async-backend injection (`vllm.py:347`).
 
+## Registering a block on the engine
+
+A trace carries its block on the request it rides. That is the right shape for
+"run this one experiment", but it means a sweep serializes the same block once
+per prompt, and it can only touch requests that *are* nnsight traces.
+
+`model.register()` sends the block over once and leaves it there. Every request
+the engine runs afterwards gets its own copy — including requests submitted by
+something that never heard of nnsight, e.g. an OpenAI-API client on the same
+server. Each copy has its own scope, so what it saves is that request's, and the
+values wait on the worker until you collect them.
+
+```python
+model = VLLM("meta-llama/Llama-3.1-8B", dispatch=True, enable_prefix_caching=False)
+
+with model.register() as (tracer, registration):
+    hidden = model.model.layers[16].output[0].save()
+
+# Not traces — plain vLLM requests. The block still runs for them.
+model.vllm_entrypoint.generate(["The Eiffel Tower is in", "The capital of Japan is"], sp)
+
+results = registration.saves          # {request_id: {"hidden": tensor}}
+registration.clear()
+```
+
+The block is written exactly like a trace body — same envoy tree, same `.save()`.
+It belongs to no particular request, so there is **no `tracer.invoke(...)`**. The
+tracer is bound alongside the handle (as `model.edit()` binds `(tracer, edited)`)
+because `tracer.iter` / `tracer.all()` is what lets a registered block follow a
+request across its generated tokens rather than seeing only the prefill:
+
+```python
+with model.register() as (tracer, registration):
+    readout = nnsight.save([])
+    for step in tracer.all():
+        readout.append(model.model.layers[16].output[0][-1])
+```
+
+| Member | Description |
+|---|---|
+| `registration.saves` | `{request_id: {name: value}}` for every request that has finished. Reading does not drop anything. |
+| `registration.drain()` | The same, and takes them off the worker — what a long sweep wants. |
+| `registration.clear()` | Stop running the block and drop anything uncollected. |
+
+An error raised inside a registered block surfaces from `saves` / `drain()`; it
+has no request of its own to report through.
+
+Request ids are the engine's own, so they line up with `RequestOutput.request_id`.
+
+### When to register instead of trace
+
+- Sweeping many prompts — registering pays the serialization once instead of per
+  request. Capturing one layer over 1024 prompts on Llama-3.1-8B: **2.04 s
+  traced, 1.43 s registered** (bare vLLM 0.87 s).
+- Instrumenting traffic you don't control (a served endpoint, another client).
+- Keep tracing for one-off experiments, and whenever you want the values pushed
+  back into your own variables.
+
+> **Prefix caching must be off.** A prefix-cached token is served from the KV
+> cache without a forward pass, so no hook fires and a registered block sees a
+> short activation with no error. A trace asks for its own request to be
+> recomputed; a registration rides requests it did not create and cannot. Build
+> with `enable_prefix_caching=False` — registering against an engine that has it
+> on warns.
+
 ## Remote / serve
 
 - `trace(..., remote=True)` runs on NDIF. The model key is the repo id (`vllm.py:449`).

--- a/docs/models/vllm.md
+++ b/docs/models/vllm.md
@@ -82,7 +82,7 @@ print(model.tokenizer.decode(logits.argmax(dim=-1)))
 
 ### `logits` and `samples`
 
-These are vLLM-specific hookable values on the model — `eproperty` descriptors (the same mechanism behind a module's `.output`/`.input`, `vllm.py:144`), not on a vanilla `vllm.LLM`, and only meaningful inside a trace. **They are how you read generated output on vLLM** — `tracer.result` is *not* served here (see below).
+These are vLLM-specific hookable values on the model — `eproperty` descriptors (the same mechanism behind a module's `.output`/`.input`, `vllm.py:144`), not on a vanilla `vllm.LLM`, and only meaningful inside a trace. Read them for the logits and sampled ids of each step; for the finished request as a whole, read `tracer.result`.
 
 | Property | Description |
 |----------|-------------|
@@ -114,11 +114,32 @@ with model.trace(PROMPT, max_tokens=10) as tracer:
 # len(logits) == 10
 ```
 
-### `generate` is an alias for `trace`
+### `generate` traces, or just runs
 
-vLLM generation is driven by `max_tokens`, so there is no forward/generate split. `model.generate(...)` calls `trace` and rewrites `max_new_tokens` → `max_tokens` for parity with `TransformersModel` (`trace` accepts `max_new_tokens` too).
+vLLM generation is driven by `max_tokens`, so there is no forward/generate split. Used as a `with` block, `model.generate(...)` is `trace` (and rewrites `max_new_tokens` → `max_tokens`; `trace` accepts either).
 
-> Unlike `TransformersModel`, **`tracer.result` is not served on vLLM** — reading it parks a worker forever. Read the generated tokens through `model.logits` / `model.samples` under `tracer.iter`/`tracer.all()` (or the streamed `RequestOutput` in async mode).
+Called **without** a `with` block it simply runs the engine and returns vLLM's `RequestOutput`s — which is how you read a registered block's values without reaching past the model for `model.vllm_entrypoint`:
+
+```python
+outputs = model.generate(prompts, max_tokens=5)
+outputs[3].saves["hidden"]        # see Registering a block, below
+```
+
+On `mode="async"` the same call returns an awaitable: `outputs = await model.generate(...)`.
+
+### `tracer.result`
+
+`tracer.result` is the finished `RequestOutput` for the request an invoke made — one per invoke:
+
+```python
+with model.trace("The Eiffel Tower is in", temperature=0.0, max_tokens=3) as tracer:
+    hidden = model.model.layers[8].output[0].save()
+    result = tracer.result.save()
+
+result.outputs[0].text        # ' Paris, France'
+```
+
+It is served at collect time, which is the first moment both halves exist — the block runs in the engine's worker, the output is assembled by the engine. Two consequences: it carries the generation but **not** `.saves` (those are attached to the engine's own copy afterwards), and per-step values still come from `model.logits` / `model.samples` under `tracer.iter`, since `result` is the request's end state.
 
 ### Sampling parameters
 
@@ -243,8 +264,8 @@ per prompt, and it can only touch requests that *are* nnsight traces.
 `model.register()` sends the block over once and leaves it there. Every request
 the engine runs afterwards gets its own copy — including requests submitted by
 something that never heard of nnsight, e.g. an OpenAI-API client on the same
-server. Each copy has its own scope, so what it saves is that request's, and the
-values wait on the worker until you collect them.
+server. Each copy has its own scope, so what it saves is that request's, and it
+comes back on that request's output — the same place a trace's values arrive.
 
 ```python
 model = VLLM("meta-llama/Llama-3.1-8B", dispatch=True, enable_prefix_caching=False)
@@ -253,11 +274,15 @@ with model.register() as (tracer, registration):
     hidden = model.model.layers[16].output[0].save()
 
 # Not traces — plain vLLM requests. The block still runs for them.
-model.vllm_entrypoint.generate(["The Eiffel Tower is in", "The capital of Japan is"], sp)
+outputs = model.generate(["The Eiffel Tower is in", "The capital of Japan is"],
+                         max_tokens=5)
 
-results = registration.saves          # {request_id: {"hidden": tensor}}
+outputs[1].saves["hidden"]        # prompt 1's activations
 registration.clear()
 ```
+
+There is no id to join on: the value is on the output of the request that
+produced it. For a *traced* request, reach it through `tracer.result.saves`.
 
 The block is written exactly like a trace body — same envoy tree, same `.save()`.
 It belongs to no particular request, so there is **no `tracer.invoke(...)`**. The
@@ -274,14 +299,30 @@ with model.register() as (tracer, registration):
 
 | Member | Description |
 |---|---|
-| `registration.saves` | `{request_id: {name: value}}` for every request that has finished. Reading does not drop anything. |
-| `registration.drain()` | The same, and takes them off the worker — what a long sweep wants. |
-| `registration.clear()` | Stop running the block and drop anything uncollected. |
+| `registration.clear()` | Stop running the block. `await registration.aclear()` on an async engine. |
 
-An error raised inside a registered block surfaces from `saves` / `drain()`; it
-has no request of its own to report through.
+That is the whole handle — the values are not read through it. They are taken as
+they are collected, so nothing accumulates on the worker for as long as somebody
+is reading the outputs, which on the synchronous engine is every request there
+is. An error raised inside a registered block is re-raised where its values would
+have arrived.
 
-Request ids are the engine's own, so they line up with `RequestOutput.request_id`.
+### On an async engine
+
+Installing the block is a `collective_rpc`, which on `mode="async"` can only be
+awaited from inside the running loop — so use `async with`, and `aclear`:
+
+```python
+async with model.register() as (tracer, registration):
+    hidden = model.model.layers[16].output[0].save()
+
+outputs = await model.generate(prompts, max_tokens=5)
+outputs[1].saves["hidden"]
+
+await registration.aclear()
+```
+
+A plain `with` on an async engine raises rather than silently not installing it.
 
 ### When to register instead of trace
 
@@ -373,7 +414,7 @@ For GPT-2-style models: `model.transformer.h[i].attn.output`, `model.transformer
 
 - **A saved value comes back by its variable *name* — bind it.** `logits = model.logits.save()` works; a bare `model.logits.save()` marks the value but has no name to return it under, so `output.saves["logits"]` (async/serve) or the pushed-back local is silently missing. This is the most common "saves don't come back" bug on vLLM.
 - **Cross-invoke shared state does not merge.** A container declared outside the invokes and appended inside each one is serialized per request, so the appends don't come back — save per invoke (see [Continuous batching](#continuous-batching-multiple-invokes)).
-- **`tracer.result` is not served** — read output via `model.logits` / `model.samples`, not `tracer.result`.
+- **`tracer.result` is the finished `RequestOutput`, not per-step.** It carries the generation but not `.saves`; use `model.logits` / `model.samples` under `tracer.iter` for per-step values.
 - **An empty `tracer.invoke()` with interventions raises** (its work would vanish); a do-nothing empty invoke is a harmless no-op.
 - **A typo'd sampling kwarg raises** (`trace(temperatur=0.0)` → `TypeError`), rather than being silently ignored.
 - **Mode is fixed at construction.** Build with `mode="async"` if you want streaming.

--- a/docs/models/vllm.md
+++ b/docs/models/vllm.md
@@ -169,10 +169,21 @@ One prompt per invoke: a string, a list of token ids, a tokenizer's `{input_ids,
 ### Continuous batching (multiple invokes)
 
 Each invoke is one request; vLLM's continuous batcher processes them together.
-**Collect each invoke's values into its own saved variable** — a container declared
-outside the invokes and appended inside them does *not* merge back, because each
-invoke's intervention is serialized into its own request separately (unlike the
-in-process local path):
+Your block runs once per request, so a name saved in every invoke comes back as a
+**list**, one entry per invoke in order:
+
+```python
+with model.trace(temperature=0.0, max_tokens=1) as tracer:
+    for prompt in prompts:
+        with tracer.invoke(prompt):
+            hidden = model.transformer.h[5].output.save()
+
+hidden[0]        # the first invoke's, sized to its own prompt
+len(hidden)      # == len(prompts)
+```
+
+A name saved by exactly one invoke is that value, not a list of one — so giving
+each invoke a distinct name works too, and reads as it always did:
 
 ```python
 with model.trace(max_tokens=3) as tracer:
@@ -188,10 +199,52 @@ with model.trace(max_tokens=3) as tracer:
 print(model.tokenizer.decode(paris), model.tokenizer.decode(tokyo))
 ```
 
-For a **dynamic** number of prompts you can't give each invoke a distinct name in one
-trace, and a shared container won't merge. Instead fire each prompt as its **own**
-async trace concurrently (`asyncio.gather`) — the engine still batches the concurrent
-requests, and each one's saves arrive on its own finished `output`.
+For a **dynamic** number of prompts, save one name in every invoke and read the
+list — that is what the loop above does. Firing each prompt as its own async trace
+concurrently (`asyncio.gather`) also works, and each one's saves then arrive on its
+own finished `output`.
+
+A container bound *and saved* **above** the invokes is one object locally, so it
+stays one object here: its per-request copies are merged back element-wise, which
+is what makes the pre-sized-slot idiom work.
+
+```python
+with model.trace(temperature=0.0, max_tokens=1) as tracer:
+    rows = nnsight.save([None, None])
+    with tracer.invoke(prompt_a):
+        rows[0] = model.transformer.h[5].output
+    with tracer.invoke(prompt_b):
+        rows[1] = model.transformer.h[5].output
+```
+
+### Several sampled sequences (`n > 1`)
+
+`n=k` asks vLLM for k continuations of one prompt, and it fans the request into a
+child per sequence — so your block runs k times, once per sequence, against that
+sequence's own rows. Saved names come back as a list here for the same reason:
+
+```python
+with model.trace(prompt, max_tokens=5, temperature=1.0, n=3) as tracer:
+    hidden = model.transformer.h[5].output.save()
+    result = tracer.result.save()
+
+hidden[1]                        # sequence 1's
+result.outputs[1].text           # what sequence 1 sampled
+```
+
+`tracer.result` is **not** a list: a request has one `RequestOutput`, and the
+sequences are its `outputs[i]`.
+
+Where you hold outputs rather than variables — async, `serve=`, plain `generate`
+with an edit installed — the values ride the completion they belong to:
+
+```python
+output.outputs[i].saves["hidden"]   # sequence i's
+output.saves["hidden"]              # the primary sequence's, unchanged for n=1
+```
+
+Since the prompt is shared, each sequence's *prefill* agrees to kernel tolerance;
+they diverge over the tokens they go on to sample.
 
 ### Tensor parallelism is transparent
 
@@ -441,8 +494,8 @@ For GPT-2-style models: `model.transformer.h[i].attn.output`, `model.transformer
   ```
 
 - **A saved value comes back by its variable *name* — bind it.** `logits = model.logits.save()` works; a bare `model.logits.save()` marks the value but has no name to return it under, so `output.saves["logits"]` (async/serve) or the pushed-back local is silently missing. This is the most common "saves don't come back" bug on vLLM.
-- **Cross-invoke shared state does not merge.** A container declared outside the invokes and appended inside each one is serialized per request, so the appends don't come back — save per invoke (see [Continuous batching](#continuous-batching-multiple-invokes)).
-- **`tracer.result` is the finished `RequestOutput`, not per-step.** It carries the generation but not `.saves`; use `model.logits` / `model.samples` under `tracer.iter` for per-step values.
+- **One name saved by several runs comes back as a list** — one entry per invoke, and per sampled sequence when `n > 1`, in submission order. A name saved once stays that value. A container saved *above* the invokes is one object and merges instead (see [Continuous batching](#continuous-batching-multiple-invokes)).
+- **`tracer.result` is the finished `RequestOutput`, not per-step.** Use `model.logits` / `model.samples` under `tracer.iter` for per-step values. It is one object however many sequences `n` asked for, and it carries an installed edit's values but not the trace's own — those come back as your variables.
 - **An empty `tracer.invoke()` with interventions raises** (its work would vanish); a do-nothing empty invoke is a harmless no-op.
 - **A typo'd sampling kwarg raises** (`trace(temperatur=0.0)` → `TypeError`), rather than being silently ignored.
 - **Mode is fixed at construction.** Build with `mode="async"` if you want streaming.

--- a/docs/models/vllm.md
+++ b/docs/models/vllm.md
@@ -261,7 +261,7 @@ with model.trace("Hello", temperature=0.0):
     hidden = model.model.layers[16].output.save()   # full unsharded tensor
 ```
 
-`VLLMBatcher` (`batching.py`) gathers a `ColumnParallelLinear`/`RowParallelLinear` shard into the full tensor before your intervention reads it and re-splits on write, so every rank runs the same code on the same complete tensor. Verified in `tests/vllm/test_tensor_parallel.py`.
+`VLLMFragments` (`fragments.py`) gathers a `ColumnParallelLinear`/`RowParallelLinear` shard into the full tensor before your intervention reads it and re-splits on write, so every rank runs the same code on the same complete tensor. Calling one of those layers ad hoc (a logit lens) is corrected the same way. Parameters are not: `layer.weight` is this rank's slice. Verified in `tests/vllm/test_tensor_parallel.py`.
 
 ### Mixture-of-experts models and expert parallelism
 

--- a/docs/models/vllm.md
+++ b/docs/models/vllm.md
@@ -491,13 +491,19 @@ first for you and cannot arrange the second:
   CUDA (`RuntimeError: Cannot re-initialize CUDA in forked subprocess`). This is
   vLLM's own setting and applies with or without nnsight.
 
-**MoE on 0.27 is the one gap.** That release rebuilt the fused-experts layer
-around a factory and a modular kernel, and the flags that said whether its output
-was still a per-rank partial (`reduce_results`,
-`must_reduce_shared_expert_outputs`) are gone. Rather than guess at a collective,
-nnsight leaves those values alone there — so an MoE expert output read under
-tensor parallelism on 0.27 is one rank's, not the whole. On 0.26 and earlier it is
-gathered as documented above.
+**MoE reads differently on 0.27, and needs nothing from you.** That release
+rebuilt the fused-experts layer around a factory and a modular kernel, and moved
+the final all-reduce *inside* the layer — so its output is already the whole
+value, and there is nothing for nnsight to gather. Measured on a two-rank
+Qwen1.5-MoE: both ranks hand back the identical tensor. Through 0.26 the layer
+left a per-rank partial and nnsight gathered it, as described above; either way
+what you read is the whole thing.
+
+The one case 0.27 still leaves partial is a layer built to defer its reduce
+(`skip_final_all_reduce`), which nnsight gathers as before. A
+sequence-parallel MoE layer is split by rows rather than summed — a different
+correction, and one nnsight does not make yet, so that value is read as one rank's
+rows.
 
 ## Limitations
 

--- a/docs/models/vllm.md
+++ b/docs/models/vllm.md
@@ -164,7 +164,7 @@ Common kwargs: `temperature`, `top_p`, `top_k`, `min_p`, `max_tokens`, `stop`, `
 
 ### Input forms per invoke
 
-One prompt per invoke (`vllm.py:266`): a string, a list of token ids, or a tokenizer's `{input_ids, attention_mask}` dict. A list of strings / multiple prompts is rejected — use one invoke each.
+One prompt per invoke: a string, a list of token ids, a tokenizer's `{input_ids, attention_mask}` output, or one of vLLM's own prompt dicts (`TokensPrompt`, `TextPrompt`). A list of strings / multiple prompts is rejected — use one invoke each.
 
 ### Continuous batching (multiple invokes)
 
@@ -300,7 +300,7 @@ with model.edit() as (tracer, edit):
 | Member | Description |
 |---|---|
 | `edit.clear()` | Stop running the block. `await edit.aclear()` on an async engine. |
-| `model.clear_edits()` | Clear every edit still installed on the engine. |
+| `model.clear_edits()` | Clear every edit still installed. `await model.aclear_edits()` on an async engine. |
 
 That is the whole handle — the values are not read through it. They are taken as
 they are collected, so nothing accumulates on the worker for as long as somebody
@@ -327,7 +327,9 @@ outputs[1].saves["hidden"]
 await edit.aclear()
 ```
 
-A plain `with` on an async engine raises rather than silently not installing it.
+A plain `with` on an async engine raises rather than silently not installing it,
+and so does `clear_edits()` — a coroutine nobody awaits never runs, so a
+sync-looking call would leave every edit in place and say nothing.
 
 ### When to edit instead of trace
 

--- a/docs/models/vllm.md
+++ b/docs/models/vllm.md
@@ -246,6 +246,12 @@ output.saves["hidden"]              # the primary sequence's, unchanged for n=1
 Since the prompt is shared, each sequence's *prefill* agrees to kernel tolerance;
 they diverge over the tokens they go on to sample.
 
+On an **async** engine the sequences finish at different steps, and each streamed
+output carries only the completions that ended in that step — so the last one need
+not have all `n`. Accumulate across the stream by `completion.index`, or read the
+whole set off the finished output's `nnsight_sequences`, which is one dict of the
+trace's own saves per sequence, in order.
+
 ### Tensor parallelism is transparent
 
 ```python
@@ -466,6 +472,32 @@ model.model.norm.output
 ```
 
 For GPT-2-style models: `model.transformer.h[i].attn.output`, `model.transformer.h[i].mlp.output`. Print `model` to see the actual tree.
+
+## vLLM versions
+
+Tested against **0.16 through 0.27**, which is what nnsight's own suite runs on.
+Two things about newer engines are worth knowing, because nnsight arranges the
+first for you and cannot arrange the second:
+
+- **The model runner.** vLLM 0.27 ships a second GPU model runner and defaults to
+  it for every non-MoE model. nnsight's hooks arrive by subclassing the original
+  one, so it asks vLLM for that one (`VLLM_USE_V2_MODEL_RUNNER=0`) when it builds
+  the engine. Setting that variable to `1` yourself is refused rather than
+  overridden — the engine would otherwise come up with no interventions installed
+  and fail at the first collect with a missing method. Instrumenting the V2 runner
+  is not done yet.
+- **Tensor parallelism on 0.27 needs `VLLM_WORKER_MULTIPROC_METHOD=spawn`.** vLLM
+  forks its workers there by default, and a forked process cannot re-initialize
+  CUDA (`RuntimeError: Cannot re-initialize CUDA in forked subprocess`). This is
+  vLLM's own setting and applies with or without nnsight.
+
+**MoE on 0.27 is the one gap.** That release rebuilt the fused-experts layer
+around a factory and a modular kernel, and the flags that said whether its output
+was still a per-rank partial (`reduce_results`,
+`must_reduce_shared_expert_outputs`) are gone. Rather than guess at a collective,
+nnsight leaves those values alone there — so an MoE expert output read under
+tensor parallelism on 0.27 is one rank's, not the whole. On 0.26 and earlier it is
+gathered as documented above.
 
 ## Limitations
 

--- a/docs/models/vllm.md
+++ b/docs/models/vllm.md
@@ -118,11 +118,11 @@ with model.trace(PROMPT, max_tokens=10) as tracer:
 
 vLLM generation is driven by `max_tokens`, so there is no forward/generate split. Used as a `with` block, `model.generate(...)` is `trace` (and rewrites `max_new_tokens` → `max_tokens`; `trace` accepts either).
 
-Called **without** a `with` block it simply runs the engine and returns vLLM's `RequestOutput`s — which is how you read a registered block's values without reaching past the model for `model.vllm_entrypoint`:
+Called **without** a `with` block it simply runs the engine and returns vLLM's `RequestOutput`s — which is how you read an edit's values without reaching past the model for `model.vllm_entrypoint`:
 
 ```python
 outputs = model.generate(prompts, max_tokens=5)
-outputs[3].saves["hidden"]        # see Registering a block, below
+outputs[3].saves["hidden"]        # see Editing the engine, below
 ```
 
 On `mode="async"` the same call returns an awaitable: `outputs = await model.generate(...)`.
@@ -255,13 +255,13 @@ print(last.saves["logits"].shape)
 - Errors in the block surface when you iterate the stream (a `1/0` raises `RuntimeError: ...ZeroDivisionError`).
 - `remote=True` skips async-backend injection (`vllm.py:347`).
 
-## Registering a block on the engine
+## Editing the engine
 
 A trace carries its block on the request it rides. That is the right shape for
 "run this one experiment", but it means a sweep serializes the same block once
 per prompt, and it can only touch requests that *are* nnsight traces.
 
-`model.register()` sends the block over once and leaves it there. Every request
+`model.edit()` sends the block over once and leaves it there. Every request
 the engine runs afterwards gets its own copy — including requests submitted by
 something that never heard of nnsight, e.g. an OpenAI-API client on the same
 server. Each copy has its own scope, so what it saves is that request's, and it
@@ -270,7 +270,7 @@ comes back on that request's output — the same place a trace's values arrive.
 ```python
 model = VLLM("meta-llama/Llama-3.1-8B", dispatch=True, enable_prefix_caching=False)
 
-with model.register() as (tracer, registration):
+with model.edit() as (tracer, edit):
     hidden = model.model.layers[16].output[0].save()
 
 # Not traces — plain vLLM requests. The block still runs for them.
@@ -278,7 +278,7 @@ outputs = model.generate(["The Eiffel Tower is in", "The capital of Japan is"],
                          max_tokens=5)
 
 outputs[1].saves["hidden"]        # prompt 1's activations
-registration.clear()
+edit.clear()
 ```
 
 There is no id to join on: the value is on the output of the request that
@@ -286,12 +286,12 @@ produced it. For a *traced* request, reach it through `tracer.result.saves`.
 
 The block is written exactly like a trace body — same envoy tree, same `.save()`.
 It belongs to no particular request, so there is **no `tracer.invoke(...)`**. The
-tracer is bound alongside the handle (as `model.edit()` binds `(tracer, edited)`)
-because `tracer.iter` / `tracer.all()` is what lets a registered block follow a
+tracer is bound alongside the handle (as `Envoy.edit()` binds `(tracer, edited)`)
+because `tracer.iter` / `tracer.all()` is what lets an installed block follow a
 request across its generated tokens rather than seeing only the prefill:
 
 ```python
-with model.register() as (tracer, registration):
+with model.edit() as (tracer, edit):
     readout = nnsight.save([])
     for step in tracer.all():
         readout.append(model.model.layers[16].output[0][-1])
@@ -299,13 +299,18 @@ with model.register() as (tracer, registration):
 
 | Member | Description |
 |---|---|
-| `registration.clear()` | Stop running the block. `await registration.aclear()` on an async engine. |
+| `edit.clear()` | Stop running the block. `await edit.aclear()` on an async engine. |
+| `model.clear_edits()` | Clear every edit still installed on the engine. |
 
 That is the whole handle — the values are not read through it. They are taken as
 they are collected, so nothing accumulates on the worker for as long as somebody
 is reading the outputs, which on the synchronous engine is every request there
-is. An error raised inside a registered block is re-raised where its values would
+is. An error raised inside an installed block is re-raised where its values would
 have arrived.
+
+If an edit saves under the same name as the trace reading it, `output.saves`
+keeps the trace's — but the edit's own is still there under
+`output.nnsight_saves`. Different names avoid the question.
 
 ### On an async engine
 
@@ -313,32 +318,31 @@ Installing the block is a `collective_rpc`, which on `mode="async"` can only be
 awaited from inside the running loop — so use `async with`, and `aclear`:
 
 ```python
-async with model.register() as (tracer, registration):
+async with model.edit() as (tracer, edit):
     hidden = model.model.layers[16].output[0].save()
 
 outputs = await model.generate(prompts, max_tokens=5)
 outputs[1].saves["hidden"]
 
-await registration.aclear()
+await edit.aclear()
 ```
 
 A plain `with` on an async engine raises rather than silently not installing it.
 
-### When to register instead of trace
+### When to edit instead of trace
 
-- Sweeping many prompts — registering pays the serialization once instead of per
+- Sweeping many prompts — an edit pays the serialization once instead of per
   request. Capturing one layer over 1024 prompts on Llama-3.1-8B: **2.04 s
-  traced, 1.43 s registered** (bare vLLM 0.87 s).
+  traced, 1.43 s edited** (bare vLLM 0.87 s).
 - Instrumenting traffic you don't control (a served endpoint, another client).
 - Keep tracing for one-off experiments, and whenever you want the values pushed
   back into your own variables.
 
 > **Prefix caching must be off.** A prefix-cached token is served from the KV
-> cache without a forward pass, so no hook fires and a registered block sees a
+> cache without a forward pass, so no hook fires and an installed block sees a
 > short activation with no error. A trace asks for its own request to be
-> recomputed; a registration rides requests it did not create and cannot. Build
-> with `enable_prefix_caching=False` — registering against an engine that has it
-> on warns.
+> recomputed; an edit rides requests it did not create and cannot. Build with
+> `enable_prefix_caching=False` — editing an engine that has it on warns.
 
 ## Remote / serve
 
@@ -362,7 +366,20 @@ with model.trace("The Eiffel Tower is in", serve="http://127.0.0.1:8000", api_ke
 print(model.tokenizer.decode(logits.argmax(dim=-1)))
 ```
 
-The server returns saved values only (not generated tokens); build and runtime errors come back with their real type and traceback. See `src/nnsight/modeling/vllm/serve/`.
+The server returns saved values only — save `tracer.result` to get the finished `RequestOutput` back with them. Build and runtime errors come back with their real type and traceback. See `src/nnsight/modeling/vllm/serve/`.
+
+`model.edit(serve=url, api_key=...)` installs a block on the server's engine the same way, over `POST /v1/nnsight/register/{id}`:
+
+```python
+with model.edit(serve="http://127.0.0.1:8000") as (tracer, edit):
+    hidden = model.transformer.h[5].output.save()
+
+with model.trace("The Eiffel Tower is in", serve="http://127.0.0.1:8000") as tracer:
+    result = tracer.result.save()
+result.saves["hidden"]        # the edit's value, on the request it ran on
+
+edit.clear()
+```
 
 ## Special properties
 
@@ -391,6 +408,7 @@ For GPT-2-style models: `model.transformer.h[i].attn.output`, `model.transformer
 
 - **`enforce_eager=True` is forced** — costs some decode throughput, required for hooks.
 - **One prompt per invoke** — no `tracer.invoke(["a", "b"])`.
+- **No `tracer.barrier(n)`** — each invoke is its own request and the engine schedules them independently, so the blocks never run against the same forward. Calling it raises rather than hanging.
 - **No backward / gradients, no `.scan()`, no source tracing on fused CUDA kernels.**
 - **Text-only** — multimodal vLLM is not exposed.
 - **Version sensitivity** — targets vLLM's v1 architecture (`AsyncLLM` at `vllm.v1.engine.async_llm`).

--- a/docs/models/vllm.md
+++ b/docs/models/vllm.md
@@ -501,7 +501,7 @@ For GPT-2-style models: `model.transformer.h[i].attn.output`, `model.transformer
 - **Mode is fixed at construction.** Build with `mode="async"` if you want streaming.
 - **`tracer.backend` is iterable only in async mode.** In sync mode, results land in your local variables when the block exits.
 - **`logits` / `samples` don't exist on a vanilla `vllm.LLM`** — use them only inside a trace.
-- **Per-invoke kwargs override root kwargs.**
+- **Per-invoke kwargs override trace-level ones**, including when the value an invoke names happens to be vLLM's own default (`temperature=1.0`, `max_tokens=16`). Trace-level settings only fill in what an invoke did not name.
 - **`gpu_memory_utilization` defaults to 0.9** — lower it for small/shared GPUs (tests use 0.1).
 - **Async saves are finished-only** — for per-step saves, accumulate inside `tracer.iter[:]`.
 

--- a/docs/models/vllm.md
+++ b/docs/models/vllm.md
@@ -308,9 +308,17 @@ is reading the outputs, which on the synchronous engine is every request there
 is. An error raised inside an installed block is re-raised where its values would
 have arrived.
 
-If an edit saves under the same name as the trace reading it, `output.saves`
-keeps the trace's — but the edit's own is still there under
-`output.nnsight_saves`. Different names avoid the question.
+Two different objects carry these, which matters when the names collide:
+
+- **`tracer.result`** is the copy the *worker* hands your block, and it carries the
+  edit's values only — `result.saves["hidden"]` is the edit's even if your trace
+  saved `hidden` too, and there is no `nnsight_saves` on it. Your trace's own value
+  is not missing; it comes back as your variable, the way every traced value does.
+- **An output from `model.generate(...)`** is the engine's copy, assembled after the
+  fact: `output.saves` holds both kinds with the trace's winning a collision, and
+  `output.nnsight_saves` holds the trace's own apart.
+
+Different names avoid the question entirely.
 
 ### On an async engine
 

--- a/docs/patterns/logit-lens.md
+++ b/docs/patterns/logit-lens.md
@@ -25,6 +25,38 @@ Calling `model.lm_head(...)` inside a trace runs `forward()` directly and
 out of order without re-triggering the model. See
 `docs/usage/access-and-modify.md` ("Calling modules directly inside a trace").
 
+!!! warning "`lm_head.output` is not always the model's logits"
+
+    Some architectures post-process the head's output. **Gemma-2 and Gemma-3 apply
+    `tanh` logit softcapping after `lm_head`** (`final_logit_softcapping=30.0` in
+    the config), and `transformers` does it in `Gemma2ForCausalLM.forward`, *not*
+    inside `lm_head`:
+
+    ```python
+    logits = self.lm_head(hidden_states[:, slice_indices, :])
+    if self.config.final_logit_softcapping is not None:
+        logits = logits / self.config.final_logit_softcapping
+        logits = torch.tanh(logits)
+        logits = logits * self.config.final_logit_softcapping
+    ```
+
+    So on those models `model.lm_head.output` is the *pre-cap* logits: the top-1
+    token usually survives, but probabilities, entropies and perplexities do not —
+    one measured run reported a 46x perplexity error from this alone, with nothing
+    raising.
+
+    Check `model.config` for `final_logit_softcapping` before trusting any
+    probability you compute from `lm_head`. For the true logits use
+    `model.output.logits`; for a *lens* at layer L, apply the same cap yourself
+    after the head, so intermediate layers are read on the model's own scale:
+
+    ```python
+    cap = getattr(model.config, "final_logit_softcapping", None)
+    logits = model.lm_head(model.model.norm(hs))
+    if cap is not None:
+        logits = torch.tanh(logits / cap) * cap
+    ```
+
 Tutorial mirror: https://nnsight.net/notebooks/tutorials/logit_lens/
 
 ## When to use

--- a/docs/patterns/logit-lens.md
+++ b/docs/patterns/logit-lens.md
@@ -20,10 +20,10 @@ The residual stream at layer L is `h_L`. The model's final prediction is
 `lm_head(ln_f(h_L))` for L = 0, 1, 2, ... This often shows a smooth refinement:
 early layers predict generic frequent tokens, late layers converge on the answer.
 
-Calling `model.lm_head(...)` inside a trace runs `forward()` directly and
-**bypasses the interleaving hooks** — it is just the linear math you want, applied
-out of order without re-triggering the model. See
-`docs/usage/access-and-modify.md` ("Calling modules directly inside a trace").
+Calling `model.lm_head(...)` inside a trace runs the module with the trace
+**stood down** — it is just the linear math you want, applied out of order
+without re-triggering the model. See `docs/usage/access-and-modify.md`
+("Calling modules directly inside a trace").
 
 !!! warning "`lm_head.output` is not always the model's logits"
 

--- a/docs/patterns/sae-and-auxiliary-modules.md
+++ b/docs/patterns/sae-and-auxiliary-modules.md
@@ -263,8 +263,83 @@ accessor in `tests/test_language.py` (`Heads` / `TestCustomEnvoys`) and
   trace runs `forward` and skips hooks — the right default for `model.lm_head(...)`
   in a logit-lens recipe, but it means `.output`/`.input` on the aux module's
   submodules are never populated. Pass `hook=True` to opt into the hook path.
+- **`hook=True` only exposes `nn.Module` children.** It runs the attachment's
+  `__call__` so its *submodules* fire; bare `nn.Parameter`s and plain Python
+  methods are not hook points and never will be. Most pretrained SAEs ship as an
+  array file (Gemma Scope is a `.npz` of `W_enc`/`W_dec`/`threshold`), so a
+  faithful loader has no submodules at all and `sae.encode.output` raises
+  `AttributeError: 'function' object has no attribute 'output'`. Give each step
+  you want to read its own module — see below.
 - **Device placement** of the SAE must match the activation site
   (`sae.to(model.device)`).
+
+## Making a parameter-based SAE observable
+
+The SAE above is built from `torch.nn.Linear` submodules, so `sae.encoder.output`
+is a hook point for free. Real pretrained dictionaries usually are not: they ship
+as an array file, and a faithful loader holds bare parameters and does the work in
+plain methods.
+
+```python
+class RawSAE(torch.nn.Module):                     # nothing here is hookable
+    def __init__(self):
+        super().__init__()
+        self.W_enc = torch.nn.Parameter(...)
+        self.W_dec = torch.nn.Parameter(...)
+    def encode(self, x):
+        return torch.relu(x @ self.W_enc)
+    def forward(self, x):
+        return self.encode(x) @ self.W_dec
+```
+
+`encode` is a method, so `sae.encode.output` raises
+`AttributeError: 'function' object has no attribute 'output'`. The values are
+computed — there is just nowhere to hang a hook.
+
+**Fix: make every value you want to read pass through a module.** `WrapperModule`
+is an identity module that exists for exactly this — it returns its input
+unchanged, so routing a value through it costs nothing and makes it hookable.
+
+```python
+from nnsight.modeling.transformers import WrapperModule
+
+class ModuleSAE(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.encode = WrapperModule()              # now a hook point
+        self.decode = WrapperModule()
+        self.W_enc = torch.nn.Parameter(...)
+        self.W_dec = torch.nn.Parameter(...)
+        self.threshold = torch.nn.Parameter(...)
+
+    def forward(self, x):
+        pre = x @ self.W_enc
+        acts = self.encode(torch.relu(pre) * (pre > self.threshold))
+        return self.decode(acts @ self.W_dec)
+```
+
+Attach it, splice it in with an `edit`, and read its internals from any later
+trace:
+
+```python
+model.transformer.h[LAYER].sae = ModuleSAE().to(model.device)
+
+with model.edit(inplace=True):
+    acts = model.transformer.h[LAYER].output
+    model.transformer.h[LAYER].output[:] = model.transformer.h[LAYER].sae(acts, hook=True)
+
+with model.trace(prompt):
+    feats = model.transformer.h[LAYER].sae.encode.output.save()   # (B, S, n_features)
+    recon = model.transformer.h[LAYER].sae.decode.output.save()   # (B, S, d_model)
+```
+
+The `edit` matters: calling `sae(acts, hook=True)` inline and then reading
+`sae.encode.output` in the *same* trace body raises `OutOfOrderError`, because the
+call has already run the encoder by the time you ask for it.
+
+The same trick applies to anything you want to observe that is not already a
+module — an intermediate in a custom loss, a probe's pre-activation, a step inside
+an adapter. If you want to read it, route it through a module.
 
 ## Related
 

--- a/docs/reference/api-quick-reference.md
+++ b/docs/reference/api-quick-reference.md
@@ -102,6 +102,7 @@ Deprecated aliases (warn; use the `tracer.*` forms): `model.iter`, `model.all()`
 | `model.generator.streamer.output` | `TransformersModel` | Per-step generated tokens during decoding. |
 | `model.logits` | `VLLM` | This request's pre-sampling logits for the step. |
 | `model.samples` | `VLLM` | The token ids the sampler drew for the step. |
+| `model.edit` | `VLLM` | `with model.edit() as (tracer, edit):` — install a block on the engine, run for *every* request it handles; values arrive on `output.saves`. `edit.clear()` / `model.clear_edits()` stop it. Needs `enable_prefix_caching=False`. |
 
 ## Top-level functions
 

--- a/docs/reference/api-quick-reference.md
+++ b/docs/reference/api-quick-reference.md
@@ -81,7 +81,7 @@ Available on `model` and every wrapped submodule (`model.transformer.h[0].mlp`, 
 | Item | Signature | One-liner |
 |------|-----------|-----------|
 | `envoy.skip` | `envoy.skip(replacement)` | Bypass this module's forward, using `replacement` as its output. |
-| `envoy(...)` | `envoy(*args, hook=False, **kwargs)` | Ad-hoc apply the module to a value (e.g. logit lens). `hook=True` fires the module's own hooks — for adapters/SAEs/LoRA attached to the tree. |
+| `envoy(...)` | `envoy(*args, hook=False, **kwargs)` | Ad-hoc apply the module to a value (e.g. logit lens); the trace is stood down for the call, so it spends no occurrences. `hook=True` lets the trace watch it — for adapters/SAEs/LoRA attached to the tree. |
 | `envoy.get` | `envoy.get("transformer.h.0.mlp")` | Fetch a descendant envoy by dotted path. |
 | `envoy.modules` | `envoy.modules(include_fn=None, names=False)` | List all descendant envoys (optionally filtered / with paths). |
 | `envoy.named_modules` | `envoy.named_modules(include_fn=None)` | `modules(names=True)` — `(path, envoy)` pairs. |

--- a/docs/remote/remote-trace.md
+++ b/docs/remote/remote-trace.md
@@ -136,7 +136,7 @@ with model.trace("...", backend=backend):
 
 - Variables created **outside** the trace and mutated inside it won't be transmitted back. Create and `.save()` the value *inside* the block — see [remote-session.md](./remote-session.md).
 - The model identifier passed to `TransformersModel` must match an NDIF deployment. Run `nnsight.is_model_running("...")` before submitting.
-- A GPT-2 block's `.output` is a plain tensor `(batch, seq, hidden)` in current transformers — `model.transformer.h[i].output[0]` selects the first batch row. Attention submodules still return a tuple; don't assume — check `model.transformer.h[i].source`.
+- A GPT-2 block's `.output` is a plain tensor `(batch, seq, hidden)` in current transformers — `model.transformer.h[i].output` selects the first batch row. Attention submodules still return a tuple; don't assume — check `model.transformer.h[i].source`.
 - A `LOG` line that prints a multi-megabyte tensor floods the websocket. Print summaries, not raw tensors.
 - Local helper modules (anything not installed on the server) ship automatically via `pull_env`, or register them with `nnsight.register(...)`. See [register-local-modules.md](./register-local-modules.md).
 - Define helpers at module scope. Dynamically created functions (lambdas built in loops, `exec`-ed code) can confuse the source-based serializer.

--- a/docs/usage/access-and-modify.md
+++ b/docs/usage/access-and-modify.md
@@ -96,9 +96,9 @@ In-place modifications happen on the live tensor — reading `.output` again aft
 
 ```python
 with model.trace("Hello world"):
-    before = model.transformer.h[0].output[0].clone().save()  # pre-mod
-    model.transformer.h[0].output[0][:] = 0
-    after = model.transformer.h[0].output[0].save()           # post-mod
+    before = model.transformer.h[0].output.clone().save()  # pre-mod
+    model.transformer.h[0].output[:] = 0
+    after = model.transformer.h[0].output.save()           # post-mod
 # before is not all-zeros; after is all-zeros
 ```
 

--- a/docs/usage/access-and-modify.md
+++ b/docs/usage/access-and-modify.md
@@ -127,7 +127,7 @@ with model.trace("The Eiffel Tower is in the city of"):
 # model.tokenizer.decode(tok) -> ' Paris'
 ```
 
-While interleaving, `Envoy.__call__` calls `module.forward(...)` directly. Pass `hook=True` to opt back into the full `module(...)` path (its hooks fire, its submodules become observable) — used for a module attached to the tree that isn't part of the real forward pass (an adapter/LoRA/SAE applied in an edit). See `Envoy.__call__`.
+While interleaving, `Envoy.__call__` runs the module normally but stands the trace down, so nothing the call touches — the module or its submodules — serves a value or spends an occurrence. Pass `hook=True` to let the trace watch it too (its submodules become observable) — used for a module attached to the tree that isn't part of the real forward pass (an adapter/LoRA/SAE applied in an edit). See `Envoy.__call__`.
 
 ## Overloaded names
 

--- a/docs/usage/barrier.md
+++ b/docs/usage/barrier.md
@@ -173,6 +173,10 @@ still at site *i*.
 - **A barrier is per-trace.** Create it inside the `with model.trace()` block.
 - **An early `return` that skips a `barrier()` in one invoke hangs that round** —
   every participant must reach it.
+- **Not available on vLLM.** Each invoke there is a separate engine request,
+  scheduled independently, so the blocks never run against one forward — a barrier
+  could not release. `tracer.barrier(n)` raises `NotImplementedError` rather than
+  hanging.
 - **Reading a later site too early breaks an earlier one.** With several sites,
   put each source's read *after* the rounds for every site before it; requesting
   a location is what advances the model. See above.

--- a/docs/usage/barrier.md
+++ b/docs/usage/barrier.md
@@ -120,21 +120,21 @@ with model.trace() as tracer:
     b = tracer.barrier(3)
 
     with tracer.invoke(source_a):
-        a5 = model.transformer.h[5].output[0]   # site 1: mine, read it now
+        a5 = model.transformer.h[5].output   # site 1: mine, read it now
         b()                                     # round 1
         b()                                     # round 2: not mine, still attend
 
     with tracer.invoke(source_b):
         b()                                     # round 1: not mine — wait first
-        a8 = model.transformer.h[8].output[0]   # site 2: only now may I read
+        a8 = model.transformer.h[8].output   # site 2: only now may I read
         b()                                     # round 2
 
     with tracer.invoke(base):
         b()
-        h5 = model.transformer.h[5].output[0]   # site 1
+        h5 = model.transformer.h[5].output   # site 1
         h5[:, -1] = a5[:, -1]
         b()
-        h8 = model.transformer.h[8].output[0]   # site 2
+        h8 = model.transformer.h[8].output   # site 2
         h8[:, -1] = a8[:, -1]
         logits = model.lm_head.output[:, -1].save()
 ```
@@ -148,10 +148,10 @@ written there, and the write raises `OutOfOrderError`:
 
 ```python
     with tracer.invoke(source_a):
-        a5 = model.transformer.h[5].output[0]
+        a5 = model.transformer.h[5].output
         b()
     with tracer.invoke(source_b):
-        a8 = model.transformer.h[8].output[0]   # too early — advances past h[5]
+        a8 = model.transformer.h[8].output   # too early — advances past h[5]
         b()
 ```
 

--- a/docs/usage/cache.md
+++ b/docs/usage/cache.md
@@ -85,16 +85,32 @@ with model.trace("Hello") as tracer:
         detach=True,                 # detach from autograd (default)
         include_output=True,
         include_inputs=False,
-        non_blocking=True,           # async device transfer (default); set False to
-                                     # synchronize the copy (see note below)
+        non_blocking=False,          # default: synchronous copy. True is async and
+                                     # requires your own sync (see note below)
     )
 ```
 
-`non_blocking=True` (the default) makes the move to `device` asynchronous, which is
-faster and safe under nnsight's single-stream execution — captured values are read
-after the run (and any Python read syncs anyway). Set `non_blocking=False` only if
-you move captured tensors across CUDA streams yourself and need the copy finished
-before another stream reads them.
+!!! warning "`non_blocking=True` is opt-in, and unsafe unless you synchronise"
+
+    The move to `device` is enqueued asynchronously and **nothing synchronises
+    before you read the result**, so a capture off a CUDA device can be read while
+    the copy is still in flight. Reading a CPU tensor does *not* synchronise CUDA.
+
+    Measured on GPT-2, batch 128 x 64 tokens, 12 blocks captured, idle GPU:
+
+    | | differs from a plain `register_forward_hook` |
+    |---|---|
+    | `non_blocking=True` | **10/10 batches**, up to 100% of elements wrong |
+    | `non_blocking=False` (the default) | 0/10, bit-identical |
+
+    The values are not permanently wrong -- they arrive late; a
+    `torch.cuda.synchronize()` after the trace makes the same capture bit-exact.
+    The window scales with copy size, so a small example looks fine while a
+    corpus-scale run is silently corrupted. This is why the default is
+    `False`: correctness costs roughly 15-20% throughput, and the failure it
+    prevents is invisible.
+
+    Pass `non_blocking=True` only if you synchronise yourself before reading.
 
 ### Cache across generation steps
 
@@ -163,7 +179,7 @@ tracer.cache(
     detach=True,
     include_output=True,
     include_inputs=False,
-    non_blocking=True,            # async device transfer; False synchronizes it
+    non_blocking=False,           # default; True is async but needs your own sync
 )
 ```
 

--- a/docs/usage/cache.md
+++ b/docs/usage/cache.md
@@ -171,8 +171,9 @@ Returns a `CacheView` (already saved, so it survives past the trace).
 
 ## Gotchas
 
-- **Only modules reached *after* the `tracer.cache(...)` call are captured.** Call
-  it early (right after opening the trace).
+- **Declare `tracer.cache(...)` before reading or modifying a model value.** Cache
+  routes are fixed before the model starts; opening one after an activation access
+  raises `ValueError`.
 - **`tracer.cache()` must be called inside a trace.** It registers on the running
   worker's mediator; outside interleaving there is nothing to attach to.
 - **Multiple visits accumulate into a list.** Across generation steps (or a

--- a/docs/usage/cache.md
+++ b/docs/usage/cache.md
@@ -149,7 +149,7 @@ The cache observes post-intervention values:
 ```python
 with model.trace("Hello") as tracer:
     cache = tracer.cache()
-    model.transformer.h[0].output[0][:] = 0
+    model.transformer.h[0].output[:] = 0
 
 (cache["model.transformer.h.0"].output == 0).all()   # True
 ```

--- a/docs/usage/conditionals-and-loops.md
+++ b/docs/usage/conditionals-and-loops.md
@@ -42,9 +42,9 @@ with model.trace("Hello world"):
 
     # real tensor -> torch.all returns a real bool
     if torch.all(out < 1e5):
-        model.transformer.h[-1].output[0][:] = 0
+        model.transformer.h[-1].output[:] = 0
 
-    final = model.transformer.h[-1].output[0].save()
+    final = model.transformer.h[-1].output.save()
 ```
 
 `final` is all zeros — the branch was taken because `out` is a real tensor.
@@ -57,7 +57,7 @@ with model.trace("Hello world"):
     norm = hs.norm(dim=-1).mean()
 
     if norm > 10.0:                      # real 0-d tensor; Python calls __bool__
-        model.transformer.h[6].output[0][:] = 0
+        model.transformer.h[6].output[:] = 0
 
     final = model.output.logits.save()
 ```
@@ -69,8 +69,8 @@ def normalize(x):
     return (x - x.mean()) / x.std()
 
 with model.trace("Hello world"):
-    norm  = normalize(model.transformer.h[0].output[0]).save()   # helper call
-    means = [model.transformer.h[i].output[0].mean() for i in range(12)]
+    norm  = normalize(model.transformer.h[0].output).save()   # helper call
+    means = [model.transformer.h[i].output.mean() for i in range(12)]
     means = nnsight.save(means)          # save a list of tensors in one call
 ```
 

--- a/docs/usage/edit.md
+++ b/docs/usage/edit.md
@@ -35,12 +35,12 @@ model = TransformersModel("openai-community/gpt2", dispatch=True)
 
 # Store the edit on a copy; `model` stays clean.
 with model.edit() as (tracer, edited):
-    edited.transformer.h[0].output[0][:] = 0
+    edited.transformer.h[0].output[:] = 0
 
 with edited.trace("Hello world"):
-    out_edited = edited.transformer.h[0].output[0].save()    # zeros
+    out_edited = edited.transformer.h[0].output.save()    # zeros
 with model.trace("Hello world"):
-    out_original = model.transformer.h[0].output[0].save()   # unchanged
+    out_original = model.transformer.h[0].output.save()   # unchanged
 
 # len(model._edits) == 0 ; len(edited._edits) == 1
 ```
@@ -49,11 +49,11 @@ with model.trace("Hello world"):
 
 ```python
 with model.edit(inplace=True) as tracer:
-    model.transformer.h[1].output[0][:] = 0
+    model.transformer.h[1].output[:] = 0
 
 # Now every trace through model replays the edit
 with model.trace("Hello world"):
-    out = model.transformer.h[1].output[0].save()            # zeros
+    out = model.transformer.h[1].output.save()            # zeros
 ```
 
 ## Clearing edits
@@ -76,9 +76,9 @@ On every later trace, `Envoy.interleave` prepends `self._edits` to the run's med
 
 ```python
 with model.edit(inplace=True):
-    model.transformer.h[0].output[0][:] = 0     # first edit
+    model.transformer.h[0].output[:] = 0     # first edit
 with model.edit(inplace=True):
-    model.transformer.h[1].output[0][:] = 0     # second edit — both apply
+    model.transformer.h[1].output[:] = 0     # second edit — both apply
 
 # len(model._edits) == 2 ; they run in registration order on every trace
 ```
@@ -109,9 +109,9 @@ Edits ride with the model to a remote server — they live in `envoy._edits`, wh
 
 ```python
 with model.edit() as (tracer, edited):
-    edited.transformer.h[0].output[0][:] = 0
+    edited.transformer.h[0].output[:] = 0
 with edited.trace("The Eiffel Tower is in", remote="local"):
-    out = edited.transformer.h[0].output[0].save()   # zeros
+    out = edited.transformer.h[0].output.save()   # zeros
 ```
 
 ## Gotchas

--- a/docs/usage/extending.md
+++ b/docs/usage/extending.md
@@ -109,9 +109,9 @@ with model.trace(torch.rand(1, 5)):
     lens = model.logit_lens(h0).save()
 ```
 
-Calling `self[1](hidden)` inside a trace runs that module's forward directly,
-out of execution order, without re-firing the interleaver's hooks (see
-`Envoy.__call__`) — the logit-lens idiom.
+Calling `self[1](hidden)` inside a trace runs that module out of execution
+order with the trace stood down, so it serves no values and spends no
+occurrences (see `Envoy.__call__`) — the logit-lens idiom.
 
 ## 3. Attaching a standalone module
 

--- a/docs/usage/invoke-and-batching.md
+++ b/docs/usage/invoke-and-batching.md
@@ -50,7 +50,15 @@ with model.trace() as tracer:
 ```
 
 Each invoke's `.output` carries only that invoke's row(s). A batched last-token
-logit from an invoke equals the same prompt run on its own.
+logit from an invoke matches the same prompt run on its own **up to floating-point
+kernel selection** — not bit-for-bit. Measured drift on fp32 CUDA is ~2e-4 (GPT-2)
+and ~2e-5 (Llama-3.2-1B); it is a property of torch, not nnsight (nnsight's logits
+are `torch.equal` to raw HuggingFace at every batch size), it does not grow with
+batch size, and reruns are bit-identical. It is driven by the *shape* the kernel
+sees, so lengthening a sequence perturbs earlier positions by the same magnitude.
+In fp32 this is far below any real effect size; in **bf16** it is comparable to the
+metric quantum and can reorder a head ranking, so read a ranking metric through an
+fp32 head.
 
 ## Batched input (single invoke, list of strings)
 

--- a/docs/usage/iter-all-next.md
+++ b/docs/usage/iter-all-next.md
@@ -49,8 +49,8 @@ with model.generate("Hello", max_new_tokens=3, do_sample=False) as tracer:
 with model.generate("Hello", max_new_tokens=3, do_sample=False) as tracer:
     hidden = nnsight.save([])
     for step in tracer.all():                     # == tracer.iter[:]
-        model.transformer.h[0].output[0][:] = 0   # zero-ablate layer 0 every step
-        hidden.append(model.transformer.h[-1].output[0])
+        model.transformer.h[0].output[:] = 0   # zero-ablate layer 0 every step
+        hidden.append(model.transformer.h[-1].output)
 ```
 
 ## Variations
@@ -89,7 +89,7 @@ with model.generate("Hello", max_new_tokens=5, do_sample=False) as tracer:
 with model.generate("Hello", max_new_tokens=5, do_sample=False) as tracer:
     for step in tracer.iter[:5]:
         if step == 2:
-            model.transformer.h[0].output[0][:] = 0
+            model.transformer.h[0].output[:] = 0
         # other steps pass through
 ```
 
@@ -110,7 +110,7 @@ Prefer `for step in tracer.iter[...]:`.
 ```python
 with model.generate("Hello", max_new_tokens=3, do_sample=False) as tracer:
     with tracer.iter[:3]:            # DeprecationWarning
-        x = model.transformer.h[0].output[0].save()
+        x = model.transformer.h[0].output.save()
 ```
 
 ## Gotchas

--- a/docs/usage/source.md
+++ b/docs/usage/source.md
@@ -153,6 +153,26 @@ within one forward (e.g. an MoE expert loop) is indexed per fire.
   and on which versions.
 - **Requesting an operation out of execution order deadlocks → `OutOfOrderError`.**
   Reading `self_fc2_0.output` then `self_fc1_0.output` (fc1 runs first) is late.
+- **The *first* `.source` access on a module also raises `OutOfOrderError`, and it
+  is not an ordering mistake.** Instrumenting an operation rewrites the module's
+  forward, which can only happen *before* that forward runs. If the trace body
+  already read something, the model is mid-pass by the time the request lands, so
+  the instrumentation misses this pass and the interleaver reports it as having
+  run past the location. It is **per module** — warming `h[5].attn` does nothing
+  for `h[7].attn`, so a layer sweep hits it once per layer. Warm it up in a
+  throwaway trace first:
+
+    ```python
+    with model.trace(prompt):                        # warm-up: nothing else read
+        _ = model.transformer.h[5].attn.source.attention_interface_0.output[1].save()
+
+    with model.trace(prompt):                        # now the real trace works
+        qkv     = model.transformer.h[5].attn.c_attn.output.save()
+        pattern = model.transformer.h[5].attn.source.attention_interface_0.output[1].save()
+    ```
+
+    Accessing the source *first* in the block works too, but only when nothing you
+    need runs earlier in the forward — the warm-up trace has no such constraint.
 - **Skipping a whole module drops its source ops.** A skipped module's body never
   runs, so reading `skipped_module.source.<op>.output` is out of order. See
   [skip.md](skip.md).

--- a/docs/usage/trace.md
+++ b/docs/usage/trace.md
@@ -62,9 +62,9 @@ ValueError: trace() needs an input, or at least one `with tracer.invoke(...)` bl
 ```python
 with model.trace() as tracer:
     with tracer.invoke("The Eiffel Tower is in"):
-        out_a = model.transformer.h[0].output[0].save()
+        out_a = model.transformer.h[0].output.save()
     with tracer.invoke("The Colosseum is in"):
-        out_b = model.transformer.h[0].output[0].save()
+        out_b = model.transformer.h[0].output.save()
 ```
 
 Each invoke's body sees only its own rows of the batch. See `docs/usage/invoke-and-batching.md` for empty invokes, batching constraints, and barriers.

--- a/src/nnsight/intervention/barrier.py
+++ b/src/nnsight/intervention/barrier.py
@@ -85,7 +85,7 @@ class Barrier:
                 # raiser's request ends. Otherwise re-raise; the raiser's
                 # traceback is already stashed by Mediator.switch.
                 other.pending = None
-                other.exception = exception
                 interleaver = other.interleaver
                 if interleaver is None or not interleaver.defer_exceptions:
                     raise
+                other.exception = exception

--- a/src/nnsight/intervention/cache.py
+++ b/src/nnsight/intervention/cache.py
@@ -75,7 +75,7 @@ class Cache:
         detach: bool = True,
         include_output: bool = True,
         include_inputs: bool = False,
-        non_blocking: bool = True,
+        non_blocking: bool = False,
     ) -> None:
         self.model = model
         self.device = device

--- a/src/nnsight/intervention/cache.py
+++ b/src/nnsight/intervention/cache.py
@@ -136,11 +136,43 @@ class Cache:
         """
         return self._select(location) is not None
 
+    def subscriptions(self) -> "dict[str, tuple[str, str]] | None":
+        """The fixed locations this cache observes, or ``None`` for a wildcard.
+
+        A cache with an explicit module list can name every location it will ever
+        keep before the model starts. The interleaver uses that to route a value
+        directly to its caches instead of asking every cache about every hook.
+        ``modules=None`` deliberately remains a wildcard: it preserves the
+        existing behaviour of selecting every matching ``.input``/``.output``
+        location, including locations introduced later by source tracing.
+        """
+        if self.targets is None:
+            return None
+
+        subscriptions = {}
+        for path in self.targets:
+            if self.include_output:
+                subscriptions[f"{path}.output"] = (path, "output")
+            if self.include_inputs:
+                subscriptions[f"{path}.input"] = (path, "inputs")
+        return subscriptions
+
     def observe(self, location: str, value: Any) -> None:
         """Record ``value`` if ``location`` is a selected module's input/output."""
         selected = self._select(location)
         if selected is None:
             return
+
+        self.observe_selected(selected, value)
+
+    def observe_selected(self, selected: tuple[str, str], value: Any) -> None:
+        """Record a location the interleaver has already selected.
+
+        This is the fast counterpart to [`observe`][nnsight.intervention.cache.Cache.observe]:
+        an explicit-target cache receives its ``(path, slot)`` subscription from
+        the interleaver, so there is no second provider-string parse on the hot
+        path.
+        """
 
         path, key = selected
         self._record(path, key, self._transform(value))

--- a/src/nnsight/intervention/envoy.py
+++ b/src/nnsight/intervention/envoy.py
@@ -682,7 +682,9 @@ class Envoy:
         # Registered edits run first — prepend them so an edit's swap lands before a
         # trace intervention reads that location. They act on the whole batch (no
         # group); the interleaver's `prepare` has already added any invoke workers.
-        self.interleaver.mediators[:0] = self._edits
+        # Assigned rather than spliced in place, so this goes through the setter
+        # and the interleaver's index of who is parked where is re-derived with it.
+        self.interleaver.mediators = self._edits + self.interleaver.mediators
         result = None
         try:
             with self.interleaver:

--- a/src/nnsight/intervention/envoy.py
+++ b/src/nnsight/intervention/envoy.py
@@ -734,17 +734,20 @@ class Envoy:
                 hidden = model.transformer.h[-1].output
                 logits = model.lm_head(model.transformer.ln_f(hidden))
 
-        While interleaving, ``module.forward`` is called directly rather than
-        ``module(...)``, so PyTorch's hook dispatch is skipped. That both keeps
-        this ad-hoc call from re-firing the interleaver's hooks (which would try to
-        switch into the very worker greenlet making the call) and leaves the
-        module's real place in the forward pass untouched. Outside a trace it is an
-        ordinary module call.
+        While interleaving the module is called the ordinary way, with this
+        trace stood down for the duration. Its own hooks still fire — a runtime
+        that keeps collectives in them (transformers tensor parallelism) needs
+        them to — while nnsight serves nothing and spends no occurrence, for this
+        module *or anything under it*. That keeps the call from switching into
+        the very worker greenlet making it, and leaves the module's real place in
+        the forward pass untouched: calling a whole layer ad hoc does not consume
+        the occurrence its children's real visit was going to fill. Outside a
+        trace it is an ordinary module call.
 
-        Pass ``hook=True`` to force the full ``module(...)`` call so the module's
-        own hooks *do* fire. Use it for a module attached to the tree that isn't
-        part of the real forward pass — an adapter, LoRA, or SAE applied in an
-        edit — so its internals become observable at ``.submodule.output``::
+        Pass ``hook=True`` to let the trace watch the call too. Use it for a
+        module attached to the tree that isn't part of the real forward pass —
+        an adapter, LoRA, or SAE applied in an edit — so its internals become
+        observable at ``.submodule.output``::
 
             model.transformer.h[0].adapter = MyAdapter()
             with model.edit() as (tracer, edited):
@@ -766,19 +769,39 @@ class Envoy:
 
         Args:
             *args: Inputs to run the module's forward on.
-            hook: If ``False`` (default), run the forward directly while
-                interleaving, leaving the module's hooks — and its real place in
-                the forward pass — untouched. If ``True``, run the full
-                ``module(...)`` so its hooks fire and its submodules become
-                addressable; use it for a module attached to the tree rather than
-                one the forward pass already runs.
+            hook: Whether *nnsight* watches the call. If ``False`` (default)
+                the module runs normally, its own hooks and all, but this trace
+                is stood down for the duration — so neither this module nor
+                anything under it serves a value or spends an occurrence, and
+                its real place in the forward pass is untouched. If ``True``,
+                the trace watches too, so the call's internals are addressable
+                at ``.submodule.output``; use it for a module attached to the
+                tree rather than one the forward pass already runs.
             **kwargs: Keyword inputs to the module's forward.
 
         Returns:
             The module's output for these inputs.
         """
         if self.interleaver.interleaving and not hook:
-            return self._module.forward(*args, **kwargs)
+            # Run the module the ordinary way — its own hooks included — with
+            # only *this* interleaver stood down, so nothing the call touches is
+            # mistaken for the real forward pass. Switching the flag rather than
+            # dodging `__call__` matters twice over: hooks the module's runtime
+            # installed still fire (transformers keeps its tensor-parallel
+            # collectives in them, so calling `forward` directly returns one
+            # rank's slice), and the suppression reaches *submodules* too — a
+            # direct `forward` on a composite module leaves its children
+            # instrumented, so the ad-hoc call feeds their locations and steals
+            # the occurrence the real forward was going to fill.
+            #
+            # Restores the previous value rather than True, so this composes if
+            # anything ever calls it while already stood down.
+            interleaving = self.interleaver.interleaving
+            self.interleaver.interleaving = False
+            try:
+                return self._module(*args, **kwargs)
+            finally:
+                self.interleaver.interleaving = interleaving
         return self._module(*args, **kwargs)
 
     def __setattr__(self, name: str, value: Any) -> None:

--- a/src/nnsight/intervention/interleaver.py
+++ b/src/nnsight/intervention/interleaver.py
@@ -25,9 +25,9 @@ This module implements that dance with `greenlets <https://greenlet.readthedocs.
 * An [`Interleaver`][nnsight.intervention.interleaver.Interleaver] installs PyTorch hooks on the model's modules. As the
   forward pass reaches each location, the hook calls
   [`Interleaver.handle(location, value)`][nnsight.intervention.interleaver.Interleaver.handle], which offers
-  the value to every parked worker. A worker waiting on that location is served
-  the value (read) or has its replacement substituted in (swap); the possibly
-  edited value is returned back into the model's execution.
+  the value to the workers and caches interested in that location. A worker
+  waiting on it is served the value (read) or has its replacement substituted in
+  (swap); the possibly edited value is returned back into the model's execution.
 
 Because a worker and the model take strict turns on one thread, there are no
 locks or queues — only greenlet switches. Each [`Mediator`][nnsight.intervention.interleaver.Mediator] holds at most
@@ -382,22 +382,20 @@ class Mediator:
     def pending(self) -> Pending | None:
         """What this worker is parked on, or None when it isn't parked.
 
-        A property so that every park is recorded in the interleaver's
-        [`parked`][nnsight.intervention.interleaver.Interleaver.parked] set —
-        which is what lets the model side skip a location nobody wants — from the
-        one place that assigns this rather than the several that would otherwise
-        have to remember to. Only ever adds: see `parked` for why forgetting to
-        remove is the safe direction and forgetting to add would not be.
+        A property so every transition is routed through
+        [`Interleaver.park`][nnsight.intervention.interleaver.Interleaver.park].
+        That keeps the interleaver's provider wait counts current from the one
+        place that assigns a pending event.
         """
         return self._pending
 
     @pending.setter
     def pending(self, pending: Pending | None) -> None:
+        previous = self._pending
         self._pending = pending
-        if pending is not None and pending.provider is not None:
-            interleaver = self.interleaver
-            if interleaver is not None:
-                interleaver.parked.add(pending.provider)
+        interleaver = self.interleaver
+        if interleaver is not None:
+            interleaver.park(self, previous, pending)
 
     @property
     def alive(self) -> bool:
@@ -485,11 +483,8 @@ class Mediator:
         that step's requests follow the model sequentially rather than re-forcing
         the index.
         """
-        # Not parked on this location at all — the overwhelmingly common case, since
-        # a trace reads a handful of the hundreds of locations a forward passes
-        # through. Comparing the location alone settles it, which is why
-        # [`Pending`][nnsight.intervention.interleaver.Pending] keeps it apart
-        # from the occurrence rather than glued into one string.
+        # The interleaver normally calls this only for a worker routed to this
+        # location. Keep the guard for direct/unit calls and nested transitions.
         pending = self._pending
         if pending is None or pending.provider != provider:
             return value
@@ -585,22 +580,13 @@ class Interleaver:
     def __init__(self, fragments: Optional["Fragments"] = None) -> None:
         self.handles: dict[str, list[torch.utils.hooks.RemovableHandle]] = {}
         self._mediators: list[Mediator] = []
-        # The locations a worker has parked on since this set was last rebuilt —
-        # what lets `handle` recognize "nobody wants this one" without walking the
-        # workers, since a forward passes through hundreds of locations and a trace
-        # asks for a handful.
-        #
-        # Deliberately a *superset*, not an exact tally: workers are only ever
-        # added, and the set is rebuilt when the worker list is replaced. Being
-        # wrong in that direction is free — a location no one is parked on any more
-        # costs one walk that finds nothing. Being wrong the other way is not: a
-        # missing entry makes `handle` skip a worker that *was* waiting, and its
-        # read goes unanswered with nothing to show for it. So the cheap mistake is
-        # the only one this can make.
-        self.parked: set[str] = set()
-        # Whether any worker holds a `tracer.cache()`. A cache wants locations
-        # nobody is parked on, so it disables the skip.
-        self.caching = False
+        # Exact number of workers waiting on each provider. An explicit-target
+        # cache is in one list per location it keeps. Wildcard caches remain
+        # separate because their target locations are only known when a hook fires.
+        # `reindex` rebuilds all three whenever the active worker list changes.
+        self.waiting: dict[str, int] = {}
+        self.observers: dict[str, list[tuple[Mediator, Any, tuple[str, str]]]] = {}
+        self.wildcard_observers: list[tuple[Mediator, Any]] = []
         # What, if anything, makes a value at a location whole before workers see
         # it — see intervention/fragments.py. None on an ordinary model, and on a
         # distributed one it is the runtime's own object. Kept as a collaborator
@@ -630,10 +616,10 @@ class Interleaver:
     def mediators(self) -> list["Mediator"]:
         """The workers this run serves.
 
-        Replacing the list rebuilds [`parked`][nnsight.intervention.interleaver.Interleaver.parked]
-        from it, so a driver that hands over a different set each step (vLLM
-        reschedules per step, and a worker can stay parked across several) never
-        leaves the index describing workers that are no longer being served.
+        Replacing the list rebuilds the wait counts and cache indexes, so a driver
+        that hands over a different set each step (vLLM reschedules per step, and
+        a worker can stay parked across several) never leaves an old worker in a
+        provider's route.
         """
         return self._mediators
 
@@ -643,25 +629,79 @@ class Interleaver:
         self.reindex()
 
     def reindex(self) -> None:
-        """Re-derive `parked` and `caching` from the workers as they are now.
+        """Rebuild provider wait counts and cache routes from active workers.
 
-        Run at the start of every run and whenever the worker list is replaced, so
-        neither index can carry anything over from the last one. That matters
-        because the list is not always *replaced*: the local path appends to it and
-        `cancel` empties it in place, so a version that only rebuilt on assignment
-        went stale — one ``tracer.cache()`` left `caching` true for the life of the
-        model, quietly costing every later trace the walk this exists to skip.
-
-        Re-derive rather than clear: a worker parked across a re-entered
-        interleaver must stay in `parked`, and dropping it is the one direction
-        that loses a read.
+        The list is intentionally mutable — local tracing appends workers, while
+        vLLM replaces it as the scheduler changes the active requests — so the
+        execution boundaries call this before hooks run. Individual parks then
+        update `waiting` incrementally through [`Mediator.pending`][nnsight.intervention.interleaver.Mediator.pending].
         """
-        self.parked = {
-            mediator.pending.provider
-            for mediator in self._mediators
-            if mediator.pending is not None and mediator.pending.provider is not None
-        }
-        self.caching = any(mediator.caches for mediator in self._mediators)
+        self.waiting = {}
+        self.observers = {}
+        self.wildcard_observers = []
+
+        for mediator in self._mediators:
+            pending = mediator.pending
+            if pending is not None and pending.provider is not None:
+                self.waiting[pending.provider] = (
+                    self.waiting.get(pending.provider, 0) + 1
+                )
+            for cache in mediator.caches:
+                subscriptions = cache.subscriptions()
+                if subscriptions is None:
+                    self.wildcard_observers.append((mediator, cache))
+                else:
+                    for provider, selected in subscriptions.items():
+                        self.observers.setdefault(provider, []).append(
+                            (mediator, cache, selected)
+                        )
+
+    def park(
+        self,
+        mediator: Mediator,
+        previous: Pending | None,
+        pending: Pending | None,
+    ) -> None:
+        """Move one worker between provider waiting counts.
+
+        This is the sole incremental mutation path: assigning `pending` is what a
+        worker does whenever it parks, resumes, reaches a barrier, or finishes.
+        `reindex` establishes the current workers at run boundaries; a count is
+        enough here because `handle` already walks every worker to bump its
+        occurrence counter.
+        """
+        # vLLM starts a request before it hands the new scheduled list to the
+        # interleaver. It will be included by that following reindex; until then,
+        # it must not affect the current step's counts.
+        if mediator not in self._mediators:
+            return
+        old_provider = None if previous is None else previous.provider
+        new_provider = None if pending is None else pending.provider
+        if old_provider == new_provider:
+            return
+        if old_provider is not None:
+            remaining = self.waiting.get(old_provider, 0) - 1
+            if remaining > 0:
+                self.waiting[old_provider] = remaining
+            else:
+                self.waiting.pop(old_provider, None)
+        if new_provider is not None:
+            self.waiting[new_provider] = self.waiting.get(new_provider, 0) + 1
+
+    def _observers_for(
+        self, provider: str
+    ) -> list[tuple[Mediator, Any, tuple[str, str]]]:
+        """The caches that keep this provider."""
+        selected = self.observers.get(provider, [])
+        if not self.wildcard_observers:
+            return selected
+
+        matched = list(selected)
+        for mediator, cache in self.wildcard_observers:
+            selection = cache._select(provider)
+            if selection is not None:
+                matched.append((mediator, cache, selection))
+        return matched
 
     def __enter__(self) -> Interleaver:
         """Begin interleaving: arm the hooks and start each not-yet-started worker.
@@ -703,42 +743,6 @@ class Interleaver:
         # An EarlyStopException means an intervention asked to halt the run; it
         # has done its job unwinding the model, so swallow it here.
         return exc_type is EarlyStopException
-
-    def observed(self, provider: str) -> bool:
-        """Whether anything is waiting on *this* visit to ``provider``.
-
-        Mirrors the match [`Mediator.handle`][nnsight.intervention.interleaver.Mediator.handle]
-        makes — a worker parks already carrying the occurrence it wants, so this
-        compares the same location and count. Deliberately not "is any worker
-        parked anywhere": a worker waiting on a *later* iteration of this location
-        must not trigger work now.
-
-        Reached only from `handle`, and only past its
-        [`parked`][nnsight.intervention.interleaver.Interleaver.parked] gate — so
-        this walks the workers for the handful of locations something wants, not
-        for every location a forward passes through. Repeating that gate here
-        would be dead: `handle` has already returned when it holds.
-
-        A ``tracer.cache()`` counts too — it would otherwise record fragments —
-        but only for the locations it actually keeps. A cache is usually scoped to
-        a handful of modules, so asking it (rather than assuming any open cache
-        wants everything) is the difference between a few collectives and one at
-        every sharded module in the model.
-
-        Used to gate the gather in `handle`. Every rank evaluates it over the same
-        block, so it answers the same everywhere.
-        """
-        for mediator in self._mediators:
-            pending = mediator.pending
-            if (
-                pending is not None
-                and pending.provider == provider
-                and pending.iteration == mediator.iterations[provider]
-            ):
-                return True
-            if any(cache.wants(provider) for cache in mediator.caches):
-                return True
-        return False
 
     def instrument(self, envoy: Envoy) -> None:
         """Install this interleaver's forward hooks on an envoy's module.
@@ -795,91 +799,100 @@ class Interleaver:
         ]
 
     def handle(self, provider: str, value: Any) -> Any:
-        """Offer ``value`` at ``provider`` to every mediator; return it, edited if
-        any intervention wrote to this location.
+        """Route ``value`` to this provider's consumers; return it, edited if any
+        intervention wrote to this location.
 
-        After the mediators run, the (now post-intervention) value is offered to
-        any active caches, so ``tracer.cache()`` records the values interventions
-        actually produced. A cache belongs to one worker, so it sees that worker's
-        own rows of the batch — narrowed the same way the worker's reads are.
-        Caches select which locations to keep themselves.
+        The provider index picks only workers parked here and caches that selected
+        it. Iteration counts are deliberately different: they are still bumped for
+        *every active mediator on every hook*, because a worker that is waiting at
+        another location must know this occurrence has passed when it later asks
+        for ``provider``.
         """
-        # Only where something is waiting. A forward passes through hundreds of
-        # locations and a trace asks for a handful, so on nearly every visit no
-        # worker's view of the run can differ whether or not this runs — and
-        # without the check every worker would be consulted about every location.
-        if provider in self.parked or self.caching:
-            # A fragment is made whole before any worker sees it, and only when
-            # one is actually waiting: a collective at every other location would
-            # cost far more than the reads do. `observed` answers the same on
-            # every rank, which is what keeps their collectives matched.
-            gathering = False
-            if (
-                self.fragments is not None
-                and self.fragments.enabled
-                and self.observed(provider)
-            ):
-                self.fragments.read(provider)
-                if self.fragments.fragmented(provider):
-                    gathering = True
-                    value = self.fragments.whole(provider, value)
-
-            for mediator in self._mediators:
-                try:
-                    value = mediator.handle(provider, value)
-                    # Tallied here, in the pass that is already walking the
-                    # workers. After this worker has been served, never before:
-                    # a block that reads a location and then writes it re-parks
-                    # mid-visit, and `Mediator.event` tags that re-park with the
-                    # count as it stands — bumping first would tag it for the
-                    # *next* visit and strand the write until the model came
-                    # round again. Skipped for a worker that raised, which is
-                    # done and whose count no longer means anything.
-                    mediator.iterations[provider] += 1
-                except Exception as exception:
-                    # Record the worker's exception on its mediator — a stop's
-                    # EarlyStopException or a real error, treated the same here.
-                    mediator.exception = exception
-                    if not self.defer_exceptions:
-                        # Not deferring: let it propagate, so a local run unwinds
-                        # the forward (a stop is swallowed at the top; an error
-                        # surfaces).
-                        raise
-                    # Deferring: this worker is done; carry on serving the others,
-                    # and leave it to the driver to end this worker's request.
-
-            # A batched skip left its invokes' replacements gathered rather than
-            # one value; concatenate them into the combined output (see
-            # Batcher.gather_skip).
-            if self.batcher is not None:
-                value = self.batcher.assemble_skip(value)
-
-            for mediator in self._mediators:
-                if not mediator.caches:
-                    continue
-                served = (
-                    value
-                    if self.batcher is None
-                    else self.batcher.narrow(value, mediator.batch_group)
-                )
-                for cache in mediator.caches:
-                    cache.observe(provider, served)
-
-            # Back to the piece the model's own forward expects, carrying whatever
-            # the workers left behind — so an edit to the assembled tensor reaches
-            # the model rather than being dropped with the gather.
-            if gathering:
-                value = self.fragments.fragment(provider, value)
-
-        else:
-            # Nobody was served, so nothing walked the workers — but the model
-            # still passed this location and every worker's count of it has to
-            # move, or a later `tracer.iter[n]` binds to the wrong occurrence.
-            # Counted per worker because workers start at different times: a
-            # request that joined at step 5 is on its own first visit, not the
-            # run's sixth. This is the only work most locations cause.
+        waiting = provider in self.waiting
+        # This is the common path: a location no worker waits on and no cache
+        # observes. Iteration semantics still require the all-worker bump, but the
+        # router itself adds one dict lookup and one boolean test.
+        if not waiting and not self.observers and not self.wildcard_observers:
             for mediator in self._mediators:
                 mediator.iterations[provider] += 1
+            return value
+
+        if self.wildcard_observers:
+            observers = self._observers_for(provider)
+        else:
+            observers = self.observers.get(provider, [])
+        if not waiting and not observers:
+            for mediator in self._mediators:
+                mediator.iterations[provider] += 1
+            return value
+
+        # A fragment is made whole before any consumer sees it, but only when a
+        # worker will be served on *this* occurrence or a selected cache records
+        # it. Every rank derives this from the same provider routes, keeping their
+        # collectives matched.
+        gathering = False
+        if (
+            self.fragments is not None
+            and self.fragments.enabled
+            and (
+                observers
+                or any(
+                    pending.provider == provider
+                    and pending.iteration == mediator.iterations[provider]
+                    for mediator in self._mediators
+                    if (pending := mediator.pending) is not None
+                )
+            )
+        ):
+            self.fragments.read(provider)
+            if self.fragments.fragmented(provider):
+                gathering = True
+                value = self.fragments.whole(provider, value)
+
+        if waiting:
+            # Keep the original list order for both serving and iteration bumps.
+            # The inline match replaces the old no-op `Mediator.handle` calls.
+            for mediator in self._mediators:
+                try:
+                    pending = mediator.pending
+                    if (
+                        pending is not None
+                        and pending.provider == provider
+                        and pending.iteration == mediator.iterations[provider]
+                    ):
+                        value = mediator.handle(provider, value)
+                    # Bump immediately after this worker's turn. In particular, a
+                    # later worker releasing it from a barrier will see the next
+                    # occurrence when it re-parks on this provider.
+                    mediator.iterations[provider] += 1
+                except Exception as exception:
+                    mediator.exception = exception
+                    if not self.defer_exceptions:
+                        raise
+        else:
+            for mediator in self._mediators:
+                mediator.iterations[provider] += 1
+
+        # A batched skip leaves its invokes' replacements gathered rather than one
+        # value; concatenate them into the combined output (see
+        # Batcher.gather_skip). A future-iteration waiter has no gathered skip,
+        # but retaining this gate preserves the previous provider-level behaviour.
+        if self.batcher is not None:
+            value = self.batcher.assemble_skip(value)
+
+        for mediator, cache, selected in observers:
+            served = (
+                value
+                if self.batcher is None
+                else self.batcher.narrow(value, mediator.batch_group)
+            )
+            cache.observe_selected(selected, served)
+
+        # Back to the piece the model's own forward expects, carrying whatever the
+        # workers left behind — so an edit to the assembled tensor reaches the
+        # model rather than being dropped with the gather.
+        if gathering:
+            value = self.fragments.fragment(provider, value)
         return value
 
     def check_dangling_mediators(self) -> None:
@@ -944,7 +957,7 @@ class Interleaver:
         """
         for mediator in self.mediators:
             mediator.worker = None
-        self.mediators.clear()
+        self.mediators = []
         self.batcher = None
 
     def remove(self, path: str) -> None:

--- a/src/nnsight/intervention/interleaver.py
+++ b/src/nnsight/intervention/interleaver.py
@@ -885,9 +885,9 @@ class Interleaver:
                     # occurrence when it re-parks on this provider.
                     mediator.iterations[provider] += 1
                 except Exception as exception:
-                    mediator.exception = exception
                     if not self.defer_exceptions:
                         raise
+                    mediator.exception = exception
         else:
             for mediator in self._mediators:
                 mediator.iterations[provider] += 1

--- a/src/nnsight/intervention/interleaver.py
+++ b/src/nnsight/intervention/interleaver.py
@@ -42,7 +42,7 @@ import enum
 import warnings
 import weakref
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Optional
 
 import torch
 from greenlet import getcurrent, greenlet
@@ -70,6 +70,40 @@ class Event(enum.Enum):
     SWAP = "SWAP"  # replace a location: (Event.SWAP, location, value)
     SKIP = "SKIP"  # skip a computation: (Event.SKIP, location, value)
     BARRIER = "BARRIER"  # wait for the other blocks: (Event.BARRIER, None)
+
+
+class Pending(NamedTuple):
+    """What a worker is parked on, waiting for the model to reach.
+
+    The occurrence is kept apart from the location rather than glued onto it.
+    A worker parks once per intervention read, but a location is *visited* on
+    every forward through every module, and the model side's question at each
+    visit — is anyone waiting on this location? — is about the location alone. As
+    its own field that is a plain comparison; folded into a
+    ``"{provider}.i{n}"`` string it would have to be rebuilt, per worker, at
+    every visit, only to be thrown away.
+
+    Printing rejoins them, because that form is the one worth reading in an
+    error: ``'model.layers.16.output.i2' was requested but...`` says which pass
+    was waited for, where the bare location would not.
+
+    Attributes:
+        event: What the worker wants done at ``provider`` — see
+            [`Event`][nnsight.intervention.interleaver.Event].
+        provider: The location, undecorated, or ``None`` for a barrier, which
+            names no location and so is never served by the model side.
+        iteration: Which occurrence of ``provider`` the worker is waiting for —
+            the model has to have reached it this many times already.
+        value: The replacement a swap or skip carries; unused by a read.
+    """
+
+    event: "Event"
+    provider: Optional[str]
+    iteration: Optional[int] = None
+    value: Any = None
+
+    def __str__(self) -> str:
+        return f"{self.provider}.i{self.iteration}"
 
 
 class EarlyStopException(Exception):
@@ -130,12 +164,12 @@ class Mediator:
             invoke.
         worker: The greenlet running `code`, or ``None`` before
             `start`. Falsy once the worker has finished (see [`alive`][nnsight.intervention.interleaver.Mediator.alive]).
-        pending: The event the worker is currently parked on — a tuple like
-            ``(Event.VALUE, "model.layer1.output.i0")``, the location carrying an
-            occurrence tag (see [`event`][nnsight.intervention.interleaver.Mediator.event]) — or ``None`` when the worker isn't
-            parked (before start or after it finishes).
+        pending: What the worker is currently parked on — a
+            [`Pending`][nnsight.intervention.interleaver.Pending] naming the event,
+            the location and which occurrence of it (see [`event`][nnsight.intervention.interleaver.Mediator.event]) — or ``None``
+            when the worker isn't parked (before start or after it finishes).
         iteration: Which occurrence of a location the worker currently wants —
-            the ``i`` in the ``.i{i}`` tag its pending request is matched under.
+            the occurrence its pending request is matched under.
             ``tracer.iter`` pins it to a step; ``None`` means *relaxed* — the
             request resolves to the mediator's current count for that location (the
             next occurrence the model hasn't handled). Stays ``0`` (the first
@@ -182,9 +216,11 @@ class Mediator:
         self.interleaver: Any = None
         self.batch_group: list | None = None
         self.worker: greenlet | None = None
-        # The event the worker is currently parked on, waiting to be served (e.g.
-        # (Event.VALUE, "model.h.0.output.i0")), or None when it isn't parked.
-        self.pending: tuple | None = None
+        # What the worker is currently parked on waiting to be served (a
+        # [`Pending`][nnsight.intervention.interleaver.Pending]), or None when it
+        # isn't parked. Assigned through the `pending` property, which keeps the
+        # interleaver's index of who is parked where up to date.
+        self._pending: Pending | None = None
         # Which occurrence of a location the worker is currently asking for (or
         # None when relaxed), and a per-location tally of how many times the model
         # has reached it. See `handle` for how the two are matched up.
@@ -296,7 +332,7 @@ class Mediator:
             if mediator.iteration is not None
             else mediator.iterations[location]
         )
-        return worker.parent.switch((event, f"{location}.i{iteration}", *rest))
+        return worker.parent.switch(Pending(event, location, iteration, *rest))
 
     @classmethod
     def value(cls, location: str) -> Any:
@@ -340,7 +376,28 @@ class Mediator:
         [`Barrier`][nnsight.intervention.barrier.Barrier]). Its pending event carries
         no location, so the model side never serves it.
         """
-        getcurrent().parent.switch((Event.BARRIER, None))
+        getcurrent().parent.switch(Pending(Event.BARRIER, None))
+
+    @property
+    def pending(self) -> Pending | None:
+        """What this worker is parked on, or None when it isn't parked.
+
+        A property so that every park is recorded in the interleaver's
+        [`parked`][nnsight.intervention.interleaver.Interleaver.parked] set —
+        which is what lets the model side skip a location nobody wants — from the
+        one place that assigns this rather than the several that would otherwise
+        have to remember to. Only ever adds: see `parked` for why forgetting to
+        remove is the safe direction and forgetting to add would not be.
+        """
+        return self._pending
+
+    @pending.setter
+    def pending(self, pending: Pending | None) -> None:
+        self._pending = pending
+        if pending is not None and pending.provider is not None:
+            interleaver = self.interleaver
+            if interleaver is not None:
+                interleaver.parked.add(pending.provider)
 
     @property
     def alive(self) -> bool:
@@ -416,28 +473,42 @@ class Mediator:
 
         A location can be reached many times in one run — e.g. a module revisited
         on every step of a generation loop. This visit is the
-        ``iterations[provider]``-th, so it serves requests tagged for that
-        occurrence: ``{provider}.i{n}``. A worker parks already carrying the tag
-        it wants (see [`event`][nnsight.intervention.interleaver.Mediator.event]) — pinned to a step, or resolved to the next
-        occurrence when relaxed — so this is a single string match: a request
-        pinned to a later step doesn't match yet and waits while earlier visits
-        pass by. With no ``tracer.iter`` the tag is always ``.i0``, so every
+        ``iterations[provider]``-th, so it serves the workers waiting for that
+        occurrence of it. A worker parks already carrying the occurrence it wants
+        (see [`event`][nnsight.intervention.interleaver.Mediator.event]) — pinned to a step, or resolved to the next
+        occurrence when relaxed — so this is a location match and an integer
+        match: a request pinned to a later step doesn't match yet and waits while
+        earlier visits pass by. With no ``tracer.iter`` the occurrence is always
+        ``0``, so every
         request binds to the first visit — the original behavior. Once a pinned
         non-zero step is hit, the mediator is relaxed to ``None`` so the rest of
         that step's requests follow the model sequentially rather than re-forcing
         the index.
         """
-        location = f"{provider}.i{self.iterations[provider]}"
+        # Not parked on this location at all — the overwhelmingly common case, since
+        # a trace reads a handful of the hundreds of locations a forward passes
+        # through. Comparing the location alone settles it, which is why
+        # [`Pending`][nnsight.intervention.interleaver.Pending] keeps it apart
+        # from the occurrence rather than glued into one string.
+        pending = self._pending
+        if pending is None or pending.provider != provider:
+            return value
+
+        iteration = self.iterations[provider]
         # The batcher (if this run is batching) scopes a value to this worker's rows.
         batcher = None if self.interleaver is None else self.interleaver.batcher
-        while self.pending is not None and self.pending[1] == location:
+        while (
+            pending is not None
+            and pending.provider == provider
+            and pending.iteration == iteration
+        ):
             # First hit of an explicit iter[n] (n > 0): drop the pin so the
             # remaining requests this step follow the model sequentially (event
             # resolves them to the current count). 0 and None don't relax (0 is
             # "unpinned"; None already is).
             if self.iteration:
                 self.iteration = None
-            if self.pending[0] is Event.VALUE:  # serve this worker only its rows
+            if pending.event is Event.VALUE:  # serve this worker only its rows
                 served = value if batcher is None else batcher.narrow(value, self.batch_group)
                 self.pending = self.switch(served)
                 # If that read bound a write-back (an eproperty whose preprocess
@@ -451,23 +522,21 @@ class Mediator:
                         else batcher.widen(value, self.batch_group, mapped)
                     )
                     self.transform = None
-            elif self.pending[0] is Event.SWAP:  # splice its edit back into the batch
+            elif pending.event is Event.SWAP:  # splice its edit back into the batch
                 if batcher is None:
-                    value = self.pending[2]
+                    value = pending.value
                 else:
-                    value = batcher.widen(value, self.batch_group, self.pending[2])
+                    value = batcher.widen(value, self.batch_group, pending.value)
                 self.pending = self.switch()
-            elif self.pending[0] is Event.SKIP:  # gather per-invoke replacements
+            elif pending.event is Event.SKIP:  # gather per-invoke replacements
                 if batcher is None:
-                    value = self.pending[2]
+                    value = pending.value
                 else:
                     value = batcher.gather_skip(
-                        value, self.batch_group, self.pending[2]
+                        value, self.batch_group, pending.value
                     )
                 self.pending = self.switch()
-        # Record that the model has now passed this occurrence of the location, so
-        # the next visit is tagged as the following one.
-        self.iterations[provider] += 1
+            pending = self._pending
         return value
 
 
@@ -515,7 +584,23 @@ class Interleaver:
 
     def __init__(self, fragments: Optional["Fragments"] = None) -> None:
         self.handles: dict[str, list[torch.utils.hooks.RemovableHandle]] = {}
-        self.mediators: list[Mediator] = []
+        self._mediators: list[Mediator] = []
+        # The locations a worker has parked on since this set was last rebuilt —
+        # what lets `handle` recognize "nobody wants this one" without walking the
+        # workers, since a forward passes through hundreds of locations and a trace
+        # asks for a handful.
+        #
+        # Deliberately a *superset*, not an exact tally: workers are only ever
+        # added, and the set is rebuilt when the worker list is replaced. Being
+        # wrong in that direction is free — a location no one is parked on any more
+        # costs one walk that finds nothing. Being wrong the other way is not: a
+        # missing entry makes `handle` skip a worker that *was* waiting, and its
+        # read goes unanswered with nothing to show for it. So the cheap mistake is
+        # the only one this can make.
+        self.parked: set[str] = set()
+        # Whether any worker holds a `tracer.cache()`. A cache wants locations
+        # nobody is parked on, so it disables the skip.
+        self.caching = False
         # What, if anything, makes a value at a location whole before workers see
         # it — see intervention/fragments.py. None on an ordinary model, and on a
         # distributed one it is the runtime's own object. Kept as a collaborator
@@ -541,6 +626,43 @@ class Interleaver:
         # its own request instead of tearing down the shared engine.
         self.defer_exceptions = False
 
+    @property
+    def mediators(self) -> list["Mediator"]:
+        """The workers this run serves.
+
+        Replacing the list rebuilds [`parked`][nnsight.intervention.interleaver.Interleaver.parked]
+        from it, so a driver that hands over a different set each step (vLLM
+        reschedules per step, and a worker can stay parked across several) never
+        leaves the index describing workers that are no longer being served.
+        """
+        return self._mediators
+
+    @mediators.setter
+    def mediators(self, mediators: list["Mediator"]) -> None:
+        self._mediators = mediators
+        self.reindex()
+
+    def reindex(self) -> None:
+        """Re-derive `parked` and `caching` from the workers as they are now.
+
+        Run at the start of every run and whenever the worker list is replaced, so
+        neither index can carry anything over from the last one. That matters
+        because the list is not always *replaced*: the local path appends to it and
+        `cancel` empties it in place, so a version that only rebuilt on assignment
+        went stale — one ``tracer.cache()`` left `caching` true for the life of the
+        model, quietly costing every later trace the walk this exists to skip.
+
+        Re-derive rather than clear: a worker parked across a re-entered
+        interleaver must stay in `parked`, and dropping it is the one direction
+        that loses a read.
+        """
+        self.parked = {
+            mediator.pending.provider
+            for mediator in self._mediators
+            if mediator.pending is not None and mediator.pending.provider is not None
+        }
+        self.caching = any(mediator.caches for mediator in self._mediators)
+
     def __enter__(self) -> Interleaver:
         """Begin interleaving: arm the hooks and start each not-yet-started worker.
 
@@ -564,6 +686,10 @@ class Interleaver:
             # won't run to clear the flag, so reset it here or it leaks to the next run.
             self.interleaving = False
             raise
+        # After the workers have parked, so this run's index describes this run's
+        # workers — including any registered by appending to the list rather than
+        # replacing it, which is how the local path does it.
+        self.reindex()
         return self
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> bool:
@@ -582,10 +708,16 @@ class Interleaver:
         """Whether anything is waiting on *this* visit to ``provider``.
 
         Mirrors the match [`Mediator.handle`][nnsight.intervention.interleaver.Mediator.handle]
-        makes — a worker parks already carrying the occurrence tag it wants, so
-        this is the same single string comparison against this visit's count.
-        Deliberately not "is any worker parked anywhere": a worker waiting on a
-        *later* iteration of this location must not trigger work now.
+        makes — a worker parks already carrying the occurrence it wants, so this
+        compares the same location and count. Deliberately not "is any worker
+        parked anywhere": a worker waiting on a *later* iteration of this location
+        must not trigger work now.
+
+        Reached only from `handle`, and only past its
+        [`parked`][nnsight.intervention.interleaver.Interleaver.parked] gate — so
+        this walks the workers for the handful of locations something wants, not
+        for every location a forward passes through. Repeating that gate here
+        would be dead: `handle` has already returned when it holds.
 
         A ``tracer.cache()`` counts too — it would otherwise record fragments —
         but only for the locations it actually keeps. A cache is usually scoped to
@@ -596,11 +728,12 @@ class Interleaver:
         Used to gate the gather in `handle`. Every rank evaluates it over the same
         block, so it answers the same everywhere.
         """
-        for mediator in self.mediators:
+        for mediator in self._mediators:
             pending = mediator.pending
             if (
                 pending is not None
-                and pending[1] == f"{provider}.i{mediator.iterations[provider]}"
+                and pending.provider == provider
+                and pending.iteration == mediator.iterations[provider]
             ):
                 return True
             if any(cache.wants(provider) for cache in mediator.caches):
@@ -671,55 +804,82 @@ class Interleaver:
         own rows of the batch — narrowed the same way the worker's reads are.
         Caches select which locations to keep themselves.
         """
-        # A fragment is made whole before any worker sees it, and only when one
-        # is actually waiting: a trace reads a handful of locations out of
-        # hundreds, and a collective at every other one would cost far more than
-        # the reads do. `observed` answers the same on every rank, which is what
-        # keeps their collectives matched.
-        gathering = False
-        if (
-            self.fragments is not None
-            and self.fragments.enabled
-            and self.observed(provider)
-        ):
-            self.fragments.read(provider)
-            if self.fragments.fragmented(provider):
-                gathering = True
-                value = self.fragments.whole(provider, value)
+        # Only where something is waiting. A forward passes through hundreds of
+        # locations and a trace asks for a handful, so on nearly every visit no
+        # worker's view of the run can differ whether or not this runs — and
+        # without the check every worker would be consulted about every location.
+        if provider in self.parked or self.caching:
+            # A fragment is made whole before any worker sees it, and only when
+            # one is actually waiting: a collective at every other location would
+            # cost far more than the reads do. `observed` answers the same on
+            # every rank, which is what keeps their collectives matched.
+            gathering = False
+            if (
+                self.fragments is not None
+                and self.fragments.enabled
+                and self.observed(provider)
+            ):
+                self.fragments.read(provider)
+                if self.fragments.fragmented(provider):
+                    gathering = True
+                    value = self.fragments.whole(provider, value)
 
-        for mediator in self.mediators:
-            try:
-                value = mediator.handle(provider, value)
-            except Exception as exception:
-                # Record the worker's exception on its mediator — a stop's
-                # EarlyStopException or a real error, treated the same here.
-                mediator.exception = exception
-                if not self.defer_exceptions:
-                    # Not deferring: let it propagate, so a local run unwinds the
-                    # forward (a stop is swallowed at the top; an error surfaces).
-                    raise
-                # Deferring: this worker is done; carry on serving the others, and
-                # leave it to the driver to end this worker's request.
-        # A batched skip left its invokes' replacements gathered rather than one
-        # value; concatenate them into the combined output (see Batcher.gather_skip).
-        if self.batcher is not None:
-            value = self.batcher.assemble_skip(value)
-        for mediator in self.mediators:
-            if not mediator.caches:
-                continue
-            served = (
-                value
-                if self.batcher is None
-                else self.batcher.narrow(value, mediator.batch_group)
-            )
-            for cache in mediator.caches:
-                cache.observe(provider, served)
+            for mediator in self._mediators:
+                try:
+                    value = mediator.handle(provider, value)
+                    # Tallied here, in the pass that is already walking the
+                    # workers. After this worker has been served, never before:
+                    # a block that reads a location and then writes it re-parks
+                    # mid-visit, and `Mediator.event` tags that re-park with the
+                    # count as it stands — bumping first would tag it for the
+                    # *next* visit and strand the write until the model came
+                    # round again. Skipped for a worker that raised, which is
+                    # done and whose count no longer means anything.
+                    mediator.iterations[provider] += 1
+                except Exception as exception:
+                    # Record the worker's exception on its mediator — a stop's
+                    # EarlyStopException or a real error, treated the same here.
+                    mediator.exception = exception
+                    if not self.defer_exceptions:
+                        # Not deferring: let it propagate, so a local run unwinds
+                        # the forward (a stop is swallowed at the top; an error
+                        # surfaces).
+                        raise
+                    # Deferring: this worker is done; carry on serving the others,
+                    # and leave it to the driver to end this worker's request.
 
-        # Back to the piece the model's own forward expects, carrying whatever
-        # the workers left behind — so an edit to the assembled tensor reaches
-        # the model rather than being dropped with the gather.
-        if gathering:
-            value = self.fragments.fragment(provider, value)
+            # A batched skip left its invokes' replacements gathered rather than
+            # one value; concatenate them into the combined output (see
+            # Batcher.gather_skip).
+            if self.batcher is not None:
+                value = self.batcher.assemble_skip(value)
+
+            for mediator in self._mediators:
+                if not mediator.caches:
+                    continue
+                served = (
+                    value
+                    if self.batcher is None
+                    else self.batcher.narrow(value, mediator.batch_group)
+                )
+                for cache in mediator.caches:
+                    cache.observe(provider, served)
+
+            # Back to the piece the model's own forward expects, carrying whatever
+            # the workers left behind — so an edit to the assembled tensor reaches
+            # the model rather than being dropped with the gather.
+            if gathering:
+                value = self.fragments.fragment(provider, value)
+
+        else:
+            # Nobody was served, so nothing walked the workers — but the model
+            # still passed this location and every worker's count of it has to
+            # move, or a later `tracer.iter[n]` binds to the wrong occurrence.
+            # Counted per worker because workers start at different times: a
+            # request that joined at step 5 is on its own first visit, not the
+            # run's sixth. This is the only work most locations cause.
+            for mediator in self._mediators:
+                mediator.iterations[provider] += 1
         return value
 
     def check_dangling_mediators(self) -> None:
@@ -743,8 +903,10 @@ class Interleaver:
         for mediator in self.mediators:
             if not mediator.alive:
                 continue
-            requester = mediator.pending[1]
-            if mediator.pending[0] is Event.BARRIER:
+            # Printed, so it renders as "{location}.i{n}" — which occurrence was
+            # waited for is the part that explains an iter loop that outran the run.
+            requester = mediator.pending
+            if mediator.pending.event is Event.BARRIER:
                 # Waiting on blocks that never all arrived — fewer of them reached
                 # the barrier than it was built for, so it was never going to
                 # release. Point at the line that waited.

--- a/src/nnsight/intervention/interleaver.py
+++ b/src/nnsight/intervention/interleaver.py
@@ -452,6 +452,21 @@ class Mediator:
         another worker's greenlet, e.g. an ``Envoy.__call__(hook=True)`` adapter
         run whose submodule hooks serve a second worker mid-call.
         """
+        # A worker that has already finished has nothing to resume, and switching
+        # into a dead greenlet does not run anything — greenlet hands the
+        # arguments straight back. The caller would then store an activation
+        # tensor where an event belongs, and the next `reindex` would read
+        # `.provider` off it. That happens inside the model runner's own state
+        # update, where nothing catches it, so it takes the whole engine down —
+        # every tenant's request, not just the one whose block raised. Finished is
+        # finished: say so the way a worker that ran off the end does.
+        #
+        # This is reachable because an erred worker is deliberately kept scheduled
+        # (see `_finish_erred`), so it is still routed to for as long as its
+        # request lives.
+        if self.worker is not None and self.worker.dead:
+            return None
+
         self.worker.parent = getcurrent()
         try:
             return self.worker.switch(*args)

--- a/src/nnsight/intervention/interleaver.py
+++ b/src/nnsight/intervention/interleaver.py
@@ -270,6 +270,10 @@ class Mediator:
         presaved = {
             name for name, value in reduced[2].items() if id(value) in _saves()
         }
+        # Kept on this side too: it is the only record of which names were bound
+        # (and saved) *above* the block, which is what tells a value shared by
+        # every request apart from one each request computed for itself.
+        self.presaved = presaved
         return {"reduced": reduced, "copy": self.copy, "presaved": presaved}
 
     def __setstate__(self, state: dict) -> None:

--- a/src/nnsight/intervention/source.py
+++ b/src/nnsight/intervention/source.py
@@ -265,6 +265,46 @@ def _rewrap(chain: list[tuple[Callable, int]], innermost: Callable) -> Callable:
     return result
 
 
+def _closure_diagnostic(func: Callable) -> str:
+    """Describe *why* a callable has free variables, when we can tell.
+
+    A decorator's wrapper always closes over the function it wraps, so this is the
+    usual reason `.source` refuses a `forward`. When the decorator forgot
+    ``functools.wraps`` there is no ``__wrapped__`` to peel, but the wrapper's
+    ``__qualname__`` still names the decorator that built it and its closure still
+    holds the function it wraps -- both worth saying, since the bare "free
+    variables" message sends people to debug their own code.
+    """
+    parts = []
+    qualname = getattr(func, "__qualname__", "")
+    if "<locals>" in qualname:
+        decorator = qualname.split(".<locals>.")[0]
+        module = getattr(func, "__module__", None)
+        where = f" ({module})" if module else ""
+        parts.append(f"it is a wrapper built by @{decorator}{where}")
+    wrapped = next(
+        (
+            cell.cell_contents
+            for cell in (getattr(func, "__closure__", None) or ())
+            if callable(cell.cell_contents) and hasattr(cell.cell_contents, "__code__")
+        ),
+        None,
+    )
+    if wrapped is not None:
+        parts.append(f"wrapping {getattr(wrapped, '__qualname__', wrapped)}")
+    if not parts:
+        return ""
+    tail = (
+        " It could not be peeled because the decorator does not use "
+        "`functools.wraps`, so there is no `__wrapped__` to follow. Instrument a "
+        "real submodule's `.source` instead, or have the decorator apply "
+        "`@functools.wraps`."
+        if not hasattr(func, "__wrapped__")
+        else ""
+    )
+    return " -- " + ", ".join(parts) + "." + tail
+
+
 def _compile_instrumented(func: Callable, decorated: bool = False) -> Compiled:
     """Parse, instrument, and compile a Python ``func`` (a ``forward`` or a drilled-into
     callable), or raise.
@@ -287,7 +327,11 @@ def _compile_instrumented(func: Callable, decorated: bool = False) -> Compiled:
         # Recompiled at module level, free variables would become globals and
         # break. A decorator's wrapper always closes over the function it wraps,
         # so this is also what rejects one we couldn't peel.
-        raise SourceNotAvailable("callable closes over free variables")
+        names = ", ".join(repr(name) for name in code_object.co_freevars)
+        raise SourceNotAvailable(
+            f"callable closes over free variables ({names})"
+            + _closure_diagnostic(func)
+        )
     try:
         lines, start = inspect.getsourcelines(func)
     except (OSError, TypeError) as error:

--- a/src/nnsight/intervention/tracer.py
+++ b/src/nnsight/intervention/tracer.py
@@ -223,7 +223,12 @@ class InterleavingTracer(Tracer):
         )
         # The trace body runs in the worker greenlet; register the cache on its
         # mediator so the interleaver feeds it every location from here on.
-        Mediator.current("tracer.cache()").caches.append(cache)
+        mediator = Mediator.current("tracer.cache()")
+        mediator.caches.append(cache)
+        # A cache wants locations no worker is parked on, so it has to switch off
+        # the interleaver's "nobody wants this one" skip for the rest of the run.
+        if mediator.interleaver is not None:
+            mediator.interleaver.caching = True
         # Save so the view survives past the trace (like a .save()d value). The
         # view is a virtual root above the model (see CacheView).
         return save(CacheView(cache, None))

--- a/src/nnsight/intervention/tracer.py
+++ b/src/nnsight/intervention/tracer.py
@@ -183,7 +183,7 @@ class InterleavingTracer(Tracer):
         detach: bool = True,
         include_output: bool = True,
         include_inputs: bool = False,
-        non_blocking: bool = True,
+        non_blocking: bool = False,
     ) -> CacheView:
         """Record activations of many modules at once during the run.
 
@@ -206,7 +206,12 @@ class InterleavingTracer(Tracer):
             detach: Detach captured tensors from the autograd graph.
             include_output: Capture each module's output.
             include_inputs: Capture each module's inputs.
-            non_blocking: Use an async (non-blocking) device transfer (default True).
+            non_blocking: Use an async (non-blocking) device transfer (default
+                ``False``). ``True`` enqueues the copy and returns without
+                synchronising, so a capture off a CUDA device can be read while the
+                copy is still in flight -- reading a CPU tensor does not synchronise
+                CUDA. Only pass ``True`` if you
+                synchronise yourself before reading the cache.
                 Safe under nnsight's single-stream execution and faster; set False if
                 you move captured tensors across CUDA streams yourself and want the
                 copy synchronized before use.

--- a/src/nnsight/intervention/tracer.py
+++ b/src/nnsight/intervention/tracer.py
@@ -195,8 +195,8 @@ class InterleavingTracer(Tracer):
             cache["model.transformer.h.0"].output      # by path
             cache.transformer.h[0].output              # or by navigation
 
-        Only modules the run reaches *after* this call are captured. Values are
-        recorded post-intervention. In a generation loop a module is captured once
+        Declare the cache before reading or modifying a model value. Values are
+        recorded post-intervention; in a generation loop a module is captured once
         per step (``len(cache[path])`` is the step count).
 
         Args:
@@ -211,6 +211,13 @@ class InterleavingTracer(Tracer):
                 you move captured tensors across CUDA streams yourself and want the
                 copy synchronized before use.
         """
+        mediator = Mediator.current("tracer.cache()")
+        if mediator.pending is not None:
+            raise ValueError(
+                "tracer.cache() must be declared before reading or modifying a "
+                "model value"
+            )
+
         cache = Cache(
             self.envoy,
             modules=modules,
@@ -221,14 +228,9 @@ class InterleavingTracer(Tracer):
             include_inputs=include_inputs,
             non_blocking=non_blocking,
         )
-        # The trace body runs in the worker greenlet; register the cache on its
-        # mediator so the interleaver feeds it every location from here on.
-        mediator = Mediator.current("tracer.cache()")
+        # The trace body runs in the worker greenlet; register the cache before
+        # the interleaver builds this run's fixed observer routes.
         mediator.caches.append(cache)
-        # A cache wants locations no worker is parked on, so it has to switch off
-        # the interleaver's "nobody wants this one" skip for the rest of the run.
-        if mediator.interleaver is not None:
-            mediator.interleaver.caching = True
         # Save so the view survives past the trace (like a .save()d value). The
         # view is a virtual root above the model (see CacheView).
         return save(CacheView(cache, None))

--- a/src/nnsight/modeling/tp/envoys.py
+++ b/src/nnsight/modeling/tp/envoys.py
@@ -1,0 +1,149 @@
+"""Envoys for modules transformers split across ranks.
+
+The ad-hoc-call half of what
+[`TPFragments`][nnsight.modeling.tp.fragments.TPFragments] does for activations.
+Interleaving already shows a worker whole activations — gathered on the way in,
+re-split on the way out, once per visit — but a trace that calls a module
+*directly*, away from its place in the forward pass, is outside that bracket. A
+logit lens running ``lm_head`` on an intermediate hidden state is holding, and
+wants back, whole tensors, while the sharded module deals in slices.
+
+So the bracket is the same one vLLM's envoy uses
+([`nnsight.modeling.vllm.envoys`][nnsight.modeling.vllm.envoys]): re-split the
+caller's whole input, run the module, reassemble the output, all off
+`TPFragments`' own rules.
+
+What is *not* needed here is any handling of the collectives themselves.
+transformers keeps them in forward hooks rather than inside ``forward``
+(``distribute_module`` registers the style's ``_prepare_input_fn`` as a pre-hook
+and ``_prepare_output_fn`` as a post-hook), and
+[`Envoy.__call__`][nnsight.intervention.envoy.Envoy.__call__] runs the module the
+ordinary way — standing the interleaver down rather than dodging ``__call__`` —
+so those hooks fire on their own. That is what makes a row-parallel layer's
+all-reduce and ``colwise_gather_output``'s all-gather happen without this module
+restating them.
+
+It does mean the style's *pre*-hook fires too, which is why re-splitting the
+input is conditional: see
+[`SPLITS_ITS_OWN_INPUT`][nnsight.modeling.tp.envoys.SPLITS_ITS_OWN_INPUT].
+
+Parameters are left alone. ``layer.weight`` is this rank's real slice, as it is
+anywhere else under transformers tensor parallelism.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import torch
+
+from ...intervention.envoy import Envoy
+from .fragments import is_sharded
+
+#: Styles whose own pre-hook splits the input for them.
+#:
+#: Both of these take a *whole* tensor at the module boundary, so a caller
+#: handing one in has already given the hook what it wants and nnsight must not
+#: cut it down first — the hook would then cut the slice again. Every other
+#: sharded-input style (plain ``rowwise``, ``packed_rowwise``) receives an input
+#: that was already split by the column-parallel layer upstream, so its pre-hook
+#: passes the value straight through and the caller's whole tensor *is* what
+#: needs splitting.
+#:
+#: Read off ``RowwiseParallel._prepare_input_fn``, which splits only when its
+#: ``split_input`` is set — true for ``rowwise_split_input`` alone among the
+#: styles transformers registers.
+SPLITS_ITS_OWN_INPUT = ("rowwise_split_input",)
+
+
+def _style(module: torch.nn.Module) -> Optional[str]:
+    """The tensor-parallel style transformers sharded ``module`` with, if any."""
+    return getattr(module, "_hf_tp_plan", None)
+
+
+def _mesh(module: torch.nn.Module) -> Any:
+    """``module``'s device mesh, or None if it spans fewer than two ranks."""
+    mesh = getattr(module, "_hf_device_mesh", None)
+    if mesh is None or mesh.size() < 2:
+        return None
+    return mesh
+
+
+class TPEnvoy(Envoy):
+    """An envoy over a module transformers may have sharded.
+
+    Inert on an unsharded model and on a one-rank mesh — the correction is gated
+    on the module actually carrying a style — so this is a safe envoy class for
+    every ``Linear`` and ``Embedding`` in a tree that was loaded across ranks.
+    """
+
+    def __call__(self, *args: Any, hook: bool = False, **kwargs: Any) -> Any:
+        """Run this module ad hoc, on whole tensors either side.
+
+        Every rank runs the block, so every rank reaches the same collectives in
+        the same order — as long as the call is not under rank-dependent control
+        flow, the condition every collective in a block carries.
+        """
+        module = self._module
+        fragments = self.interleaver.fragments
+
+        if (
+            hook
+            or fragments is None
+            or not fragments.enabled
+            or _style(module) is None
+            or _mesh(module) is None
+        ):
+            return super().__call__(*args, hook=hook, **kwargs)
+
+        into, outof = f"{self.path}.input", f"{self.path}.output"
+
+        if fragments.fragmented(into) and _style(module) not in SPLITS_ITS_OWN_INPUT:
+            args, kwargs = fragments.fragment(into, (args, kwargs))
+
+        # The module's own hooks run inside this — the interleaver stands itself
+        # down rather than bypassing them — so the style's collectives happen
+        # here without being restated.
+        result = super().__call__(*args, hook=False, **kwargs)
+
+        if fragments.fragmented(outof):
+            result = fragments.whole(outof, result)
+
+        return result
+
+
+def tp_envoys() -> dict:
+    """The ``envoys`` map pairing shardable module types with `TPEnvoy`.
+
+    Keyed by type rather than by style because a style is stamped on the
+    *instance* at load — the same ``nn.Linear`` class is ``colwise`` in one place
+    and ``rowwise`` in another — while the map is consulted per module as the
+    tree is built. `TPEnvoy` reads the stamp itself.
+    """
+    return {
+        torch.nn.Linear: TPEnvoy,
+        torch.nn.Embedding: TPEnvoy,
+    }
+
+
+def wants_tensor_parallel(target: Any, load_kwargs: dict) -> bool:
+    """Whether this construction is going to produce a sharded model.
+
+    Asked from a constructor, before the model exists — so for a repo id it reads
+    the *request* (``distributed_config``) rather than the result. A ready module
+    is already there and can be asked directly.
+
+    Erring towards True is the safe direction: `TPEnvoy` is inert on a module
+    with no style stamped on it, so a false positive costs a different envoy
+    class and nothing else, while a false negative silently leaves ad-hoc calls
+    handing back slices. Hence ``tp_plan`` counts even with no ``tp_size``.
+    """
+    if isinstance(target, torch.nn.Module):
+        return is_sharded(target)
+
+    config = load_kwargs.get("distributed_config")
+    if config is None:
+        return False
+    if getattr(config, "tp_plan", None):
+        return True
+    return (getattr(config, "tp_size", None) or 1) > 1

--- a/src/nnsight/modeling/transformers.py
+++ b/src/nnsight/modeling/transformers.py
@@ -40,6 +40,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Optional
 
+import warnings
+
 import torch
 from torch._guards import detect_fake_mode
 
@@ -125,6 +127,40 @@ def _infer_task(module: torch.nn.Module) -> str:
     raise ValueError(
         f"Could not infer a pipeline task for a pre-loaded {type(module).__name__}; "
         "pass task=... explicitly (e.g. TransformersModel(model, task='text-generation'))."
+    )
+
+
+def _refuse_noop_peft(peft_id: str, caught: list) -> None:
+    """Turn peft's "missing adapter keys" warning into an error.
+
+    peft places adapter weights by **name** and drops the ones it cannot match. As
+    ``lora_B`` initialises to zeros, an adapter whose weights did not land is
+    exactly the identity -- the model behaves like the base checkpoint, so a
+    base-vs-adapter comparison silently becomes base-vs-base with every number in
+    it plausible. peft warns about this precisely because ``from_pretrained``
+    cannot return its load result (see `PeftModel.from_pretrained`), but a warning
+    is easy to miss in a long load, and by the time it matters the run is finished.
+
+    Only the mismatch warns: an adapter whose keys all place -- including a freshly
+    initialised one whose ``lora_B`` is legitimately still zero -- produces none.
+    """
+    missing = [
+        warning
+        for warning in caught
+        if "missing adapter keys" in str(warning.message).lower()
+    ]
+    if not missing:
+        return
+
+    raise ValueError(
+        f"The PEFT adapter {peft_id!r} did not attach: peft could not match its "
+        "weights to this model's modules by name, dropped them, and left the "
+        "adapter at its zero initialisation -- so it is a no-op and the model "
+        "would behave exactly like the base checkpoint. The usual cause is a "
+        "`task=` that builds a different architecture than the adapter was trained "
+        "against: e.g. task='text-generation' where the adapter targets a "
+        "multimodal config, which needs task='image-text-to-text'. peft reported: "
+        f"{str(missing[0].message)[:400]}"
     )
 
 
@@ -449,9 +485,14 @@ class TransformersModel(HuggingFaceModel):
         if self.peft is not None:
             # The pipeline loaded the base weights; wrap them with the adapter's
             # real weights so the dispatched model runs with the adapter applied.
-            self.pipeline.model = _import_peft().PeftModel.from_pretrained(
-                self.pipeline.model, self.peft
-            )
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                self.pipeline.model = _import_peft().PeftModel.from_pretrained(
+                    self.pipeline.model, self.peft
+                )
+            for warning in caught:
+                warnings.warn(warning.message, warning.category)
+            _refuse_noop_peft(self.peft, caught)
         self._sync()
         return self.pipeline.model
 
@@ -604,8 +645,22 @@ class TransformersModel(HuggingFaceModel):
 
         if self.peft is not None:
             rebind(self._module.unload())
+            # The module is the base checkpoint from here; keep `self.peft` honest
+            # so a refused load below leaves this envoy self-consistent.
+            self.peft = None
+
         if requested:
-            rebind(_import_peft().PeftModel.from_pretrained(self._module, requested))
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                adapted = _import_peft().PeftModel.from_pretrained(self._module, requested)
+            for warning in caught:
+                warnings.warn(warning.message, warning.category)
+            # Check before rebinding, so a no-op adapter never becomes this envoy's
+            # module. A swap is where this matters most: sweeping several adapters
+            # over one loaded base is exactly the workload where every organism
+            # silently collapsing to the base checkpoint looks like a real result.
+            _refuse_noop_peft(requested, caught)
+            rebind(adapted)
 
         self.peft = requested
 

--- a/src/nnsight/modeling/transformers.py
+++ b/src/nnsight/modeling/transformers.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Optional
 
 import torch
+from torch._guards import detect_fake_mode
 
 from ..intervention.envoy import Envoy, traceable
 from .huggingface import HuggingFaceModel
@@ -994,15 +995,24 @@ class TransformersModel(HuggingFaceModel):
         model (GPT-2 family) would mispredict a short prompt padded up to a longer
         one. Deriving ``position_ids`` from the attention mask keeps every real token
         at its true 0-based position. Only applied to a genuinely left-padded,
-        multi-row, text-only batch: a single or unpadded row needs no correction, a
-        right-padded (encoder) batch is already correct, and a multimodal model
-        derives its own positions from the image-expanded sequence.
+        text-only batch: an *unpadded* batch needs no correction (caught by
+        ``mask.all()``), a right-padded (encoder) batch is already correct, and a
+        multimodal model derives its own positions from the image-expanded sequence.
+        Row count is deliberately not part of this test -- a single padded row needs
+        the correction just as much as a padded batch does, and gating on
+        ``shape[0] > 1`` made the same prompt answer differently depending on whether
+        another row happened to share its batch.
         """
         mask = encoding.get("attention_mask")
+        # Under `scan` the forward runs on fake tensors to propagate shapes only, so
+        # there are no real mask values to read -- `bool(mask.all())` would raise
+        # GuardOnDataDependentSymNode. position_ids do not affect shapes, so skipping
+        # the correction here changes nothing a scan can observe.
+        if detect_fake_mode() is not None:
+            return
         if (
             not isinstance(mask, torch.Tensor)
             or mask.dim() != 2
-            or mask.shape[0] <= 1
             or bool(mask.all())
             or getattr(self.tokenizer, "padding_side", None) != "left"
             or any(key not in self._TEXT_KEYS for key in encoding)

--- a/src/nnsight/modeling/transformers.py
+++ b/src/nnsight/modeling/transformers.py
@@ -283,6 +283,19 @@ class TransformersModel(HuggingFaceModel):
         # per request via _remoteable_set_env without redeploying the base.
         self.peft = peft
 
+        # A sharded module called ad hoc — a logit lens — deals in one rank's
+        # slices either side, where the caller is holding whole tensors.
+        # `TPEnvoy` corrects that, but it is keyed by module *type* (every Linear
+        # and Embedding in the tree) because the style that decides the
+        # correction is stamped on the instance at load rather than carried by a
+        # class. So it goes on only when this construction is actually going to
+        # shard something; an ordinary model keeps the plain `Envoy` it always
+        # had. A caller passing `envoys` of their own replaces it wholesale.
+        from .tp.envoys import tp_envoys, wants_tensor_parallel
+
+        if wants_tensor_parallel(repo_id, kwargs):
+            kwargs.setdefault("envoys", tp_envoys())
+
         super().__init__(repo_id, *args, **kwargs)
 
         # A standalone module (not part of the HF model) that generation output is

--- a/src/nnsight/modeling/vllm/async_backend.py
+++ b/src/nnsight/modeling/vllm/async_backend.py
@@ -38,7 +38,6 @@ a ``step()`` to hook, it happens here, in the stream.
 
 from __future__ import annotations
 
-import pickle
 import uuid
 from typing import TYPE_CHECKING, Any, AsyncGenerator
 
@@ -118,9 +117,9 @@ class AsyncVLLMBackend(Backend):
         """Release an aborted request's worker (and its saved tensors) on the engine."""
         if self._request_id is None:
             return
-        await self.model.vllm_entrypoint.collective_rpc(
-            "collect_nnsight", args=([self._request_id], [self._request_id])
-        )
+        from .engines.engine import acollect
+
+        await acollect(self.model.vllm_entrypoint, self._request_id)
 
     def __await__(self):
         """``await tracer.backend`` drains the stream and returns the last output."""
@@ -137,17 +136,11 @@ class AsyncVLLMBackend(Backend):
         """Fetch this finished request's saved values from the worker onto ``output``."""
         from ...intervention.errors import raise_deferred
 
-        from .engines.engine import attach, merge_collected
+        from .engines.engine import acollect, attach
 
-        request_id = self._request_id
-        results = await self.model.vllm_entrypoint.collective_rpc(
-            "collect_nnsight",
-            args=([request_id], [request_id], {request_id: output}),
+        entry = await acollect(
+            self.model.vllm_entrypoint, self._request_id, output
         )
-        # Merged rather than taking the first rank to answer: a trace's values
-        # come from the rank holding the sampled output, a registered block's from
-        # whichever rank ran the layers it read.
-        entry = merge_collected(results).get(request_id)
         if entry is not None:
             attach(output, entry)
             raise_deferred(entry["error"])

--- a/src/nnsight/modeling/vllm/async_backend.py
+++ b/src/nnsight/modeling/vllm/async_backend.py
@@ -137,15 +137,17 @@ class AsyncVLLMBackend(Backend):
         """Fetch this finished request's saved values from the worker onto ``output``."""
         from ...intervention.errors import raise_deferred
 
+        from .engines.engine import attach, merge_collected
+
         request_id = self._request_id
         results = await self.model.vllm_entrypoint.collective_rpc(
-            "collect_nnsight", args=([request_id], [request_id])
+            "collect_nnsight",
+            args=([request_id], [request_id], {request_id: output}),
         )
-        # Only the rank holding the sampled output returns anything.
-        payload = next((result for result in results if result is not None), None)
-        if payload is None:
-            return
-        entry = pickle.loads(payload).get(request_id)
+        # Merged rather than taking the first rank to answer: a trace's values
+        # come from the rank holding the sampled output, a registered block's from
+        # whichever rank ran the layers it read.
+        entry = merge_collected(results).get(request_id)
         if entry is not None:
-            output.saves = entry["saves"]
+            attach(output, entry)
             raise_deferred(entry["error"])

--- a/src/nnsight/modeling/vllm/batching.py
+++ b/src/nnsight/modeling/vllm/batching.py
@@ -20,19 +20,11 @@ happen once per value however many workers read it.
 
 from __future__ import annotations
 
-from typing import Optional
-
 from ...intervention.batching import Batcher
 
 
 class VLLMBatcher(Batcher):
     """A [`Batcher`][nnsight.intervention.batching.Batcher] over vLLM's flat token axis."""
-
-    def __init__(self, envoy: Optional[object] = None) -> None:
-        # The envoy is optional here alone: the model runner constructs this
-        # before there is a tree to hand it, and nothing in the row math needs
-        # one — the spans come from the scheduler, not from an invoke.
-        super().__init__(envoy)
 
     @property
     def batching(self) -> bool:

--- a/src/nnsight/modeling/vllm/collect.py
+++ b/src/nnsight/modeling/vllm/collect.py
@@ -15,14 +15,18 @@ from __future__ import annotations
 def merge_shared_saves(mediators: list, per_request_saves: list) -> dict:
     """Merge same-name saves across a multi-invoke trace's requests, in place.
 
-    A name shipped by MORE than one request is a shared outer save; its copies
-    merge element-wise — same-length lists slot-wise with ``None`` as the
+    A name that was bound and saved ABOVE the invokes (``mediator.presaved``) is
+    one object locally, so its per-request copies merge element-wise — same-length lists slot-wise with ``None`` as the
     unwritten marker (the common pattern: a pre-sized slot list each invoke
     fills at its own index), dicts by key-union, everything else (and any
     conflicting slot several requests wrote) keeping the later request's copy —
     and the merged value is written into every mediator's scope so results push
-    identically whichever mediator they're read from. A name only one request
-    shipped stays exactly as that request returned it.
+    identically whichever mediator they're read from.
+
+    A name each block saved for itself is NOT merged, however many requests
+    shipped it: those are separate values, not copies of one, and merging them
+    kept only the last — which is how three prompts came back holding one
+    prompt's activation. The caller returns those as a list instead.
 
     Returns the merged shared values by name (the caller re-marks them saved:
     the merge builds new containers the save-gate hasn't seen).
@@ -39,10 +43,16 @@ def merge_shared_saves(mediators: list, per_request_saves: list) -> dict:
             return {**a, **b}
         return b
 
+    presaved: set = set()
+    for mediator in mediators:
+        presaved |= getattr(mediator, "presaved", set())
+
     counts: dict = {}
     merged: dict = {}
     for saves in per_request_saves:
         for name, value in saves.items():
+            if name not in presaved:
+                continue
             counts[name] = counts.get(name, 0) + 1
             merged[name] = merge_pair(merged[name], value) if name in merged else value
     shared = {name: value for name, value in merged.items() if counts[name] > 1}

--- a/src/nnsight/modeling/vllm/engines/engine.py
+++ b/src/nnsight/modeling/vllm/engines/engine.py
@@ -14,7 +14,7 @@ can be handed back on the output they belong to.
 from __future__ import annotations
 
 import pickle
-from typing import Any
+from typing import Any, Optional
 
 from vllm.v1.engine.llm_engine import LLMEngine
 
@@ -63,19 +63,34 @@ def attach(output: Any, entry: dict) -> None:
     output.nnsight_error = entry["error"]
 
 
+async def acollect(engine: Any, request_id: str, output: Any = None) -> Optional[dict]:
+    """One finished request's collected values, merged across the ranks.
+
+    The awaitable form, for the engines whose ``collective_rpc`` is a coroutine.
+    ``output`` is the finished ``RequestOutput``, which the worker cannot build
+    and needs in order to serve ``tracer.result``; without one this is simply the
+    call that winds the request's workers up and frees what they held.
+    """
+    ids = [request_id]
+    args = (ids, ids) if output is None else (ids, ids, {request_id: output})
+    return merge_collected(await engine.collective_rpc("collect_nnsight", args=args)).get(
+        request_id
+    )
+
+
 class NNsightLLMEngine(LLMEngine):
     """An engine that attaches each finished request's saved values to its output."""
 
     def step(self) -> Any:
         outputs = super().step()
 
-        finished = [output.request_id for output in outputs if output.finished]
-        if not finished:
-            return outputs
-
         # The outputs ride along so a block parked on `tracer.result` can be
         # served: the value it is waiting for is assembled here, not in the worker.
         by_id = {output.request_id: output for output in outputs if output.finished}
+        if not by_id:
+            return outputs
+
+        finished = list(by_id)
         collected = merge_collected(
             self.engine_core.collective_rpc(
                 "collect_nnsight", args=(finished, finished, by_id)

--- a/src/nnsight/modeling/vllm/engines/engine.py
+++ b/src/nnsight/modeling/vllm/engines/engine.py
@@ -39,11 +39,19 @@ def merge_collected(payloads: list) -> dict:
             continue
         for request_id, entry in pickle.loads(payload).items():
             into = merged.setdefault(
-                request_id, {"saves": {}, "error": None, "registered": {}}
+                request_id,
+                {"saves": {}, "error": None, "registered": {}, "sequences": {}},
             )
             into["saves"].update(entry.get("saves") or {})
             for name, value in (entry.get("registered") or {}).items():
                 into["registered"].setdefault(name, value)
+            for index, sequence in (entry.get("sequences") or {}).items():
+                target = into["sequences"].setdefault(
+                    index, {"saves": {}, "registered": {}}
+                )
+                target["saves"].update(sequence.get("saves") or {})
+                for name, value in (sequence.get("registered") or {}).items():
+                    target["registered"].setdefault(name, value)
             if into["error"] is None:
                 into["error"] = entry.get("error")
     return merged
@@ -57,10 +65,27 @@ def attach(output: Any, entry: dict) -> None:
     apart, because that is what gets pushed back into the trace's variables and a
     registered value must not land there — see
     [`collect_nnsight`][nnsight.modeling.vllm.model_runners.GPUModelRunner.NNsightGPUModelRunner.collect_nnsight].
+
+    A request that asked for several sampled sequences ran the block once per
+    sequence, so each has values of its own. They go on the completion they
+    belong to — ``output.outputs[i].saves``, alongside that sequence's text and
+    token ids — while ``output.saves`` stays the primary sequence's, which is all
+    there is unless ``n`` was set.
     """
     output.saves = {**entry["registered"], **entry["saves"]}
     output.nnsight_saves = entry["saves"]
     output.nnsight_error = entry["error"]
+
+    sequences = entry.get("sequences") or {}
+    for completion in getattr(output, "outputs", ()) or ():
+        sequence = sequences.get(getattr(completion, "index", 0))
+        if sequence is not None:
+            completion.saves = {**sequence["registered"], **sequence["saves"]}
+    # The trace's own, per sequence and in order, for the push back into the
+    # caller's variables.
+    output.nnsight_sequences = [
+        sequences[index]["saves"] for index in sorted(sequences)
+    ]
 
 
 async def acollect(engine: Any, request_id: str, output: Any = None) -> Optional[dict]:

--- a/src/nnsight/modeling/vllm/engines/engine.py
+++ b/src/nnsight/modeling/vllm/engines/engine.py
@@ -4,6 +4,11 @@ A worker's saved values live in the worker process, and nothing in vLLM's own
 output carries them. The engine knows when a request finishes, which is when its
 worker has nothing left to run, so that is where they are fetched and attached to
 the output the request produced.
+
+Every finished request is collected for, not only the traced ones: a registered
+block (see [`nnsight.modeling.vllm.registration`][nnsight.modeling.vllm.registration])
+runs on requests nnsight never created, and this is the one place their values
+can be handed back on the output they belong to.
 """
 
 from __future__ import annotations
@@ -12,6 +17,43 @@ import pickle
 from typing import Any
 
 from vllm.v1.engine.llm_engine import LLMEngine
+
+
+def merge_collected(payloads: list) -> dict:
+    """Combine what each rank returned from ``collect_nnsight``.
+
+    Not "take the first non-empty": a trace's values come from the rank holding
+    the sampled output, while a registered block's come from whichever rank ran
+    the layers it read — under pipeline parallelism those are different ranks,
+    and taking one would silently drop the other.
+    """
+    merged: dict[str, dict] = {}
+    for payload in payloads or ():
+        if payload is None:
+            continue
+        for request_id, entry in pickle.loads(payload).items():
+            into = merged.setdefault(
+                request_id, {"saves": {}, "error": None, "registered": {}}
+            )
+            into["saves"].update(entry.get("saves") or {})
+            into["registered"].update(entry.get("registered") or {})
+            if into["error"] is None:
+                into["error"] = entry.get("error")
+    return merged
+
+
+def attach(output: Any, entry: dict) -> None:
+    """Put a request's collected values on its output.
+
+    ``saves`` carries both kinds, since from the caller's side they are simply
+    what was saved for this request. ``nnsight_saves`` keeps the trace's own
+    apart, because that is what gets pushed back into the trace's variables and a
+    registered value must not land there — see
+    [`collect_nnsight`][nnsight.modeling.vllm.model_runners.GPUModelRunner.NNsightGPUModelRunner.collect_nnsight].
+    """
+    output.saves = {**entry["registered"], **entry["saves"]}
+    output.nnsight_saves = entry["saves"]
+    output.nnsight_error = entry["error"]
 
 
 class NNsightLLMEngine(LLMEngine):
@@ -24,19 +66,17 @@ class NNsightLLMEngine(LLMEngine):
         if not finished:
             return outputs
 
-        results = self.engine_core.collective_rpc(
-            "collect_nnsight", args=(finished, finished)
+        # The outputs ride along so a block parked on `tracer.result` can be
+        # served: the value it is waiting for is assembled here, not in the worker.
+        by_id = {output.request_id: output for output in outputs if output.finished}
+        collected = merge_collected(
+            self.engine_core.collective_rpc(
+                "collect_nnsight", args=(finished, finished, by_id)
+            )
         )
-        # Ranks that hold no sampled output return nothing.
-        payload = next((result for result in results if result is not None), None)
-        if payload is None:
-            return outputs
-
-        collected = pickle.loads(payload)
         for output in outputs:
             entry = collected.get(output.request_id)
             if entry is not None:
-                output.saves = entry["saves"]
-                output.nnsight_error = entry["error"]
+                attach(output, entry)
 
         return outputs

--- a/src/nnsight/modeling/vllm/engines/engine.py
+++ b/src/nnsight/modeling/vllm/engines/engine.py
@@ -26,6 +26,12 @@ def merge_collected(payloads: list) -> dict:
     the sampled output, while a registered block's come from whichever rank ran
     the layers it read — under pipeline parallelism those are different ranks,
     and taking one would silently drop the other.
+
+    Where two ranks did report the same name — tensor parallelism, where every
+    rank runs the block and each gathers the same whole value — the earliest
+    rank's wins. They are equal, but they are on different devices, and a value
+    whose device depended on which rank answered last would be a confusing thing
+    to hand back next to a traced one.
     """
     merged: dict[str, dict] = {}
     for payload in payloads or ():
@@ -36,7 +42,8 @@ def merge_collected(payloads: list) -> dict:
                 request_id, {"saves": {}, "error": None, "registered": {}}
             )
             into["saves"].update(entry.get("saves") or {})
-            into["registered"].update(entry.get("registered") or {})
+            for name, value in (entry.get("registered") or {}).items():
+                into["registered"].setdefault(name, value)
             if into["error"] is None:
                 into["error"] = entry.get("error")
     return merged

--- a/src/nnsight/modeling/vllm/envoys.py
+++ b/src/nnsight/modeling/vllm/envoys.py
@@ -1,0 +1,94 @@
+"""Envoys for modules vLLM split across ranks.
+
+Interleaving already makes a sharded *activation* whole: the value at a location
+is gathered on the way to a worker and re-split on the way back into vLLM's own
+forward, once per visit, by
+[`VLLMFragments`][nnsight.modeling.vllm.fragments.VLLMFragments]. That covers
+everything read at a location — ``.output``, ``.input`` — because what drives it
+is the model firing its own hooks, and every rank fires them alike.
+
+What it does not cover is an **ad-hoc call**: a logit lens runs ``lm_head`` on
+an intermediate hidden state, away from that module's place in the forward pass.
+The caller is holding, and wants back, whole tensors, but a parallel layer's
+forward expects this rank's piece and returns this rank's piece — so the input is
+cut down on the way in and the output reassembled on the way out, off the rules
+[`VLLMFragments`][nnsight.modeling.vllm.fragments.VLLMFragments] already recorded
+for exactly this envoy's two locations.
+
+Parameters are left alone. ``layer.weight`` is this rank's real slice here, as it
+is anywhere else in vLLM, and gathering one is the caller's business.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from ...intervention.envoy import Envoy
+
+
+def parallel_envoys() -> dict:
+    """The ``envoys`` map pairing vLLM's parallel layers with `ParallelEnvoy`.
+
+    Keys are matched against a module's MRO, so the merged subclasses
+    (``QKVParallelLinear``, ``MergedColumnParallelLinear``, ``ParallelLMHead``)
+    are covered by their bases. Built on demand rather than at import so the
+    module stays importable without vLLM.
+    """
+    from vllm.model_executor.layers.linear import (
+        ColumnParallelLinear,
+        RowParallelLinear,
+    )
+    from vllm.model_executor.layers.vocab_parallel_embedding import (
+        VocabParallelEmbedding,
+    )
+
+    return {
+        ColumnParallelLinear: ParallelEnvoy,
+        RowParallelLinear: ParallelEnvoy,
+        VocabParallelEmbedding: ParallelEnvoy,
+    }
+
+
+class ParallelEnvoy(Envoy):
+    """An envoy over a module holding one rank's piece of a larger one.
+
+    Behaves exactly as an [`Envoy`][nnsight.intervention.envoy.Envoy] on an
+    unsharded engine — the corrections below are keyed off
+    [`VLLMFragments`][nnsight.modeling.vllm.fragments.VLLMFragments], which finds
+    nothing to do on one rank.
+    """
+
+    def __call__(self, *args: Any, hook: bool = False, **kwargs: Any) -> Any:
+        """Run this module's forward ad hoc, on whole tensors either side.
+
+        A parallel layer's forward expects this rank's piece and returns this
+        rank's piece, but a caller reaching for the module ad hoc is holding, and
+        wants back, the real thing. So the input is cut down to this rank's share
+        on the way in and the output reassembled on the way out — which is what
+        [`VLLMFragments`][nnsight.modeling.vllm.fragments.VLLMFragments] already
+        knows how to do, keyed by exactly the two locations `instrument` recorded
+        for this envoy.
+
+        Every rank runs the block, so every rank reaches the same collectives in
+        the same order — as long as the call itself is not under rank-dependent
+        control flow, which is the same condition every other collective here
+        carries.
+        """
+        fragments = self.interleaver.fragments
+
+        if fragments is None or not fragments.enabled:
+            return super().__call__(*args, hook=hook, **kwargs)
+
+        into, outof = f"{self.path}.input", f"{self.path}.output"
+
+        if fragments.fragmented(into):
+            args, kwargs = fragments.fragment(into, (args, kwargs))
+
+        result = super().__call__(*args, hook=hook, **kwargs)
+
+        if fragments.fragmented(outof):
+            result = fragments.whole(outof, result)
+
+        return result

--- a/src/nnsight/modeling/vllm/fragments.py
+++ b/src/nnsight/modeling/vllm/fragments.py
@@ -219,23 +219,38 @@ def _is_piece(module: torch.nn.Module, side: str) -> bool:
 
     if moe is not None and isinstance(module, moe):
         # Only the output is ever a piece: the inputs (hidden states, router
-        # logits) are full replicated tensors under both expert layouts.
-        # `reduce_results=True` (Mixtral) reduces inside forward, and a combine
-        # kernel that already reduced across ranks
-        # (must_reduce_shared_expert_outputs) leaves nothing to gather — neither
-        # was ever exposed as a partial.
-        #
-        # Neither flag exists from 0.27, where the combine moved into the modular
-        # kernel. Until it is settled there whether the layer's output is still a
-        # deferred partial, say no: leaving a value alone reads back whatever vLLM
-        # produced, while gathering one that was never split invents data.
-        if not hasattr(module, "reduce_results"):
+        # logits) are full replicated tensors under every expert layout.
+        if side != "output" or _moe_group_size(module) <= 1:
             return False
-        return (
-            side == "output"
-            and not module.reduce_results
-            and _moe_group_size(module) > 1
-            and not module.must_reduce_shared_expert_outputs()
-        )
+
+        # Which vLLM's layer this is, asked by the flag that decides it rather
+        # than by a `moe_config`, which both eras have.
+        if hasattr(module, "reduce_results"):
+            # Through 0.26 the layer carries its own flags. `reduce_results=True`
+            # (Mixtral) reduces inside forward, and a combine kernel that already
+            # reduced across ranks leaves nothing to gather — neither was ever
+            # exposed as a partial.
+            return not module.reduce_results and (
+                not module.must_reduce_shared_expert_outputs()
+            )
+
+        config = getattr(module, "moe_config", None)
+        if config is None:
+            return False
+
+        # From 0.27 the layer reduces its own output, and the conditions under
+        # which it does not are the ones below — the negation of the guard in
+        # `MoERunner._maybe_all_reduce`. Measured on a two-rank Qwen1.5-MoE: with
+        # none of them set, both ranks hand back the identical tensor, so there is
+        # nothing to gather.
+        if getattr(module, "_fused_output_is_reduced", False):
+            return False
+        if getattr(config, "is_sequence_parallel", False):
+            # Split by rows rather than left as a partial sum: a real fragment,
+            # but one wanting concatenation rather than a sum, which nothing here
+            # does yet. Leaving it alone reads one rank's rows; gathering it as a
+            # partial would be arithmetic on unrelated tokens.
+            return False
+        return bool(getattr(config, "skip_final_all_reduce", False))
 
     return False

--- a/src/nnsight/modeling/vllm/fragments.py
+++ b/src/nnsight/modeling/vllm/fragments.py
@@ -31,7 +31,7 @@ needed: no memo, no ``watch``/``release``, no extra hooks.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Tuple
 
 import torch
 
@@ -42,9 +42,11 @@ from ...util import apply
 def _tp_world_size() -> int:
     """How many ranks this engine's tensor-parallel group spans.
 
-    ``1`` when there is no group yet — a client building a meta tree has vLLM's
-    single-rank gloo group and nothing model-parallel — which is also the answer
-    that means "nothing here is a fragment".
+    The one caller is `VLLMFragments.instrument`, which runs while a worker builds
+    its tree in `NNsightGPUModelRunner.load_model` — after vLLM has initialized the
+    group. The fallback is for a tree built anywhere else: ``1`` is also the answer
+    that means "nothing here is a fragment", so degrading to it leaves an
+    unsharded tree rather than failing the load.
     """
     try:
         from vllm.distributed.parallel_state import get_tp_group
@@ -78,8 +80,7 @@ class VLLMFragments(Fragments):
         once, after ``load_model``, and does not swap modules under it — a hook
         registered on a swapped-out module would have gone just as dead.
         """
-        world_size = _tp_world_size()
-        if world_size < 2:
+        if _tp_world_size() < 2:
             return
 
         module = envoy._module
@@ -97,25 +98,21 @@ class VLLMFragments(Fragments):
             tensor_model_parallel_all_gather,
             tensor_model_parallel_all_reduce,
         )
-        from vllm.model_executor.layers.fused_moe import FusedMoE
         from vllm.model_executor.layers.linear import ColumnParallelLinear
 
         module, side = self.rules[location]
 
-        if isinstance(module, ColumnParallelLinear):
+        if isinstance(module, ColumnParallelLinear) or side == "input":
             # Column sharding splits the output features, so the ranks hold
-            # different columns of the same rows.
+            # different columns of the same rows; a row-parallel layer takes its
+            # input already split by feature. Either way the whole is the ranks'
+            # concatenation.
             collective = tensor_model_parallel_all_gather
-        elif side == "input":
-            # A row-parallel layer takes its input already split by feature.
-            collective = tensor_model_parallel_all_gather
-        elif isinstance(module, FusedMoE):
-            # Each rank holds a partial sum of the experts' combined output —
-            # the same collective the outer block runs right afterwards.
-            collective = tensor_model_parallel_all_reduce
         else:
-            # Row sharding splits the summed terms, so each rank holds a partial
-            # sum and the whole is their total.
+            # Row sharding splits the summed terms, and a deferred-combine FusedMoE
+            # leaves each rank a partial sum of the experts' output — either way
+            # each rank holds part of the total and the whole is their sum. For the
+            # MoE it is the same collective the outer block runs right afterwards.
             collective = tensor_model_parallel_all_reduce
 
         return apply(value, collective, torch.Tensor)
@@ -172,7 +169,7 @@ def _is_piece(module: torch.nn.Module, side: str) -> bool:
 
     if isinstance(module, ColumnParallelLinear):
         # vLLM gathers this itself when asked to, and then it isn't a piece.
-        return not module.gather_output if side == "output" else False
+        return side == "output" and not module.gather_output
 
     if isinstance(module, RowParallelLinear):
         if side == "input":

--- a/src/nnsight/modeling/vllm/fragments.py
+++ b/src/nnsight/modeling/vllm/fragments.py
@@ -125,23 +125,20 @@ class VLLMFragments(Fragments):
         Applied to whatever intervention code left behind, so an edit made to the
         assembled tensor is carried back into the model rather than dropped.
         """
-        from vllm.model_executor.layers.fused_moe import FusedMoE
         from vllm.model_executor.layers.linear import (
             ColumnParallelLinear,
             split_tensor_along_last_dim,
         )
 
         module, side = self.rules[location]
+        moe = _moe_layer()
 
-        if isinstance(module, FusedMoE):
+        if moe is not None and isinstance(module, moe):
             # The block all-reduces this right after the module returns, so hand
             # back an equal share rather than the whole: dividing by the
             # collective's group size gives partials the block's own reduce sums
             # back to the value exactly once instead of double-counting it.
-            # Expert parallelism reassigns the same ranks (the module-internal
-            # tp_size becomes 1 and ep_size becomes the group), so the product is
-            # the group size under both layouts.
-            group_size = module.tp_size * module.ep_size
+            group_size = _moe_group_size(module)
             return apply(whole, lambda tensor: tensor / group_size, torch.Tensor)
 
         if isinstance(module, ColumnParallelLinear) or side == "input":
@@ -157,17 +154,50 @@ class VLLMFragments(Fragments):
         return apply(whole, lambda tensor: tensor / module.tp_size, torch.Tensor)
 
 
+def _moe_layer() -> Any:
+    """The class a model's fused-experts module is, or None if there isn't one.
+
+    ``FusedMoE`` through vLLM 0.26; from 0.27 the layer was rebuilt around a
+    factory and a modular kernel, and the thing a model holds is a ``MoERunner``.
+    Absent is not an error — it only means nothing in this tree can be a
+    fused-experts module, which is the right answer for a vLLM that has neither.
+    """
+    from vllm.model_executor.layers import fused_moe
+
+    for name in ("FusedMoE", "MoERunner"):
+        found = getattr(fused_moe, name, None)
+        if isinstance(found, type):
+            return found
+    return None
+
+
+def _moe_group_size(module: Any) -> int:
+    """How many ranks this MoE layer's experts are spread over.
+
+    Expert parallelism reassigns the same ranks — the module-internal ``tp_size``
+    drops to 1 and ``ep_size`` becomes the group — so the product is the group
+    size under both layouts. From 0.27 these live on the layer's config rather
+    than on the layer.
+    """
+    config = getattr(module, "moe_config", None)
+    if config is not None:
+        parallel = config.moe_parallel_config
+        return parallel.tp_size * parallel.ep_size
+    return module.tp_size * module.ep_size
+
+
 def _is_piece(module: torch.nn.Module, side: str) -> bool:
     """Whether ``module``'s ``side`` really holds one rank's piece.
 
     Asked once per module at load rather than on every forward, so it may be as
     particular as it likes about the cases vLLM already handles itself.
     """
-    from vllm.model_executor.layers.fused_moe import FusedMoE
     from vllm.model_executor.layers.linear import (
         ColumnParallelLinear,
         RowParallelLinear,
     )
+
+    moe = _moe_layer()
 
     # A layer built with `disable_tp=True` is replicated on every rank rather than
     # sharded — vLLM sets its `tp_size` to 1 and guards its own collectives on
@@ -187,17 +217,24 @@ def _is_piece(module: torch.nn.Module, side: str) -> bool:
             return module.input_is_parallel
         return not module.reduce_results
 
-    if isinstance(module, FusedMoE):
+    if moe is not None and isinstance(module, moe):
         # Only the output is ever a piece: the inputs (hidden states, router
         # logits) are full replicated tensors under both expert layouts.
         # `reduce_results=True` (Mixtral) reduces inside forward, and a combine
         # kernel that already reduced across ranks
         # (must_reduce_shared_expert_outputs) leaves nothing to gather — neither
         # was ever exposed as a partial.
+        #
+        # Neither flag exists from 0.27, where the combine moved into the modular
+        # kernel. Until it is settled there whether the layer's output is still a
+        # deferred partial, say no: leaving a value alone reads back whatever vLLM
+        # produced, while gathering one that was never split invents data.
+        if not hasattr(module, "reduce_results"):
+            return False
         return (
             side == "output"
             and not module.reduce_results
-            and module.tp_size * module.ep_size > 1
+            and _moe_group_size(module) > 1
             and not module.must_reduce_shared_expert_outputs()
         )
 

--- a/src/nnsight/modeling/vllm/fragments.py
+++ b/src/nnsight/modeling/vllm/fragments.py
@@ -49,9 +49,11 @@ def _tp_world_size() -> int:
     unsharded tree rather than failing the load.
     """
     try:
-        from vllm.distributed.parallel_state import get_tp_group
+        from vllm.distributed.parallel_state import (
+            get_tensor_model_parallel_world_size,
+        )
 
-        return get_tp_group().world_size
+        return get_tensor_model_parallel_world_size()
     except Exception:
         return 1
 
@@ -166,6 +168,15 @@ def _is_piece(module: torch.nn.Module, side: str) -> bool:
         ColumnParallelLinear,
         RowParallelLinear,
     )
+
+    # A layer built with `disable_tp=True` is replicated on every rank rather than
+    # sharded — vLLM sets its `tp_size` to 1 and guards its own collectives on
+    # `tp_size > 1` for exactly that reason (DeepSeek-V2's `fused_qkv_a_proj` is
+    # one; the branch beside it uses a `ReplicatedLinear` for the same role). The
+    # engine's world size says nothing about it, so ask the module.
+    if isinstance(module, (ColumnParallelLinear, RowParallelLinear)):
+        if module.tp_size == 1:
+            return False
 
     if isinstance(module, ColumnParallelLinear):
         # vLLM gathers this itself when asked to, and then it isn't a piece.

--- a/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
+++ b/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
@@ -33,7 +33,7 @@ import torch
 from vllm.distributed.parallel_state import get_pp_group
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
-from ....intervention.interleaver import Interleaver
+from ....intervention.interleaver import Interleaver, Mediator
 from ....intervention.serialization import loads
 from ....tracing.tracer import _local, _saves, inc
 from ..batching import VLLMBatcher
@@ -49,12 +49,25 @@ if TYPE_CHECKING:
 class Requests:
     """The workers riding this engine's in-flight requests.
 
+    Two kinds of worker run here. A *traced* one arrives on its request, one per
+    request, and goes home when that request finishes. A *registered* one is a
+    block left on the engine ahead of time (see
+    [`nnsight.modeling.vllm.registration`][nnsight.modeling.vllm.registration]):
+    the template is deserialized once, and every request that arrives afterwards
+    — whether or not it is an nnsight trace at all — gets a fresh copy with a
+    scope of its own, whose saves are kept here until they are collected.
+
     Attributes:
-        mediators: Worker by request id, for as long as the request lives.
+        mediators: Traced worker by request id, for as long as the request lives.
         errored: Deferred error by request id for a payload that failed to
             deserialize — surfaced at collect instead of crashing the engine.
         rows: Request ids in the order the forward's tensors carry them.
         tokens: Token count each request contributes this step, by request id.
+        templates: Registration id -> what a per-request copy of that block is
+            built from, so the source is compiled once rather than per request.
+        registered: Request id -> registration id -> that request's own copy.
+        harvested: Registration id -> engine request id -> the values that
+            request's copy saved, waiting to be collected.
     """
 
     def __init__(self) -> None:
@@ -62,6 +75,32 @@ class Requests:
         self.errored: dict[str, Any] = {}
         self.rows: list[str] = []
         self.tokens: dict[str, int] = {}
+        self.templates: dict[str, tuple] = {}
+        self.registered: dict[str, dict[str, Any]] = {}
+        self.harvested: dict[str, dict[str, dict]] = {}
+
+    def register(self, registration_id: str, payload: bytes, persistent_objects: dict) -> None:
+        """Take a block the engine should run for every request from now on.
+
+        Deserializing recompiles the block's source, so it is done once here and
+        the pieces kept; `add` then builds each request's copy from them, which
+        is the whole point of registering rather than tracing.
+        """
+        template = loads(payload, persistent_objects=persistent_objects)
+        self.templates[registration_id] = (
+            template.code,
+            template.glbls,
+            dict(template.lcls),
+            template.presaved,
+        )
+        self.harvested.setdefault(registration_id, {})
+
+    def unregister(self, registration_id: str) -> None:
+        """Stop running a block and forget anything it has not handed back."""
+        self.templates.pop(registration_id, None)
+        self.harvested.pop(registration_id, None)
+        for per_request in self.registered.values():
+            per_request.pop(registration_id, None)
 
     def add(
         self, new_requests: list["NewRequestData"], persistent_objects: dict
@@ -81,6 +120,18 @@ class Requests:
         from ....intervention.errors import capture_exception
 
         for request in new_requests:
+            # Registered blocks apply to every request, including ones carrying no
+            # nnsight payload at all — that is what registering is for. Each gets
+            # its own mediator so its scope, and so what it saves, is this
+            # request's alone.
+            if self.templates:
+                copies = self.registered.setdefault(request.req_id, {})
+                for registration_id, template in self.templates.items():
+                    code, glbls, lcls, presaved = template
+                    mediator = Mediator(code, glbls, dict(lcls))
+                    mediator.presaved = presaved
+                    copies[registration_id] = mediator
+
             extra_args = getattr(request.sampling_params, "extra_args", None) or {}
             if "nnsight_mediator" not in extra_args:
                 continue
@@ -105,45 +156,57 @@ class Requests:
         """
         for mediator in self.mediators.values():
             mediator.batch_group = None
+        for copies in self.registered.values():
+            for mediator in copies.values():
+                mediator.batch_group = None
 
         interleaver = model.interleaver
         scheduled = []
         start = 0
 
+        def take(mediator: Any, tokens: int) -> None:
+            """Give one worker this request's span, starting it the first time."""
+            # A block that already finished is normally dropped — its work is
+            # done and it must not run a second time. Two exceptions stay
+            # scheduled (never restarted, only kept in view): one holding open
+            # caches (tracer.cache()) keeps observing every step until the request
+            # ends, and one that raised keeps a row here so _finish_erred can force
+            # its end-of-sequence every step until vLLM actually retires it —
+            # forcing once is not enough when min_tokens defers the stop.
+            # A mediator has no worker until start(); once started it keeps a
+            # (dead once its block finishes) greenlet. So `worker is not None`
+            # means started, and started-but-not-alive means the block finished.
+            started = mediator.worker is not None
+            finished = started and not mediator.alive
+            if finished and not mediator.caches and mediator.exception is None:
+                return
+            mediator.batch_group = [start, tokens]
+            scheduled.append(mediator)
+            # Which requests run is only settled here, once the forward has
+            # already begun, so a worker is started the moment its request
+            # is first scheduled rather than on the way into the interleaver.
+            if not started:
+                try:
+                    mediator.start(interleaver)
+                except Exception as exception:
+                    # A block that errors before it first parks (a bad line
+                    # at the top) is deferred here, like one that errors
+                    # mid-run in the interleaver; _finish_erred ends it.
+                    if not interleaver.defer_exceptions:
+                        raise
+                    mediator.exception = exception
+
         for request_id in self.rows:
             tokens = self.tokens.get(request_id)
             if tokens is None:
                 continue
+            # Registered copies go first, so a trace written for this request
+            # reads whatever they left behind rather than racing them.
+            for mediator in self.registered.get(request_id, {}).values():
+                take(mediator, tokens)
             mediator = self.mediators.get(request_id)
             if mediator is not None:
-                # A block that already finished is normally dropped — its work is
-                # done and it must not run a second time. Two exceptions stay
-                # scheduled (never restarted, only kept in view): one holding open
-                # caches (tracer.cache()) keeps observing every step until the request
-                # ends, and one that raised keeps a row here so _finish_erred can force
-                # its end-of-sequence every step until vLLM actually retires it —
-                # forcing once is not enough when min_tokens defers the stop.
-                # A mediator has no worker until start(); once started it keeps a
-                # (dead once its block finishes) greenlet. So `worker is not None`
-                # means started, and started-but-not-alive means the block finished.
-                started = mediator.worker is not None
-                finished = started and not mediator.alive
-                if not finished or mediator.caches or mediator.exception is not None:
-                    mediator.batch_group = [start, tokens]
-                    scheduled.append(mediator)
-                    # Which requests run is only settled here, once the forward has
-                    # already begun, so a worker is started the moment its request
-                    # is first scheduled rather than on the way into the interleaver.
-                    if not started:
-                        try:
-                            mediator.start(interleaver)
-                        except Exception as exception:
-                            # A block that errors before it first parks (a bad line
-                            # at the top) is deferred here, like one that errors
-                            # mid-run in the interleaver; _finish_erred ends it.
-                            if not interleaver.defer_exceptions:
-                                raise
-                            mediator.exception = exception
+                take(mediator, tokens)
             start += tokens
 
         # Every scheduled request's tokens, nnsight's or not — the leading dim of
@@ -165,6 +228,9 @@ class Requests:
         for request_id in self.rows:
             if self.tokens.get(request_id) is None:
                 continue
+            for mediator in self.registered.get(request_id, {}).values():
+                if id(mediator) in scheduled:
+                    mediator.batch_group = [row, 1]
             mediator = self.mediators.get(request_id)
             if mediator is not None and id(mediator) in scheduled:
                 mediator.batch_group = [row, 1]
@@ -204,7 +270,12 @@ class Requests:
         from ....intervention.errors import capture_exception
 
         saved = _saves()
-        for mediator in self.mediators.values():
+        registered = [
+            mediator
+            for copies in self.registered.values()
+            for mediator in copies.values()
+        ]
+        for mediator in list(self.mediators.values()) + registered:
             if mediator.batch_group is None:
                 continue
             # Saves marked in this process, plus names the sending process
@@ -222,6 +293,60 @@ class Requests:
                 and getattr(mediator, "nnsight_error", None) is None
             ):
                 mediator.nnsight_error = capture_exception(mediator.exception)
+
+    def harvest(self, finished: set[str]) -> None:
+        """Move finished requests' registered values somewhere collectable.
+
+        Driven by the scheduler's own finished set rather than by a collect, so a
+        registration works for requests nobody is tracing — the OpenAI server's,
+        say — where nothing would otherwise come asking. A worker still parked
+        when its request ends was waiting for a location this request never
+        reached; that is ordinary for a registration (a block written for one
+        architecture's layer, a request that stopped early), so it is unwound
+        quietly and whatever it did save is kept.
+        """
+        for worker_id in list(self.registered):
+            if worker_id not in finished:
+                continue
+            engine_id = worker_id.rsplit("-", 1)[0]
+            for registration_id, mediator in self.registered.pop(worker_id).items():
+                if registration_id not in self.harvested:
+                    continue
+                if mediator.alive:
+                    self.finish_dangling_mediator(mediator)
+                names = getattr(mediator, "nnsight_saved", set()) | mediator.presaved
+                saved = {
+                    name: mediator.lcls[name]
+                    for name in names
+                    if name in mediator.lcls
+                }
+                # A block that raised has to be reported. It saved nothing, so
+                # without this the request would simply be missing from the
+                # results and a broken registration would look like an idle one.
+                error = getattr(mediator, "nnsight_error", None)
+                if saved or error is not None:
+                    self.harvested[registration_id][engine_id] = {
+                        "saves": saved,
+                        "error": error,
+                    }
+
+    def finish_dangling_mediator(self, mediator: Any) -> None:
+        """Unwind a still-parked worker without surfacing an error to anyone.
+
+        `finish_dangling` reports through the request its worker rode in on; a
+        registered copy has no such request to report to, so it is only unwound
+        (running its ``finally`` blocks) and its exception dropped.
+        """
+        from greenlet import error as greenlet_error
+
+        from ....intervention.interleaver import OutOfOrderError
+
+        try:
+            mediator.worker.throw(
+                OutOfOrderError("the request finished before this location was reached")
+            )
+        except (greenlet_error, BaseException):
+            return
 
     def finish_dangling(self, worker_id: str) -> None:
         """Surface a worker still parked when its request has finished.
@@ -247,10 +372,11 @@ class Requests:
         if mediator is None or not mediator.alive:
             return
 
-        # pending is (event, location) for a read, (event, location, value) for a
-        # swap/skip — index rather than unpack, or a worker parked on an edit crashes
-        # here and takes the shared engine down with it.
-        event, requester = mediator.pending[0], mediator.pending[1]
+        # `requester` is printed into the error, where Pending renders as
+        # "{location}.i{n}" — the occurrence is what explains an iter loop that
+        # asked for more steps than the request generated.
+        pending = mediator.pending
+        event, requester = pending.event, pending
         if event is Event.BARRIER:
             error: BaseException = ValueError(
                 "A barrier was never reached by every block it waits for; "
@@ -334,6 +460,12 @@ class NNsightGPUModelRunner(GPUModelRunner):
         super()._update_states(scheduler_output)
 
         requests = self.nnsight_requests
+        # Registered blocks are collected off the scheduler's own finished set:
+        # a request nobody traced has no collect coming for it, and this is the
+        # one place the runner is told it is over.
+        finished = getattr(scheduler_output, "finished_req_ids", None)
+        if finished and requests.registered:
+            requests.harvest(set(finished))
         requests.add(
             scheduler_output.scheduled_new_reqs, self.nnsight_persistent_objects
         )
@@ -367,7 +499,11 @@ class NNsightGPUModelRunner(GPUModelRunner):
         # bounds its growth and stops any id reuse across separate waves of requests.
         # (Residual: reuse *within* one wave of concurrent requests, which is rare.)
         requests = self.nnsight_requests
-        if not requests.mediators and not requests.errored:
+        # Registered blocks count as in-flight too. They mark saves like any other
+        # block, and a block that spans several steps (tracer.iter) is only marked
+        # on the step it first bound the value — clearing underneath it would make
+        # `record_saves` recompute an empty set and drop what it already had.
+        if not requests.mediators and not requests.errored and not requests.registered:
             _saves().clear()
 
         interleaver = self.nnsight_model.interleaver
@@ -532,6 +668,45 @@ class NNsightGPUModelRunner(GPUModelRunner):
             torch.cuda.synchronize()
 
         return pickle.dumps(collected)
+
+    # ------------------------------------------------------------------
+    # Registered blocks (called via collective_rpc on every rank)
+    # ------------------------------------------------------------------
+
+    def nnsight_register(self, registration_id: str, payload: bytes) -> None:
+        """Keep a block and run it for every request from now on.
+
+        See [`nnsight.modeling.vllm.registration`][nnsight.modeling.vllm.registration].
+        Runs on all ranks, so every rank builds the same per-request copies and
+        their reads stay in lockstep — which is what a sharded model's gathers
+        need.
+        """
+        self.nnsight_requests.register(
+            registration_id, payload, self.nnsight_persistent_objects
+        )
+
+    def nnsight_collect_registered(
+        self, registration_id: str, clear: bool = True
+    ) -> Optional[bytes]:
+        """Hand back what a registration's finished requests saved.
+
+        Unlike `collect_nnsight` this answers from every rank: a registered block
+        runs wherever the layers it reads live, so under pipeline parallelism the
+        values are split across stages and the client merges them.
+        """
+        harvested = self.nnsight_requests.harvested.get(registration_id)
+        if not harvested:
+            return None
+        collected = dict(harvested)
+        if clear:
+            harvested.clear()
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+        return pickle.dumps(collected)
+
+    def nnsight_clear_registered(self, registration_id: str) -> None:
+        """Stop running a block and drop what it has not handed back."""
+        self.nnsight_requests.unregister(registration_id)
 
     def nnsight_request_count(self) -> int:
         """How many requests' workers this runner still tracks.

--- a/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
+++ b/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
@@ -129,7 +129,7 @@ class Requests:
                 for registration_id, template in self.templates.items():
                     code, glbls, lcls, presaved = template
                     mediator = Mediator(code, glbls, dict(lcls))
-                    mediator.presaved = presaved
+                    mediator.presaved = set(presaved)
                     copies[registration_id] = mediator
 
             extra_args = getattr(request.sampling_params, "extra_args", None) or {}
@@ -142,6 +142,23 @@ class Requests:
                 )
             except Exception as exception:
                 self.errored[request.req_id] = capture_exception(exception)
+
+    def _by_row(self):
+        """Each scheduled request's token count and its workers, in batch order.
+
+        Registered copies come first, so a trace written for this request reads
+        whatever they left behind rather than racing them. A request the scheduler
+        did not run this step contributes no tokens and no row.
+        """
+        for request_id in self.rows:
+            tokens = self.tokens.get(request_id)
+            if tokens is None:
+                continue
+            workers = list(self.registered.get(request_id, {}).values())
+            mediator = self.mediators.get(request_id)
+            if mediator is not None:
+                workers.append(mediator)
+            yield tokens, workers
 
     def scope(self, model: "VLLM") -> None:
         """Point every worker at its own tokens within this step's batch.
@@ -196,16 +213,8 @@ class Requests:
                         raise
                     mediator.exception = exception
 
-        for request_id in self.rows:
-            tokens = self.tokens.get(request_id)
-            if tokens is None:
-                continue
-            # Registered copies go first, so a trace written for this request
-            # reads whatever they left behind rather than racing them.
-            for mediator in self.registered.get(request_id, {}).values():
-                take(mediator, tokens)
-            mediator = self.mediators.get(request_id)
-            if mediator is not None:
+        for tokens, workers in self._by_row():
+            for mediator in workers:
                 take(mediator, tokens)
             start += tokens
 
@@ -221,41 +230,45 @@ class Requests:
         spans that scoped the forward would select the wrong thing. The row order
         is the same order the forward's tensors used.
         """
-        interleaver = model.interleaver
-        scheduled = {id(mediator) for mediator in interleaver.mediators}
         row = 0
-
-        for request_id in self.rows:
-            if self.tokens.get(request_id) is None:
-                continue
-            for mediator in self.registered.get(request_id, {}).values():
-                if id(mediator) in scheduled:
+        for _, workers in self._by_row():
+            for mediator in workers:
+                # Having a span is exactly what "scheduled" means: `scope` clears
+                # every tracked worker's, `take` sets it for the ones it kept, and
+                # nothing writes one between there and here.
+                if mediator.batch_group is not None:
                     mediator.batch_group = [row, 1]
-            mediator = self.mediators.get(request_id)
-            if mediator is not None and id(mediator) in scheduled:
-                mediator.batch_group = [row, 1]
             row += 1
 
-        interleaver.batcher.total = row
+        model.interleaver.batcher.total = row
 
-    def match(self, request_ids: set[str]) -> list[tuple[str, str]]:
-        """Pair the engine's name for each request with this worker's.
+    @staticmethod
+    def engine_key(worker_id: str, request_ids) -> Optional[str]:
+        """The name the engine knows this request by, or None if it is not asking.
 
         The two sides name the same request differently: vLLM appends a hash of the
         request's content on the way in, so a request the engine calls ``"0"``
         arrives here as ``"0-a2460f0e"``. Saves have to go home under the name the
-        engine will recognize.
+        engine will recognize — which is usually the stripped one, but a runtime
+        that does not append the hash (or an id with a ``-`` of its own, as the
+        serve path mints) is known by the whole thing.
+        """
+        engine_id = worker_id.rsplit("-", 1)[0]
+        if engine_id in request_ids:
+            return engine_id
+        return worker_id if worker_id in request_ids else None
+
+    def match(self, request_ids: set[str]) -> list[tuple[str, str]]:
+        """Pair the engine's name for each of our requests with this worker's.
 
         Returns:
             ``(engine_id, worker_id)`` for each requested id that is ours.
         """
         matched = []
         for worker_id in self.mediators:
-            engine_id = worker_id.rsplit("-", 1)[0]
-            if engine_id in request_ids:
+            engine_id = self.engine_key(worker_id, request_ids)
+            if engine_id is not None:
                 matched.append((engine_id, worker_id))
-            elif worker_id in request_ids:
-                matched.append((worker_id, worker_id))
         return matched
 
     def record_saves(self) -> None:
@@ -267,8 +280,6 @@ class Requests:
         captured here and carried on the mediator instead. The set only grows across
         a request's steps, so re-recording each step keeps the latest superset.
         """
-        from ....intervention.errors import capture_exception
-
         registered = [
             mediator
             for copies in self.registered.values()
@@ -328,7 +339,7 @@ class Requests:
             engine_id = worker_id.rsplit("-", 1)[0]
             # Named either way: the scheduler says "0-a2460f0e", a collect asks
             # with the engine's "0".
-            if worker_id not in finished and engine_id not in finished:
+            if self.engine_key(worker_id, finished) is None:
                 continue
             for registration_id, mediator in self.registered.pop(worker_id).items():
                 if registration_id not in self.harvested:
@@ -358,15 +369,13 @@ class Requests:
         registered copy has no such request to report to, so it is only unwound
         (running its ``finally`` blocks) and its exception dropped.
         """
-        from greenlet import error as greenlet_error
-
         from ....intervention.interleaver import OutOfOrderError
 
         try:
             mediator.worker.throw(
                 OutOfOrderError("the request finished before this location was reached")
             )
-        except (greenlet_error, BaseException):
+        except BaseException:
             return
 
     def serve_result(self, worker_id: str, output: Any) -> None:
@@ -422,9 +431,8 @@ class Requests:
         # `requester` is printed into the error, where Pending renders as
         # "{location}.i{n}" — the occurrence is what explains an iter loop that
         # asked for more steps than the request generated.
-        pending = mediator.pending
-        event, requester = pending.event, pending
-        if event is Event.BARRIER:
+        requester = mediator.pending
+        if requester.event is Event.BARRIER:
             error: BaseException = ValueError(
                 "A barrier was never reached by every block it waits for; "
                 "check the count it was created with"
@@ -475,8 +483,6 @@ class NNsightGPUModelRunner(GPUModelRunner):
 
         super().load_model(*args, **kwargs)
 
-        batcher = VLLMBatcher()
-
         # An Envoy tree over the real module. Passing a loaded module builds it
         # directly, so no weights are read twice and the paths match the ones the
         # client's meta tree gave the user. Building it here is also what walks
@@ -489,8 +495,9 @@ class NNsightGPUModelRunner(GPUModelRunner):
         self.nnsight_model.tokenizer = cached_tokenizer_from_config(self.model_config)
 
         interleaver = self.nnsight_model.interleaver
-        interleaver.mediators = []
-        interleaver.batcher = batcher
+        # No envoy: the spans come from the scheduler rather than from an invoke,
+        # so the row math never looks at a tree — and there is none to hand it yet.
+        interleaver.batcher = VLLMBatcher(None)
         # A worker's error must end only its own request, not tear down the engine
         # every other request shares.
         interleaver.defer_exceptions = True
@@ -685,6 +692,11 @@ class NNsightGPUModelRunner(GPUModelRunner):
         wanted = set(request_ids) | finished
         collected: dict[str, dict] = {}
 
+        def entry_for(request_id: str) -> dict:
+            return collected.setdefault(
+                request_id, {"saves": {}, "error": None, "registered": {}}
+            )
+
         # Harvest anything finished that the scheduler has not got to yet, so a
         # collect never reads an empty shelf for a request that is over.
         if finished and requests.registered:
@@ -701,16 +713,22 @@ class NNsightGPUModelRunner(GPUModelRunner):
                 if engine_id not in wanted:
                     continue
                 taken = harvested.pop(engine_id)
-                entry = collected.setdefault(
-                    engine_id, {"saves": {}, "error": None, "registered": {}}
-                )
+                entry = entry_for(engine_id)
                 entry["registered"].update(taken["saves"])
                 if entry["error"] is None:
                     entry["error"] = taken["error"]
 
-        # Everything below is the trace's own, and only one rank holds it.
-        if get_pp_group().rank != 0:
-            return pickle.dumps(collected)
+        # Everything below is the trace's own. Every rank ran the block and so
+        # has a worker to wind up, but only one rank's values are wanted: the
+        # reads are gathered, so every rank holds the same ones, and shipping
+        # them all would cost bandwidth to hand back a copy that is thrown away.
+        #
+        # Only the *reporting* is gated. This used to be an early return, which
+        # left every other rank's workers, their greenlets, and their captured
+        # activations in place for the life of the engine — `get_pp_group().rank`
+        # is the global rank when there is no pipeline, so under plain tensor
+        # parallelism every rank but 0 skipped its own cleanup.
+        reporting = get_pp_group().rank == 0
 
         matched = requests.match(wanted)
 
@@ -742,39 +760,34 @@ class NNsightGPUModelRunner(GPUModelRunner):
             if engine_id in finished:
                 requests.finish_dangling(worker_id)
 
-        for engine_id, worker_id in matched:
-            entry = collected.setdefault(
-                engine_id, {"saves": {}, "error": None, "registered": {}}
-            )
-            entry["saves"] = requests.saves(worker_id)
-            if entry["error"] is None:
-                entry["error"] = requests.error(worker_id)
-
-        # Requests whose payload failed to deserialize (see Requests.add) carry no
-        # worker; surface their captured error here, keyed like the collected saves.
-        for req_id, error in list(requests.errored.items()):
-            engine_id = req_id.rsplit("-", 1)[0]
-            key = engine_id if engine_id in wanted else req_id if req_id in wanted else None
-            if key is None:
-                continue
-            entry = collected.setdefault(
-                key, {"saves": {}, "error": None, "registered": {}}
-            )
-            entry["error"] = error
-            if engine_id in finished or req_id in finished:
-                requests.errored.pop(req_id, None)
-
         saved = _saves()
         for engine_id, worker_id in matched:
+            values = requests.saves(worker_id)
+            if reporting:
+                entry = entry_for(engine_id)
+                entry["saves"] = values
+                if entry["error"] is None:
+                    entry["error"] = requests.error(worker_id)
             if engine_id in finished:
                 # Drop this request's saved values from the thread-local set as they
                 # leave: it is keyed by object id, so a finished request's ids left
                 # behind could be reused by a later request's values and mistaken for
                 # saved. (No-op on a collect thread other than the workers' own, e.g.
                 # Ray, where that set is empty — but harmless.)
-                for value in collected[engine_id]["saves"].values():
+                for value in values.values():
                     saved.discard(id(value))
                 requests.mediators.pop(worker_id, None)
+
+        # Requests whose payload failed to deserialize (see Requests.add) carry no
+        # worker; surface their captured error here, keyed like the collected saves.
+        for req_id, error in list(requests.errored.items()):
+            key = Requests.engine_key(req_id, wanted)
+            if key is None:
+                continue
+            if reporting:
+                entry_for(key)["error"] = error
+            if Requests.engine_key(req_id, finished) is not None:
+                requests.errored.pop(req_id, None)
 
         # Saves may still be device work in flight; they are about to be pickled.
         if torch.cuda.is_available():
@@ -783,7 +796,7 @@ class NNsightGPUModelRunner(GPUModelRunner):
         return pickle.dumps(collected)
 
     # ------------------------------------------------------------------
-    # Registered blocks (called via collective_rpc on every rank)
+    # Worker-side RPC entry points (called by name via collective_rpc)
     # ------------------------------------------------------------------
 
     def nnsight_register(self, registration_id: str, payload: bytes) -> None:

--- a/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
+++ b/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
@@ -269,7 +269,6 @@ class Requests:
         """
         from ....intervention.errors import capture_exception
 
-        saved = _saves()
         registered = [
             mediator
             for copies in self.registered.values()
@@ -278,27 +277,47 @@ class Requests:
         for mediator in list(self.mediators.values()) + registered:
             if mediator.batch_group is None:
                 continue
-            # Saves marked in this process, plus names the sending process
-            # marked before serialization (Mediator.presaved).
-            mediator.nnsight_saved = {
-                name for name, value in mediator.lcls.items() if id(value) in saved
-            } | mediator.presaved
-            # An error (or stop) is captured on the workers' own thread too, for the
-            # same reason saves are — the collect thread cannot read the exception's
-            # intervention traceback off this greenlet. Captured once: an erred worker
-            # stays scheduled (see Requests.scope) and would otherwise re-capture every
-            # step until the request is retired.
-            if (
-                mediator.exception is not None
-                and getattr(mediator, "nnsight_error", None) is None
-            ):
-                mediator.nnsight_error = capture_exception(mediator.exception)
+            self.record(mediator)
+
+    def record(self, mediator: Any) -> None:
+        """Snapshot one worker's saved names, and its error if it has one.
+
+        Split out because the snapshot is not only taken per step: a worker served
+        at collect time — one parked on ``tracer.result``, which only exists once
+        the engine has assembled the output — binds its name after the last
+        `record_saves` of the run, and would otherwise be recorded as having
+        saved nothing.
+        """
+        from ....intervention.errors import capture_exception
+
+        saved = _saves()
+        # Saves marked in this process, plus names the sending process
+        # marked before serialization (Mediator.presaved).
+        mediator.nnsight_saved = {
+            name for name, value in mediator.lcls.items() if id(value) in saved
+        } | mediator.presaved
+        # An error (or stop) is captured on the workers' own thread too, for the
+        # same reason saves are — the collect thread cannot read the exception's
+        # intervention traceback off this greenlet. Captured once: an erred worker
+        # stays scheduled (see Requests.scope) and would otherwise re-capture every
+        # step until the request is retired.
+        if (
+            mediator.exception is not None
+            and getattr(mediator, "nnsight_error", None) is None
+        ):
+            mediator.nnsight_error = capture_exception(mediator.exception)
 
     def harvest(self, finished: set[str]) -> None:
         """Move finished requests' registered values somewhere collectable.
 
-        Driven by the scheduler's own finished set rather than by a collect, so a
-        registration works for requests nobody is tracing — the OpenAI server's,
+        Driven by the scheduler's own finished set, and again by a collect that
+        finds a request not yet harvested — the scheduler's pass happens at the
+        top of the *next* step, which on the async path may come after the
+        collect, or (for the last request in flight) never. Idempotent: a request
+        already harvested is gone from `registered` and skipped.
+
+        Off the scheduler rather than only off a collect so a registration works
+        for requests nobody is tracing — the OpenAI server's,
         say — where nothing would otherwise come asking. A worker still parked
         when its request ends was waiting for a location this request never
         reached; that is ordinary for a registration (a block written for one
@@ -306,9 +325,11 @@ class Requests:
         quietly and whatever it did save is kept.
         """
         for worker_id in list(self.registered):
-            if worker_id not in finished:
-                continue
             engine_id = worker_id.rsplit("-", 1)[0]
+            # Named either way: the scheduler says "0-a2460f0e", a collect asks
+            # with the engine's "0".
+            if worker_id not in finished and engine_id not in finished:
+                continue
             for registration_id, mediator in self.registered.pop(worker_id).items():
                 if registration_id not in self.harvested:
                     continue
@@ -347,6 +368,32 @@ class Requests:
             )
         except (greenlet_error, BaseException):
             return
+
+    def serve_result(self, worker_id: str, output: Any) -> None:
+        """Hand a finished request's output to a worker parked on ``tracer.result``.
+
+        A worker parked anywhere else is left alone — its own location is what it
+        is waiting for, and `finish_dangling` reports it. Runs on the workers'
+        own thread where the greenlet can be resumed; where that differs (Ray's
+        collect) the switch is refused and the read is left unserved, exactly as
+        it was before.
+        """
+        from greenlet import error as greenlet_error
+
+        mediator = self.mediators.get(worker_id)
+        if mediator is None or not mediator.alive:
+            return
+        pending = mediator.pending
+        if pending is None or pending.provider != "result":
+            return
+        try:
+            mediator.handle("result", output)
+        except greenlet_error:
+            return
+        # The block ran on past its read and bound whatever it saved there, after
+        # the run's last `record_saves` — so take the snapshot again or those
+        # names go home missing.
+        self.record(mediator)
 
     def finish_dangling(self, worker_id: str) -> None:
         """Surface a worker still parked when its request has finished.
@@ -604,26 +651,90 @@ class NNsightGPUModelRunner(GPUModelRunner):
         return interleaver
 
     def collect_nnsight(
-        self, request_ids: list[str], finished_request_ids: Optional[list[str]] = None
+        self,
+        request_ids: list[str],
+        finished_request_ids: Optional[list[str]] = None,
+        outputs: Optional[dict] = None,
     ) -> Optional[bytes]:
         """Return the saved values and any deferred error of the named requests.
 
         Keyed per request rather than merged, so two traces that happen to name a
         variable the same don't overwrite each other on the way home. Each entry is
-        ``{"saves": {...}, "error": <deferred error or None>}``.
+        ``{"saves": {...}, "error": ..., "registered": {...}}``.
+
+        A registered block's values are kept apart from the trace's own because
+        they are not the same kind of thing: a name a *trace* saved on several
+        requests is one shared container the invokes were writing into, and
+        [`merge_shared_saves`][nnsight.modeling.vllm.collect.merge_shared_saves]
+        reassembles it on that assumption. A registration saving the same name on
+        every request it runs on looks identical from the outside and is not — it
+        is one value per request — so merging them together would quietly fold a
+        thousand separate activations into one.
 
         Args:
             request_ids: Requests to collect saved values from.
             finished_request_ids: Those that are done, whose workers are wound up
                 and forgotten afterwards.
+            outputs: Engine request id -> the ``RequestOutput`` that request
+                produced, for serving ``tracer.result``. The engine has it and the
+                worker does not, so it has to be handed back across; a caller that
+                does not pass it simply leaves ``result`` unserved.
         """
-        # Only one rank holds the sampled output; the others have nothing to say.
-        if get_pp_group().rank != 0:
-            return None
-
         requests = self.nnsight_requests
         finished = set(finished_request_ids or [])
-        matched = requests.match(set(request_ids) | finished)
+        wanted = set(request_ids) | finished
+        collected: dict[str, dict] = {}
+
+        # Harvest anything finished that the scheduler has not got to yet, so a
+        # collect never reads an empty shelf for a request that is over.
+        if finished and requests.registered:
+            requests.harvest(finished)
+
+        # Registered values, taken rather than read. This is the only way out for
+        # them: the output they ride home on is the one the caller already has, so
+        # nothing else will come asking and holding a second copy would just grow.
+        # Answered from *every* rank — a registered block runs wherever the layers
+        # it reads live, which under pipeline parallelism is not only rank 0 — and
+        # the caller merges what the ranks return.
+        for harvested in requests.harvested.values():
+            for engine_id in list(harvested):
+                if engine_id not in wanted:
+                    continue
+                taken = harvested.pop(engine_id)
+                entry = collected.setdefault(
+                    engine_id, {"saves": {}, "error": None, "registered": {}}
+                )
+                entry["registered"].update(taken["saves"])
+                if entry["error"] is None:
+                    entry["error"] = taken["error"]
+
+        # Everything below is the trace's own, and only one rank holds it.
+        if get_pp_group().rank != 0:
+            return pickle.dumps(collected)
+
+        matched = requests.match(wanted)
+
+        # The run's return value, served the way [`Envoy.interleave`][nnsight.intervention.envoy.Envoy.interleave]
+        # serves it locally — right after the model has produced it and before
+        # anything is read back. It cannot be served there for this runtime: the
+        # block runs here in the worker and the value is a `RequestOutput` the
+        # *engine* assembles, so this is the first moment both exist. Served per
+        # request, since each has its own.
+        for engine_id, worker_id in matched:
+            if engine_id in finished and outputs and engine_id in outputs:
+                output = outputs[engine_id]
+                # What a registered block saved for this request, put on the copy
+                # the block is about to be handed. It is the one thing a trace
+                # cannot reach any other way: the engine attaches it to *its* copy
+                # after this returns, and the trace never sees that object.
+                #
+                # The trace's own saves are not here and cannot be: they are what
+                # this call is collecting, and one of them may be the output
+                # itself.
+                registered = collected.get(engine_id, {}).get("registered")
+                if registered:
+                    output.saves = dict(registered)
+                requests.serve_result(worker_id, output)
 
         # A worker still parked when its request finishes was waiting on a location the
         # model never reached; surface that as its deferred error before it is read.
@@ -631,25 +742,46 @@ class NNsightGPUModelRunner(GPUModelRunner):
             if engine_id in finished:
                 requests.finish_dangling(worker_id)
 
-        collected = {
-            engine_id: {
-                "saves": requests.saves(worker_id),
-                "error": requests.error(worker_id),
-            }
-            for engine_id, worker_id in matched
-        }
+        for engine_id, worker_id in matched:
+            entry = collected.setdefault(
+                engine_id, {"saves": {}, "error": None, "registered": {}}
+            )
+            entry["saves"] = requests.saves(worker_id)
+            if entry["error"] is None:
+                entry["error"] = requests.error(worker_id)
 
         # Requests whose payload failed to deserialize (see Requests.add) carry no
         # worker; surface their captured error here, keyed like the collected saves.
-        wanted = set(request_ids) | finished
         for req_id, error in list(requests.errored.items()):
             engine_id = req_id.rsplit("-", 1)[0]
             key = engine_id if engine_id in wanted else req_id if req_id in wanted else None
             if key is None:
                 continue
-            collected[key] = {"saves": {}, "error": error}
+            entry = collected.setdefault(
+                key, {"saves": {}, "error": None, "registered": {}}
+            )
+            entry["error"] = error
             if engine_id in finished or req_id in finished:
                 requests.errored.pop(req_id, None)
+
+        # Registered blocks ride requests nnsight did not create, so their values
+        # are keyed here by the same engine id. Merging them means a caller that
+        # is already collecting gets them on the output without a second trip —
+        # both the sync engine's `step`, which collects for *every* finished
+        # request, and the async backend, which collects for its own.
+        #
+        # Not removed: `Registration.drain` is still the way to take them, and a
+        # request whose output nobody reads (a served one) would otherwise lose
+        # them entirely. That does mean a collected value is held twice until the
+        # registration is drained.
+        for harvested in requests.harvested.values():
+            for engine_id in harvested:
+                if engine_id not in wanted:
+                    continue
+                entry = collected.setdefault(engine_id, {"saves": {}, "error": None})
+                entry["saves"].update(harvested[engine_id]["saves"])
+                if entry["error"] is None:
+                    entry["error"] = harvested[engine_id]["error"]
 
         saved = _saves()
         for engine_id, worker_id in matched:
@@ -684,25 +816,6 @@ class NNsightGPUModelRunner(GPUModelRunner):
         self.nnsight_requests.register(
             registration_id, payload, self.nnsight_persistent_objects
         )
-
-    def nnsight_collect_registered(
-        self, registration_id: str, clear: bool = True
-    ) -> Optional[bytes]:
-        """Hand back what a registration's finished requests saved.
-
-        Unlike `collect_nnsight` this answers from every rank: a registered block
-        runs wherever the layers it reads live, so under pipeline parallelism the
-        values are split across stages and the client merges them.
-        """
-        harvested = self.nnsight_requests.harvested.get(registration_id)
-        if not harvested:
-            return None
-        collected = dict(harvested)
-        if clear:
-            harvested.clear()
-        if torch.cuda.is_available():
-            torch.cuda.synchronize()
-        return pickle.dumps(collected)
 
     def nnsight_clear_registered(self, registration_id: str) -> None:
         """Stop running a block and drop what it has not handed back."""

--- a/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
+++ b/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
@@ -764,25 +764,6 @@ class NNsightGPUModelRunner(GPUModelRunner):
             if engine_id in finished or req_id in finished:
                 requests.errored.pop(req_id, None)
 
-        # Registered blocks ride requests nnsight did not create, so their values
-        # are keyed here by the same engine id. Merging them means a caller that
-        # is already collecting gets them on the output without a second trip —
-        # both the sync engine's `step`, which collects for *every* finished
-        # request, and the async backend, which collects for its own.
-        #
-        # Not removed: `Registration.drain` is still the way to take them, and a
-        # request whose output nobody reads (a served one) would otherwise lose
-        # them entirely. That does mean a collected value is held twice until the
-        # registration is drained.
-        for harvested in requests.harvested.values():
-            for engine_id in harvested:
-                if engine_id not in wanted:
-                    continue
-                entry = collected.setdefault(engine_id, {"saves": {}, "error": None})
-                entry["saves"].update(harvested[engine_id]["saves"])
-                if entry["error"] is None:
-                    entry["error"] = harvested[engine_id]["error"]
-
         saved = _saves()
         for engine_id, worker_id in matched:
             if engine_id in finished:

--- a/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
+++ b/src/nnsight/modeling/vllm/model_runners/GPUModelRunner.py
@@ -243,32 +243,47 @@ class Requests:
         model.interleaver.batcher.total = row
 
     @staticmethod
-    def engine_key(worker_id: str, request_ids) -> Optional[str]:
-        """The name the engine knows this request by, or None if it is not asking.
+    def engine_key(worker_id: str, request_ids) -> Optional[tuple[str, int]]:
+        """What the engine calls this request, and which of its sequences this is.
 
-        The two sides name the same request differently: vLLM appends a hash of the
-        request's content on the way in, so a request the engine calls ``"0"``
-        arrives here as ``"0-a2460f0e"``. Saves have to go home under the name the
-        engine will recognize — which is usually the stripped one, but a runtime
-        that does not append the hash (or an id with a ``-`` of its own, as the
-        serve path mints) is known by the whole thing.
+        The two sides name the same request differently, in two ways.
+
+        vLLM appends a hash of the request's content on the way in, so a request
+        the engine calls ``"0"`` arrives here as ``"0-a2460f0e"``. And ``n > 1``
+        fans one request out into a child per sampled sequence, named
+        ``"{index}_{parent}"`` (vLLM's ``ParentRequest``), while the engine only
+        ever asks about — and only ever returns — the parent.
+
+        The child reading is taken only when the parent it names is one the engine
+        is actually asking about, so a request whose own id happens to start with
+        digits and an underscore is not mistaken for somebody's second sequence.
+
+        Returns:
+            ``(engine_id, sequence_index)``, or None if this is not one of theirs.
         """
         engine_id = worker_id.rsplit("-", 1)[0]
         if engine_id in request_ids:
-            return engine_id
-        return worker_id if worker_id in request_ids else None
+            return engine_id, 0
+        index, _, parent = engine_id.partition("_")
+        if parent and index.isdigit() and parent in request_ids:
+            return parent, int(index)
+        if worker_id in request_ids:
+            return worker_id, 0
+        return None
 
-    def match(self, request_ids: set[str]) -> list[tuple[str, str]]:
+    def match(self, request_ids: set[str]) -> list[tuple[str, str, int]]:
         """Pair the engine's name for each of our requests with this worker's.
 
         Returns:
-            ``(engine_id, worker_id)`` for each requested id that is ours.
+            ``(engine_id, worker_id, sequence_index)`` for each requested id that
+            is ours. One engine id can appear several times — once per sampled
+            sequence, when the request asked for more than one.
         """
         matched = []
         for worker_id in self.mediators:
-            engine_id = self.engine_key(worker_id, request_ids)
-            if engine_id is not None:
-                matched.append((engine_id, worker_id))
+            key = self.engine_key(worker_id, request_ids)
+            if key is not None:
+                matched.append((key[0], worker_id, key[1]))
         return matched
 
     def record_saves(self) -> None:
@@ -336,7 +351,6 @@ class Requests:
         quietly and whatever it did save is kept.
         """
         for worker_id in list(self.registered):
-            engine_id = worker_id.rsplit("-", 1)[0]
             # Named either way: the scheduler says "0-a2460f0e", a collect asks
             # with the engine's "0".
             if self.engine_key(worker_id, finished) is None:
@@ -357,7 +371,7 @@ class Requests:
                 # results and a broken registration would look like an idle one.
                 error = getattr(mediator, "nnsight_error", None)
                 if saved or error is not None:
-                    self.harvested[registration_id][engine_id] = {
+                    self.harvested[registration_id][worker_id] = {
                         "saves": saved,
                         "error": error,
                     }
@@ -694,8 +708,21 @@ class NNsightGPUModelRunner(GPUModelRunner):
 
         def entry_for(request_id: str) -> dict:
             return collected.setdefault(
-                request_id, {"saves": {}, "error": None, "registered": {}}
+                request_id,
+                {"saves": {}, "error": None, "registered": {}, "sequences": {}},
             )
+
+        def sequence_of(entry: dict, index: int) -> dict:
+            """One sampled sequence's values. Index 0 also fills the flat keys.
+
+            ``saves``/``registered`` are the request's primary sequence, which is
+            all there is unless it asked for several — so a caller that never uses
+            ``n`` reads exactly what it always did.
+            """
+            sequence = entry["sequences"].setdefault(
+                index, {"saves": {}, "registered": {}}
+            )
+            return entry if index == 0 else sequence
 
         # Harvest anything finished that the scheduler has not got to yet, so a
         # collect never reads an empty shelf for a request that is over.
@@ -709,12 +736,17 @@ class NNsightGPUModelRunner(GPUModelRunner):
         # it reads live, which under pipeline parallelism is not only rank 0 — and
         # the caller merges what the ranks return.
         for harvested in requests.harvested.values():
-            for engine_id in list(harvested):
-                if engine_id not in wanted:
+            for worker_id in list(harvested):
+                key = requests.engine_key(worker_id, wanted)
+                if key is None:
                     continue
-                taken = harvested.pop(engine_id)
+                engine_id, index = key
+                taken = harvested.pop(worker_id)
                 entry = entry_for(engine_id)
-                entry["registered"].update(taken["saves"])
+                target = sequence_of(entry, index)
+                target["registered"].update(taken["saves"])
+                if index == 0:
+                    entry["sequences"][0]["registered"].update(taken["saves"])
                 if entry["error"] is None:
                     entry["error"] = taken["error"]
 
@@ -738,7 +770,7 @@ class NNsightGPUModelRunner(GPUModelRunner):
         # block runs here in the worker and the value is a `RequestOutput` the
         # *engine* assembles, so this is the first moment both exist. Served per
         # request, since each has its own.
-        for engine_id, worker_id in matched:
+        for engine_id, worker_id, index in matched:
             if engine_id in finished and outputs and engine_id in outputs:
                 output = outputs[engine_id]
                 # What a registered block saved for this request, put on the copy
@@ -749,23 +781,28 @@ class NNsightGPUModelRunner(GPUModelRunner):
                 # The trace's own saves are not here and cannot be: they are what
                 # this call is collecting, and one of them may be the output
                 # itself.
-                registered = collected.get(engine_id, {}).get("registered")
+                # This sequence's own, when the request asked for several: each
+                # child ran its own copy of the block and is owed its own values.
+                entry = collected.get(engine_id) or {}
+                sequence = (entry.get("sequences") or {}).get(index) or entry
+                registered = sequence.get("registered")
                 if registered:
                     output.saves = dict(registered)
                 requests.serve_result(worker_id, output)
 
         # A worker still parked when its request finishes was waiting on a location the
         # model never reached; surface that as its deferred error before it is read.
-        for engine_id, worker_id in matched:
+        for engine_id, worker_id, _ in matched:
             if engine_id in finished:
                 requests.finish_dangling(worker_id)
 
         saved = _saves()
-        for engine_id, worker_id in matched:
+        for engine_id, worker_id, index in matched:
             values = requests.saves(worker_id)
             if reporting:
                 entry = entry_for(engine_id)
-                entry["saves"] = values
+                sequence_of(entry, index)["saves"] = values
+                entry["sequences"][index]["saves"] = values
                 if entry["error"] is None:
                     entry["error"] = requests.error(worker_id)
             if engine_id in finished:

--- a/src/nnsight/modeling/vllm/registration.py
+++ b/src/nnsight/modeling/vllm/registration.py
@@ -1,0 +1,235 @@
+"""Interventions that stay on the engine and run for every request.
+
+A trace ships its block to the worker on the request it rides, so a sweep of a
+thousand prompts serializes and deserializes the same block a thousand times, and
+only requests that *are* nnsight traces are touched at all.
+
+A registration inverts that. The block goes to the worker once and stays there;
+from then on every request the engine runs gets its own copy of it — including
+requests submitted by something that has never heard of nnsight, an OpenAI-API
+client on the same server. Each copy keeps its own scope, so what it saves is
+that request's own, and the values accumulate on the worker until they are
+collected in one trip.
+
+Example:
+    >>> model = VLLM("meta-llama/Llama-3.1-8B", dispatch=True)
+    >>>
+    >>> with model.register() as (tracer, registration):   # doctest: +SKIP
+    ...     hidden = model.model.layers[16].output[0].save()
+    >>>
+    >>> model.generate("The Eiffel Tower is in", max_tokens=5)   # doctest: +SKIP
+    >>> model.generate("The capital of Japan is", max_tokens=5)  # doctest: +SKIP
+    >>>
+    >>> {request: saved["hidden"].shape                # doctest: +SKIP
+    ...  for request, saved in registration.saves.items()}
+    >>> registration.clear()                        # doctest: +SKIP
+
+The block is written exactly like a trace body — the same envoy tree, the same
+``.save()``. What it cannot do is anything that belongs to one particular
+request: there is no prompt to invoke, so ``tracer.invoke(...)`` has no meaning
+here, and the block applies to whatever the engine happens to run.
+"""
+
+from __future__ import annotations
+
+import pickle
+import uuid
+import warnings
+from types import CodeType
+from typing import TYPE_CHECKING, Any
+
+from ...intervention.interleaver import Mediator
+from ...intervention.serialization import dumps
+from ...intervention.tracer import InterleavingTracer
+from ...tracing.backend import Backend
+from ...tracing.tracer import skip_context, skippable
+
+if TYPE_CHECKING:
+    from .vllm import VLLM
+
+
+def _warn_if_prefix_caching(model: "VLLM") -> None:
+    """Say so if the engine will serve some tokens without a forward pass.
+
+    A prefix-cached token never runs, so no hook fires for it and a registered
+    block sees a short activation — quietly, with nothing to indicate it. A trace
+    can avoid this by asking for its own request to be recomputed (see
+    ``_attach_mediators``), but a registration rides requests it did not create
+    and often did not even come from nnsight, so there is nothing to set the flag
+    on. The engine has to be built with ``enable_prefix_caching=False`` instead,
+    and it is worth saying at the moment the mistake is made rather than leaving
+    it to be found in the shapes.
+    """
+    engine = model.vllm_entrypoint
+    if engine is None:
+        return
+    try:
+        core = getattr(engine, "llm_engine", engine)
+        cache_config = core.vllm_config.cache_config
+    except AttributeError:
+        return
+    if getattr(cache_config, "enable_prefix_caching", False):
+        warnings.warn(
+            "This engine has prefix caching on, so tokens served from the cache "
+            "never run a forward pass and a registered block will not see them — "
+            "its activations come back short, with no error. Build the model with "
+            "VLLM(..., enable_prefix_caching=False) to register against whole "
+            "prompts.",
+            stacklevel=4,
+        )
+
+
+class Registration:
+    """A handle on a block the engine is running for every request.
+
+    Returned by [`VLLM.register`][nnsight.modeling.vllm.vllm.VLLM.register] and
+    live until `clear`. Values pile up on the worker as requests finish;
+    [`saves`][nnsight.modeling.vllm.registration.Registration.saves] reads them
+    and `drain` takes them, neither of which stops the registration — so a long
+    sweep can be emptied in batches while it keeps running.
+
+    Attributes:
+        model: The engine this is registered on.
+        id: The engine-wide name for this registration, used to address it in the
+            worker and to key its side of a collect.
+    """
+
+    def __init__(self, model: "VLLM", id: str) -> None:
+        self.model = model
+        self.id = id
+        self.cleared = False
+
+    def _rpc(self, method: str, *args: Any) -> list:
+        engine = self.model.vllm_entrypoint
+        # The sync entrypoint keeps the engine one level down; the async one is
+        # already the engine.
+        core = getattr(engine, "llm_engine", engine)
+        return core.collective_rpc(method, args=args)
+
+    @property
+    def saves(self) -> dict[str, dict[str, Any]]:
+        """What each finished request's copy of the block saved, by request.
+
+        ``{request_id: {name: value}}``, named the same way a trace's values come
+        back (``output.saves["logits"]``) because they are the same thing — the
+        block's ``.save()``\\ d locals — just one set per request rather than one
+        set in total. The request id is the engine's own, so it matches the
+        ``RequestOutput`` that produced it.
+
+        Reading this does not drop anything: a value stays until `drain` or
+        `clear` takes it, so reading twice gives the same answer. Over a long
+        sweep that accumulates on the worker — use `drain` there.
+        """
+        return self._fetch(clear=False)
+
+    def drain(self) -> dict[str, dict[str, Any]]:
+        """`saves`, and drop what is returned from the worker.
+
+        What a sweep wants: take this batch's values home and leave nothing
+        behind, so the next read is the next batch and the worker's memory does
+        not grow with the number of requests served.
+        """
+        return self._fetch(clear=True)
+
+    def _fetch(self, clear: bool) -> dict[str, dict[str, Any]]:
+        from ...intervention.errors import raise_deferred
+
+        if self.cleared:
+            raise ValueError(
+                "This registration was cleared; register again to collect more."
+            )
+        payloads = self._rpc("nnsight_collect_registered", self.id, clear)
+        collected: dict[str, dict[str, Any]] = {}
+        deferred = None
+        # Under pipeline parallelism each stage holds the part of the block that
+        # ran on it, so merge rather than take the first non-empty answer.
+        for payload in payloads or ():
+            if payload is None:
+                continue
+            for request_id, entry in pickle.loads(payload).items():
+                collected.setdefault(request_id, {}).update(entry["saves"])
+                if deferred is None:
+                    deferred = entry["error"]
+        # The block runs far from whoever wrote it, so an error in it has no
+        # other way home. Raised here rather than returned, so a registration
+        # that is quietly failing on every request cannot be mistaken for one
+        # that is merely finding nothing.
+        raise_deferred(deferred)
+        return collected
+
+    def clear(self) -> None:
+        """Stop running the block and drop anything it has not handed back."""
+        if self.cleared:
+            return
+        self._rpc("nnsight_clear_registered", self.id)
+        self.cleared = True
+
+    def __repr__(self) -> str:
+        state = "cleared" if self.cleared else "active"
+        return f"<Registration {self.id} ({state})>"
+
+
+class RegisteringTracer(InterleavingTracer):
+    """Capture a block and leave it on the engine instead of running it once.
+
+    The counterpart of [`EditingTracer`][nnsight.intervention.editing.EditingTracer]
+    for a runtime whose model lives in another process: an edit is replayed by
+    the envoy that stores it, which on vLLM would leave it in the client, where
+    there are no weights. This sends the block across instead, and hands back a
+    [`Registration`][nnsight.modeling.vllm.registration.Registration] to collect
+    through.
+    """
+
+    def __init__(self, model: "VLLM", *, backend: Backend | None = None) -> None:
+        super().__init__(model, "__call__", backend=backend)
+        self._model = model
+        self.registration: Registration | None = None
+
+    def __enter__(self) -> tuple["RegisteringTracer", Registration]:
+        """Enter the block, binding the tracer and the handle results come back through.
+
+        Both, the way [`Envoy.edit`][nnsight.intervention.envoy.Envoy.edit] binds
+        ``(tracer, edited)``: a registered block is still a trace body, and the
+        tracer is what carries ``iter``/``all``, without which the block could
+        only ever see a request's first forward — its prefill — and never the
+        steps it generates::
+
+            with model.register() as (tracer, registration):
+                readouts = nnsight.save([])
+                for step in tracer.all():
+                    readouts.append(model.model.layers[16].output[0][-1])
+        """
+        # Mirror Tracer.__enter__ directly (not via super()) so capture and the
+        # skip guard see the user's frame at the same depth, as EditingTracer does.
+        self.capture()
+        if skippable(self.node):
+            skip_context(self)
+        # Not id(self): this tracer is a temporary, so the next register() can be
+        # allocated at the same address and collide with this one — which the
+        # worker would read as a re-registration, overwriting the first block and
+        # handing both handles the same values.
+        self.registration = Registration(
+            self._model, id=f"registration-{uuid.uuid4().hex}"
+        )
+        return self, self.registration
+
+    def execute(self, code: CodeType) -> None:
+        """Ship the block to the workers rather than running it here.
+
+        ``copy`` is left off: the worker builds a fresh mediator per request from
+        this template, so each request already has a scope of its own, and the
+        block's saves have to land in it for collection to find them.
+        """
+        model = self._model
+        if not model.dispatched:
+            model.dispatch()
+        _warn_if_prefix_caching(model)
+
+        template = Mediator(
+            code,
+            self.info.frame.f_globals,
+            dict(self.info.frame.f_locals),
+            node=self.node,
+        )
+        registration = self.registration
+        registration._rpc("nnsight_register", registration.id, dumps(template))

--- a/src/nnsight/modeling/vllm/registration.py
+++ b/src/nnsight/modeling/vllm/registration.py
@@ -8,31 +8,36 @@ A registration inverts that. The block goes to the worker once and stays there;
 from then on every request the engine runs gets its own copy of it — including
 requests submitted by something that has never heard of nnsight, an OpenAI-API
 client on the same server. Each copy keeps its own scope, so what it saves is
-that request's own, and the values accumulate on the worker until they are
-collected in one trip.
+that request's own, and it comes back on that request's ``RequestOutput`` —
+``output.saves`` — by the same collect a traced value uses, then is dropped.
 
 Example:
-    >>> model = VLLM("meta-llama/Llama-3.1-8B", dispatch=True)
+    >>> model = VLLM("meta-llama/Llama-3.1-8B", dispatch=True,
+    ...              enable_prefix_caching=False)
     >>>
-    >>> with model.register() as (tracer, registration):   # doctest: +SKIP
+    >>> with model.register() as (tracer, registration):        # doctest: +SKIP
     ...     hidden = model.model.layers[16].output[0].save()
     >>>
-    >>> model.generate("The Eiffel Tower is in", max_tokens=5)   # doctest: +SKIP
-    >>> model.generate("The capital of Japan is", max_tokens=5)  # doctest: +SKIP
+    >>> outputs = model.vllm_entrypoint.generate(prompts, sampling)  # doctest: +SKIP
+    >>> outputs[5].saves["hidden"].shape                        # doctest: +SKIP
     >>>
-    >>> {request: saved["hidden"].shape                # doctest: +SKIP
-    ...  for request, saved in registration.saves.items()}
-    >>> registration.clear()                        # doctest: +SKIP
+    >>> registration.clear()                                    # doctest: +SKIP
 
 The block is written exactly like a trace body — the same envoy tree, the same
 ``.save()``. What it cannot do is anything that belongs to one particular
 request: there is no prompt to invoke, so ``tracer.invoke(...)`` has no meaning
 here, and the block applies to whatever the engine happens to run.
+
+The engine has to be built with ``enable_prefix_caching=False``. A prefix-cached
+token is served without a forward pass, so no hook fires for it and the block
+sees fewer rows than the prompt has, with nothing to say so. A trace asks for its
+own request to be recomputed; a registration rides requests it did not create and
+cannot, so the cache has to be off at the engine — registering against one that
+has it on warns.
 """
 
 from __future__ import annotations
 
-import pickle
 import uuid
 import warnings
 from types import CodeType
@@ -83,15 +88,24 @@ class Registration:
     """A handle on a block the engine is running for every request.
 
     Returned by [`VLLM.register`][nnsight.modeling.vllm.vllm.VLLM.register] and
-    live until `clear`. Values pile up on the worker as requests finish;
-    [`saves`][nnsight.modeling.vllm.registration.Registration.saves] reads them
-    and `drain` takes them, neither of which stops the registration — so a long
-    sweep can be emptied in batches while it keeps running.
+    live until `clear`.
+
+    There is nothing to read here. What a registered block saves comes back on
+    the ``RequestOutput`` of the request it ran on, as ``output.saves``, by the
+    same collect that carries a traced value — so the values arrive where the
+    request that produced them already is, and are dropped as they go. Nothing
+    accumulates for as long as somebody is reading the outputs, which on the
+    synchronous engine is every request there is.
+
+    Synchronous engines only: installing the block is a ``collective_rpc``, which
+    on ``mode="async"`` is a coroutine there is no safe way to finish from a
+    plain statement, so `VLLM.register` refuses there rather than silently not
+    installing it.
 
     Attributes:
         model: The engine this is registered on.
         id: The engine-wide name for this registration, used to address it in the
-            worker and to key its side of a collect.
+            worker.
     """
 
     def __init__(self, model: "VLLM", id: str) -> None:
@@ -100,68 +114,65 @@ class Registration:
         self.cleared = False
 
     def _rpc(self, method: str, *args: Any) -> list:
+        """Reach every worker.
+
+        Synchronous, because registering and clearing are ordinary statements.
+        The async engine's ``collective_rpc`` is a coroutine instead, and there is
+        no safe way to finish one from here — driving it on a loop of our own
+        deadlocks against the loop the engine is already running on. So this
+        refuses rather than returning a coroutine nobody awaits, which is what it
+        used to do: the block was never installed and nothing said so.
+        """
+        import inspect
+
         engine = self.model.vllm_entrypoint
         # The sync entrypoint keeps the engine one level down; the async one is
         # already the engine.
         core = getattr(engine, "llm_engine", engine)
-        return core.collective_rpc(method, args=args)
-
-    @property
-    def saves(self) -> dict[str, dict[str, Any]]:
-        """What each finished request's copy of the block saved, by request.
-
-        ``{request_id: {name: value}}``, named the same way a trace's values come
-        back (``output.saves["logits"]``) because they are the same thing — the
-        block's ``.save()``\\ d locals — just one set per request rather than one
-        set in total. The request id is the engine's own, so it matches the
-        ``RequestOutput`` that produced it.
-
-        Reading this does not drop anything: a value stays until `drain` or
-        `clear` takes it, so reading twice gives the same answer. Over a long
-        sweep that accumulates on the worker — use `drain` there.
-        """
-        return self._fetch(clear=False)
-
-    def drain(self) -> dict[str, dict[str, Any]]:
-        """`saves`, and drop what is returned from the worker.
-
-        What a sweep wants: take this batch's values home and leave nothing
-        behind, so the next read is the next batch and the worker's memory does
-        not grow with the number of requests served.
-        """
-        return self._fetch(clear=True)
-
-    def _fetch(self, clear: bool) -> dict[str, dict[str, Any]]:
-        from ...intervention.errors import raise_deferred
-
-        if self.cleared:
-            raise ValueError(
-                "This registration was cleared; register again to collect more."
+        result = core.collective_rpc(method, args=args)
+        if inspect.iscoroutine(result):
+            result.close()
+            raise NotImplementedError(
+                f"{method} has to reach the engine's workers, and on an async "
+                "engine (mode='async') that call is a coroutine this cannot "
+                "await. Registration is synchronous-engine only for now; build "
+                "with mode='sync', or trace the requests you want to instrument."
             )
-        payloads = self._rpc("nnsight_collect_registered", self.id, clear)
-        collected: dict[str, dict[str, Any]] = {}
-        deferred = None
-        # Under pipeline parallelism each stage holds the part of the block that
-        # ran on it, so merge rather than take the first non-empty answer.
-        for payload in payloads or ():
-            if payload is None:
-                continue
-            for request_id, entry in pickle.loads(payload).items():
-                collected.setdefault(request_id, {}).update(entry["saves"])
-                if deferred is None:
-                    deferred = entry["error"]
-        # The block runs far from whoever wrote it, so an error in it has no
-        # other way home. Raised here rather than returned, so a registration
-        # that is quietly failing on every request cannot be mistaken for one
-        # that is merely finding nothing.
-        raise_deferred(deferred)
-        return collected
+        return result
+
+    async def _arpc(self, method: str, *args: Any) -> list:
+        """`_rpc` from inside a running event loop, where awaiting is possible.
+
+        Which is the only place it is: the engine's machinery binds to whichever
+        loop first drives it, so a loop of our own on another thread never gets an
+        answer (``run_coroutine_threadsafe`` times out), and the engine exposes no
+        loop to target instead.
+        """
+        import inspect
+
+        engine = self.model.vllm_entrypoint
+        core = getattr(engine, "llm_engine", engine)
+        result = core.collective_rpc(method, args=args)
+        if inspect.isawaitable(result):
+            return await result
+        return result
 
     def clear(self) -> None:
-        """Stop running the block and drop anything it has not handed back."""
+        """Stop running the block and drop anything it has not handed back.
+
+        Use `aclear` on an async engine, whose workers can only be reached from
+        inside the loop.
+        """
         if self.cleared:
             return
         self._rpc("nnsight_clear_registered", self.id)
+        self.cleared = True
+
+    async def aclear(self) -> None:
+        """`clear`, awaited — the async engine's form."""
+        if self.cleared:
+            return
+        await self._arpc("nnsight_clear_registered", self.id)
         self.cleared = True
 
     def __repr__(self) -> str:
@@ -176,17 +187,19 @@ class RegisteringTracer(InterleavingTracer):
     for a runtime whose model lives in another process: an edit is replayed by
     the envoy that stores it, which on vLLM would leave it in the client, where
     there are no weights. This sends the block across instead, and hands back a
-    [`Registration`][nnsight.modeling.vllm.registration.Registration] to collect
-    through.
+    [`Registration`][nnsight.modeling.vllm.registration.Registration] to switch it
+    off again with.
     """
 
     def __init__(self, model: "VLLM", *, backend: Backend | None = None) -> None:
         super().__init__(model, "__call__", backend=backend)
         self._model = model
         self.registration: Registration | None = None
+        # Set by `execute`, sent by whichever exit ran.
+        self._payload: bytes | None = None
 
     def __enter__(self) -> tuple["RegisteringTracer", Registration]:
-        """Enter the block, binding the tracer and the handle results come back through.
+        """Enter the block, binding the tracer and the handle that ends it.
 
         Both, the way [`Envoy.edit`][nnsight.intervention.envoy.Envoy.edit] binds
         ``(tracer, edited)``: a registered block is still a trace body, and the
@@ -213,12 +226,57 @@ class RegisteringTracer(InterleavingTracer):
         )
         return self, self.registration
 
+    async def __aenter__(self) -> tuple["RegisteringTracer", Registration]:
+        """`__enter__`, for ``async with`` — the form an async engine needs.
+
+        Spelled out rather than delegating to `__enter__`: `capture` reads the
+        caller's frame at a fixed depth, so going through another call would hand
+        it this method's frame and it would find no ``with`` block at all.
+        """
+        self.capture()
+        if skippable(self.node):
+            skip_context(self)
+        self.registration = Registration(
+            self._model, id=f"registration-{uuid.uuid4().hex}"
+        )
+        return self, self.registration
+
+    def __exit__(self, *exception: Any) -> bool:
+        handled = super().__exit__(*exception)
+        if self._payload is not None:
+            self.registration._rpc(
+                "nnsight_register", self.registration.id, self._payload
+            )
+            self._payload = None
+        return handled
+
+    async def __aexit__(self, *exception: Any) -> bool:
+        """Capture as usual, then await the send.
+
+        The block is prepared by `execute` either way; only the trip to the
+        workers differs, and on an async engine that trip has to be awaited from
+        inside the loop.
+        """
+        handled = super().__exit__(*exception)
+        if self._payload is not None:
+            await self.registration._arpc(
+                "nnsight_register", self.registration.id, self._payload
+            )
+            self._payload = None
+        return handled
+
     def execute(self, code: CodeType) -> None:
-        """Ship the block to the workers rather than running it here.
+        """Prepare the block for the workers rather than running it here.
+
+        Only prepared: the send happens in ``__exit__``/``__aexit__``, because
+        whether it can be awaited depends on which of the two ran.
+
+        It goes to every rank, so each builds the same per-request copies and
+        their reads stay in step — which is what a sharded model's gathers need.
 
         ``copy`` is left off: the worker builds a fresh mediator per request from
         this template, so each request already has a scope of its own, and the
-        block's saves have to land in it for collection to find them.
+        block's saves have to land in it for the collect to find them.
         """
         model = self._model
         if not model.dispatched:
@@ -231,5 +289,4 @@ class RegisteringTracer(InterleavingTracer):
             dict(self.info.frame.f_locals),
             node=self.node,
         )
-        registration = self.registration
-        registration._rpc("nnsight_register", registration.id, dumps(template))
+        self._payload = dumps(template)

--- a/src/nnsight/modeling/vllm/registration.py
+++ b/src/nnsight/modeling/vllm/registration.py
@@ -139,9 +139,10 @@ class Registration:
             result.close()
             raise NotImplementedError(
                 f"{method} has to reach the engine's workers, and on an async "
-                "engine (mode='async') that call is a coroutine this cannot "
-                "await. Registration is synchronous-engine only for now; build "
-                "with mode='sync', or trace the requests you want to instrument."
+                "engine (mode='async') that call is a coroutine, which can only "
+                "be awaited from inside the loop the engine already runs on. Use "
+                "the awaited forms there: `async with model.edit()`, "
+                "`await edit.aclear()`, `await model.aclear_edits()`."
             )
         return result
 

--- a/src/nnsight/modeling/vllm/registration.py
+++ b/src/nnsight/modeling/vllm/registration.py
@@ -15,13 +15,13 @@ Example:
     >>> model = VLLM("meta-llama/Llama-3.1-8B", dispatch=True,
     ...              enable_prefix_caching=False)
     >>>
-    >>> with model.register() as (tracer, registration):        # doctest: +SKIP
+    >>> with model.edit() as (tracer, edit):                    # doctest: +SKIP
     ...     hidden = model.model.layers[16].output[0].save()
     >>>
     >>> outputs = model.vllm_entrypoint.generate(prompts, sampling)  # doctest: +SKIP
     >>> outputs[5].saves["hidden"].shape                        # doctest: +SKIP
     >>>
-    >>> registration.clear()                                    # doctest: +SKIP
+    >>> edit.clear()                                            # doctest: +SKIP
 
 The block is written exactly like a trace body — the same envoy tree, the same
 ``.save()``. What it cannot do is anything that belongs to one particular
@@ -48,6 +48,7 @@ from ...intervention.serialization import dumps
 from ...intervention.tracer import InterleavingTracer
 from ...tracing.backend import Backend
 from ...tracing.tracer import skip_context, skippable
+from .tracer import no_barrier
 
 if TYPE_CHECKING:
     from .vllm import VLLM
@@ -87,8 +88,8 @@ def _warn_if_prefix_caching(model: "VLLM") -> None:
 class Registration:
     """A handle on a block the engine is running for every request.
 
-    Returned by [`VLLM.register`][nnsight.modeling.vllm.vllm.VLLM.register] and
-    live until `clear`.
+    Returned by [`VLLM.edit`][nnsight.modeling.vllm.vllm.VLLM.edit] and live
+    until `clear`.
 
     There is nothing to read here. What a registered block saves comes back on
     the ``RequestOutput`` of the request it ran on, as ``output.saves``, by the
@@ -99,7 +100,7 @@ class Registration:
 
     Synchronous engines only: installing the block is a ``collective_rpc``, which
     on ``mode="async"`` is a coroutine there is no safe way to finish from a
-    plain statement, so `VLLM.register` refuses there rather than silently not
+    plain statement, so `VLLM.edit` refuses there rather than silently not
     installing it.
 
     Attributes:
@@ -157,6 +158,14 @@ class Registration:
             return await result
         return result
 
+    def install(self, payload: bytes) -> None:
+        """Put the block on the engine. The seam a serve client replaces."""
+        self._rpc("nnsight_register", self.id, payload)
+
+    async def ainstall(self, payload: bytes) -> None:
+        """`install`, awaited."""
+        await self._arpc("nnsight_register", self.id, payload)
+
     def clear(self) -> None:
         """Stop running the block and drop anything it has not handed back.
 
@@ -166,18 +175,108 @@ class Registration:
         if self.cleared:
             return
         self._rpc("nnsight_clear_registered", self.id)
-        self.cleared = True
+        self._forget()
 
     async def aclear(self) -> None:
         """`clear`, awaited — the async engine's form."""
         if self.cleared:
             return
         await self._arpc("nnsight_clear_registered", self.id)
+        self._forget()
+
+    def _forget(self) -> None:
+        """Mark this cleared and drop it from the model's list of installed edits."""
         self.cleared = True
+        installed = getattr(self.model, "_installed_edits", None)
+        if installed is not None and self in installed:
+            installed.remove(self)
 
     def __repr__(self) -> str:
         state = "cleared" if self.cleared else "active"
         return f"<Registration {self.id} ({state})>"
+
+
+class ServeRegistration(Registration):
+    """A block installed on an [nnsight-serve][nnsight.modeling.vllm.serve.server] engine.
+
+    The same handle, over HTTP: the client has no engine to ``collective_rpc``
+    into — it holds a meta model and no weights — so the block goes to the
+    server, which installs it on the engine it holds. What it saves rides the
+    request it ran on, which for a serve client means ``tracer.result.saves`` of
+    a trace sent to that same server.
+    """
+
+    CONNECT_TIMEOUT: float = 10.0
+    READ_TIMEOUT: float = 600.0
+
+    def __init__(
+        self, model: "VLLM", id: str, host: str, api_key: str | None = None
+    ) -> None:
+        super().__init__(model, id)
+        self.host = host.rstrip("/")
+        self.api_key = api_key
+
+    def _headers(self) -> dict:
+        headers = {"Content-Type": "application/octet-stream"}
+        if self.api_key:
+            headers["ndif-api-key"] = self.api_key
+        return headers
+
+    def _check(self, response: Any) -> None:
+        if response.status_code != 200:
+            try:
+                detail = response.json().get("detail", response.reason_phrase)
+            except Exception:
+                detail = response.reason_phrase
+            raise ConnectionError(
+                f"nnsight-serve returned {response.status_code}: {detail}"
+            )
+
+    def _post(self, path: str, content: bytes = b"") -> None:
+        import httpx
+
+        with httpx.Client(
+            timeout=httpx.Timeout(self.CONNECT_TIMEOUT, read=self.READ_TIMEOUT)
+        ) as client:
+            self._check(
+                client.post(
+                    f"{self.host}{path}", content=content, headers=self._headers()
+                )
+            )
+
+    async def _apost(self, path: str, content: bytes = b"") -> None:
+        import httpx
+
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(self.CONNECT_TIMEOUT, read=self.READ_TIMEOUT)
+        ) as client:
+            self._check(
+                await client.post(
+                    f"{self.host}{path}", content=content, headers=self._headers()
+                )
+            )
+
+    def install(self, payload: bytes) -> None:
+        self._post(f"/v1/nnsight/register/{self.id}", payload)
+
+    async def ainstall(self, payload: bytes) -> None:
+        await self._apost(f"/v1/nnsight/register/{self.id}", payload)
+
+    def clear(self) -> None:
+        if self.cleared:
+            return
+        self._post(f"/v1/nnsight/register/{self.id}/clear")
+        self._forget()
+
+    async def aclear(self) -> None:
+        if self.cleared:
+            return
+        await self._apost(f"/v1/nnsight/register/{self.id}/clear")
+        self._forget()
+
+    def __repr__(self) -> str:
+        state = "cleared" if self.cleared else "active"
+        return f"<Registration {self.id} on {self.host} ({state})>"
 
 
 class RegisteringTracer(InterleavingTracer):
@@ -191,12 +290,39 @@ class RegisteringTracer(InterleavingTracer):
     off again with.
     """
 
-    def __init__(self, model: "VLLM", *, backend: Backend | None = None) -> None:
+    def __init__(
+        self,
+        model: "VLLM",
+        *,
+        backend: Backend | None = None,
+        serve: str | None = None,
+        api_key: str | None = None,
+    ) -> None:
         super().__init__(model, "__call__", backend=backend)
         self._model = model
+        # Where the block goes: this process's engine, or an nnsight-serve one.
+        self._serve = serve
+        self._api_key = api_key
         self.registration: Registration | None = None
         # Set by `execute`, sent by whichever exit ran.
         self._payload: bytes | None = None
+
+    def _handle(self) -> Registration:
+        """The handle for this install, addressed at whatever holds the engine."""
+        # Not id(self): this tracer is a temporary, so the next edit() can be
+        # allocated at the same address and collide with this one — which the
+        # worker would read as a re-registration, overwriting the first block and
+        # handing both handles the same values.
+        id = f"registration-{uuid.uuid4().hex}"
+        if self._serve is not None:
+            return ServeRegistration(
+                self._model, id, self._serve, api_key=self._api_key
+            )
+        return Registration(self._model, id)
+
+    def barrier(self, n: int) -> None:
+        """Not available here — see [`no_barrier`][nnsight.modeling.vllm.tracer.no_barrier]."""
+        no_barrier(n)
 
     def __enter__(self) -> tuple["RegisteringTracer", Registration]:
         """Enter the block, binding the tracer and the handle that ends it.
@@ -207,7 +333,7 @@ class RegisteringTracer(InterleavingTracer):
         only ever see a request's first forward — its prefill — and never the
         steps it generates::
 
-            with model.register() as (tracer, registration):
+            with model.edit() as (tracer, edit):
                 readouts = nnsight.save([])
                 for step in tracer.all():
                     readouts.append(model.model.layers[16].output[0][-1])
@@ -217,13 +343,7 @@ class RegisteringTracer(InterleavingTracer):
         self.capture()
         if skippable(self.node):
             skip_context(self)
-        # Not id(self): this tracer is a temporary, so the next register() can be
-        # allocated at the same address and collide with this one — which the
-        # worker would read as a re-registration, overwriting the first block and
-        # handing both handles the same values.
-        self.registration = Registration(
-            self._model, id=f"registration-{uuid.uuid4().hex}"
-        )
+        self.registration = self._handle()
         return self, self.registration
 
     async def __aenter__(self) -> tuple["RegisteringTracer", Registration]:
@@ -236,18 +356,15 @@ class RegisteringTracer(InterleavingTracer):
         self.capture()
         if skippable(self.node):
             skip_context(self)
-        self.registration = Registration(
-            self._model, id=f"registration-{uuid.uuid4().hex}"
-        )
+        self.registration = self._handle()
         return self, self.registration
 
     def __exit__(self, *exception: Any) -> bool:
         handled = super().__exit__(*exception)
         if self._payload is not None:
-            self.registration._rpc(
-                "nnsight_register", self.registration.id, self._payload
-            )
+            self.registration.install(self._payload)
             self._payload = None
+            self._model._installed_edits.append(self.registration)
         return handled
 
     async def __aexit__(self, *exception: Any) -> bool:
@@ -259,10 +376,9 @@ class RegisteringTracer(InterleavingTracer):
         """
         handled = super().__exit__(*exception)
         if self._payload is not None:
-            await self.registration._arpc(
-                "nnsight_register", self.registration.id, self._payload
-            )
+            await self.registration.ainstall(self._payload)
             self._payload = None
+            self._model._installed_edits.append(self.registration)
         return handled
 
     def execute(self, code: CodeType) -> None:
@@ -279,7 +395,9 @@ class RegisteringTracer(InterleavingTracer):
         block's saves have to land in it for the collect to find them.
         """
         model = self._model
-        if not model.dispatched:
+        # A serve client has no engine of its own — a meta model and no weights —
+        # and the block is going to the server's. Dispatching here would build one.
+        if self._serve is None and not model.dispatched:
             model.dispatch()
         _warn_if_prefix_caching(model)
 

--- a/src/nnsight/modeling/vllm/registration.py
+++ b/src/nnsight/modeling/vllm/registration.py
@@ -38,6 +38,7 @@ has it on warns.
 
 from __future__ import annotations
 
+import inspect
 import uuid
 import warnings
 from types import CodeType
@@ -45,10 +46,9 @@ from typing import TYPE_CHECKING, Any
 
 from ...intervention.interleaver import Mediator
 from ...intervention.serialization import dumps
-from ...intervention.tracer import InterleavingTracer
 from ...tracing.backend import Backend
 from ...tracing.tracer import skip_context, skippable
-from .tracer import no_barrier
+from .tracer import VLLMTracer
 
 if TYPE_CHECKING:
     from .vllm import VLLM
@@ -81,7 +81,8 @@ def _warn_if_prefix_caching(model: "VLLM") -> None:
             "its activations come back short, with no error. Build the model with "
             "VLLM(..., enable_prefix_caching=False) to register against whole "
             "prompts.",
-            stacklevel=4,
+            # execute -> Backend.__call__ -> Tracer.__exit__ -> this exit -> caller.
+            stacklevel=6,
         )
 
 
@@ -98,10 +99,11 @@ class Registration:
     accumulates for as long as somebody is reading the outputs, which on the
     synchronous engine is every request there is.
 
-    Synchronous engines only: installing the block is a ``collective_rpc``, which
-    on ``mode="async"`` is a coroutine there is no safe way to finish from a
-    plain statement, so `VLLM.edit` refuses there rather than silently not
-    installing it.
+    A plain ``with`` is synchronous-engine only: installing the block is a
+    ``collective_rpc``, which on ``mode="async"`` is a coroutine there is no safe
+    way to finish from a plain statement, so the exit raises there rather than
+    silently not installing it. On an async engine use ``async with`` and
+    `aclear`, which can await that trip from inside the loop it is already on.
 
     Attributes:
         model: The engine this is registered on.
@@ -114,6 +116,14 @@ class Registration:
         self.id = id
         self.cleared = False
 
+    def _collective(self, method: str, args: tuple) -> Any:
+        """Call `method` on every worker, however this engine reaches them."""
+        engine = self.model.vllm_entrypoint
+        # The sync entrypoint keeps the engine one level down; the async one is
+        # already the engine.
+        core = getattr(engine, "llm_engine", engine)
+        return core.collective_rpc(method, args=args)
+
     def _rpc(self, method: str, *args: Any) -> list:
         """Reach every worker.
 
@@ -124,13 +134,7 @@ class Registration:
         refuses rather than returning a coroutine nobody awaits, which is what it
         used to do: the block was never installed and nothing said so.
         """
-        import inspect
-
-        engine = self.model.vllm_entrypoint
-        # The sync entrypoint keeps the engine one level down; the async one is
-        # already the engine.
-        core = getattr(engine, "llm_engine", engine)
-        result = core.collective_rpc(method, args=args)
+        result = self._collective(method, args)
         if inspect.iscoroutine(result):
             result.close()
             raise NotImplementedError(
@@ -149,11 +153,7 @@ class Registration:
         answer (``run_coroutine_threadsafe`` times out), and the engine exposes no
         loop to target instead.
         """
-        import inspect
-
-        engine = self.model.vllm_entrypoint
-        core = getattr(engine, "llm_engine", engine)
-        result = core.collective_rpc(method, args=args)
+        result = self._collective(method, args)
         if inspect.isawaitable(result):
             return await result
         return result
@@ -166,6 +166,14 @@ class Registration:
         """`install`, awaited."""
         await self._arpc("nnsight_register", self.id, payload)
 
+    def uninstall(self) -> None:
+        """Take the block off the engine. The other half of the seam."""
+        self._rpc("nnsight_clear_registered", self.id)
+
+    async def auninstall(self) -> None:
+        """`uninstall`, awaited."""
+        await self._arpc("nnsight_clear_registered", self.id)
+
     def clear(self) -> None:
         """Stop running the block and drop anything it has not handed back.
 
@@ -174,22 +182,21 @@ class Registration:
         """
         if self.cleared:
             return
-        self._rpc("nnsight_clear_registered", self.id)
+        self.uninstall()
         self._forget()
 
     async def aclear(self) -> None:
         """`clear`, awaited — the async engine's form."""
         if self.cleared:
             return
-        await self._arpc("nnsight_clear_registered", self.id)
+        await self.auninstall()
         self._forget()
 
     def _forget(self) -> None:
         """Mark this cleared and drop it from the model's list of installed edits."""
         self.cleared = True
-        installed = getattr(self.model, "_installed_edits", None)
-        if installed is not None and self in installed:
-            installed.remove(self)
+        if self in self.model._installed_edits:
+            self.model._installed_edits.remove(self)
 
     def __repr__(self) -> str:
         state = "cleared" if self.cleared else "active"
@@ -206,9 +213,6 @@ class ServeRegistration(Registration):
     a trace sent to that same server.
     """
 
-    CONNECT_TIMEOUT: float = 10.0
-    READ_TIMEOUT: float = 600.0
-
     def __init__(
         self, model: "VLLM", id: str, host: str, api_key: str | None = None
     ) -> None:
@@ -216,43 +220,31 @@ class ServeRegistration(Registration):
         self.host = host.rstrip("/")
         self.api_key = api_key
 
-    def _headers(self) -> dict:
-        headers = {"Content-Type": "application/octet-stream"}
-        if self.api_key:
-            headers["ndif-api-key"] = self.api_key
-        return headers
-
-    def _check(self, response: Any) -> None:
-        if response.status_code != 200:
-            try:
-                detail = response.json().get("detail", response.reason_phrase)
-            except Exception:
-                detail = response.reason_phrase
-            raise ConnectionError(
-                f"nnsight-serve returned {response.status_code}: {detail}"
-            )
-
     def _post(self, path: str, content: bytes = b"") -> None:
         import httpx
 
-        with httpx.Client(
-            timeout=httpx.Timeout(self.CONNECT_TIMEOUT, read=self.READ_TIMEOUT)
-        ) as client:
-            self._check(
+        from .serve import http
+
+        with httpx.Client(timeout=http.timeout()) as client:
+            http.check(
                 client.post(
-                    f"{self.host}{path}", content=content, headers=self._headers()
+                    f"{self.host}{path}",
+                    content=content,
+                    headers=http.headers(self.api_key),
                 )
             )
 
     async def _apost(self, path: str, content: bytes = b"") -> None:
         import httpx
 
-        async with httpx.AsyncClient(
-            timeout=httpx.Timeout(self.CONNECT_TIMEOUT, read=self.READ_TIMEOUT)
-        ) as client:
-            self._check(
+        from .serve import http
+
+        async with httpx.AsyncClient(timeout=http.timeout()) as client:
+            http.check(
                 await client.post(
-                    f"{self.host}{path}", content=content, headers=self._headers()
+                    f"{self.host}{path}",
+                    content=content,
+                    headers=http.headers(self.api_key),
                 )
             )
 
@@ -262,24 +254,18 @@ class ServeRegistration(Registration):
     async def ainstall(self, payload: bytes) -> None:
         await self._apost(f"/v1/nnsight/register/{self.id}", payload)
 
-    def clear(self) -> None:
-        if self.cleared:
-            return
+    def uninstall(self) -> None:
         self._post(f"/v1/nnsight/register/{self.id}/clear")
-        self._forget()
 
-    async def aclear(self) -> None:
-        if self.cleared:
-            return
+    async def auninstall(self) -> None:
         await self._apost(f"/v1/nnsight/register/{self.id}/clear")
-        self._forget()
 
     def __repr__(self) -> str:
         state = "cleared" if self.cleared else "active"
         return f"<Registration {self.id} on {self.host} ({state})>"
 
 
-class RegisteringTracer(InterleavingTracer):
+class RegisteringTracer(VLLMTracer):
     """Capture a block and leave it on the engine instead of running it once.
 
     The counterpart of [`EditingTracer`][nnsight.intervention.editing.EditingTracer]
@@ -320,10 +306,6 @@ class RegisteringTracer(InterleavingTracer):
             )
         return Registration(self._model, id)
 
-    def barrier(self, n: int) -> None:
-        """Not available here — see [`no_barrier`][nnsight.modeling.vllm.tracer.no_barrier]."""
-        no_barrier(n)
-
     def __enter__(self) -> tuple["RegisteringTracer", Registration]:
         """Enter the block, binding the tracer and the handle that ends it.
 
@@ -349,9 +331,11 @@ class RegisteringTracer(InterleavingTracer):
     async def __aenter__(self) -> tuple["RegisteringTracer", Registration]:
         """`__enter__`, for ``async with`` — the form an async engine needs.
 
-        Spelled out rather than delegating to `__enter__`: `capture` reads the
-        caller's frame at a fixed depth, so going through another call would hand
-        it this method's frame and it would find no ``with`` block at all.
+        Spelled out rather than delegating to `__enter__`: both `capture` and the
+        skip guard read the caller's frame at a fixed depth, so going through
+        another call would hand them this method's frame — `capture` would find no
+        ``with`` block at all, and `skip_context` would arm the wrong frame and
+        let the body run here as well as on the workers.
         """
         self.capture()
         if skippable(self.node):

--- a/src/nnsight/modeling/vllm/serve/backend.py
+++ b/src/nnsight/modeling/vllm/serve/backend.py
@@ -34,9 +34,6 @@ if TYPE_CHECKING:
 class LocalServeBackend(Backend):
     """Send a trace to an nnsight-serve instance and bring its saves home."""
 
-    CONNECT_TIMEOUT: float = 10.0
-    READ_TIMEOUT: float = 600.0
-
     def __init__(self, model: Any, host: str, api_key: Optional[str] = None) -> None:
         self.model = model
         self.host = host.rstrip("/")
@@ -53,29 +50,15 @@ class LocalServeBackend(Backend):
         import httpx
 
         from ....intervention.errors import raise_deferred
+        from . import http
 
-        headers = {
-            "Content-Type": "application/octet-stream",
-            "nnsight-compress": "False",
-        }
-        if self.api_key:
-            headers["ndif-api-key"] = self.api_key
-
-        with httpx.Client(
-            timeout=httpx.Timeout(self.CONNECT_TIMEOUT, read=self.READ_TIMEOUT)
-        ) as client:
+        with httpx.Client(timeout=http.timeout()) as client:
             response = client.post(
-                f"{self.host}/v1/nnsight/generate", content=blob, headers=headers
+                f"{self.host}/v1/nnsight/generate",
+                content=blob,
+                headers=http.headers(self.api_key),
             )
-
-        if response.status_code != 200:
-            try:
-                detail = response.json().get("detail", response.reason_phrase)
-            except Exception:
-                detail = response.reason_phrase
-            raise ConnectionError(
-                f"nnsight-serve returned {response.status_code}: {detail}"
-            )
+        http.check(response)
 
         result = torch.load(
             io.BytesIO(response.content), map_location="cpu", weights_only=False

--- a/src/nnsight/modeling/vllm/serve/backend.py
+++ b/src/nnsight/modeling/vllm/serve/backend.py
@@ -13,8 +13,8 @@ a local run would, so reading a ``.save()``d value after the block just works::
 
 ``api_key`` (optional) is sent as the ``ndif-api-key`` header. The server's response
 is a ``torch.save`` of ``{"saves": {name: value}, "error": <deferred or None>}`` —
-saved values only; generated tokens are not returned. A build or runtime error comes
-back as ``error`` and is re-raised at the client with its real type and traceback; a
+saved values only, so read generated tokens by saving ``tracer.result``. A build or
+runtime error comes back as ``error`` and is re-raised at the client with its real type and traceback; a
 transport/service failure (e.g. the engine not ready) surfaces as ``ConnectionError``.
 """
 

--- a/src/nnsight/modeling/vllm/serve/cli.py
+++ b/src/nnsight/modeling/vllm/serve/cli.py
@@ -81,19 +81,16 @@ def _coerce(value: str) -> object:
 
 
 def _add_api_key_middleware(app, expected_key: str) -> None:
-    from fastapi import Request
-    from starlette.middleware.base import BaseHTTPMiddleware
     from starlette.responses import JSONResponse
 
-    class ApiKeyMiddleware(BaseHTTPMiddleware):
-        async def dispatch(self, request: Request, call_next):
-            if request.url.path == "/health":
-                return await call_next(request)
-            if request.headers.get("ndif-api-key", "") != expected_key:
-                return JSONResponse(status_code=401, content={"detail": "Invalid API key"})
-            return await call_next(request)
-
-    app.add_middleware(ApiKeyMiddleware)
+    @app.middleware("http")
+    async def check_api_key(request, call_next):
+        # /health stays open, so a liveness probe needs no secret.
+        if request.url.path != "/health" and (
+            request.headers.get("ndif-api-key", "") != expected_key
+        ):
+            return JSONResponse(status_code=401, content={"detail": "Invalid API key"})
+        return await call_next(request)
 
 
 if __name__ == "__main__":

--- a/src/nnsight/modeling/vllm/serve/http.py
+++ b/src/nnsight/modeling/vllm/serve/http.py
@@ -1,0 +1,52 @@
+"""What both halves of the serve client put on the wire.
+
+A trace and an installed block reach a server the same way — the same headers,
+the same timeouts, the same reading of a non-200 — but from two unrelated places:
+[`LocalServeBackend`][nnsight.modeling.vllm.serve.backend.LocalServeBackend] sends
+the trace, and
+[`ServeRegistration`][nnsight.modeling.vllm.registration.ServeRegistration] sends
+the block. Keeping the wire details here is what stops the two from drifting; the
+error message in particular is one a user reads, and two copies of it would
+diverge on the first edit.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+CONNECT_TIMEOUT: float = 10.0
+# Generous: the request is queued behind whatever else the engine is running.
+READ_TIMEOUT: float = 600.0
+
+
+def timeout() -> Any:
+    import httpx
+
+    return httpx.Timeout(CONNECT_TIMEOUT, read=READ_TIMEOUT)
+
+
+def headers(api_key: Optional[str] = None, compress: bool = False) -> dict:
+    """The headers every nnsight-serve request carries."""
+    sending = {
+        "Content-Type": "application/octet-stream",
+        "nnsight-compress": str(compress),
+    }
+    if api_key:
+        sending["ndif-api-key"] = api_key
+    return sending
+
+
+def check(response: Any) -> None:
+    """Raise the server's own explanation of a non-200, as a `ConnectionError`.
+
+    A transport or service failure, as distinct from an error *inside* the trace —
+    that one comes back in the body as a deferred error and is re-raised at the
+    client with its real type.
+    """
+    if response.status_code == 200:
+        return
+    try:
+        detail = response.json().get("detail", response.reason_phrase)
+    except Exception:
+        detail = response.reason_phrase
+    raise ConnectionError(f"nnsight-serve returned {response.status_code}: {detail}")

--- a/src/nnsight/modeling/vllm/serve/server.py
+++ b/src/nnsight/modeling/vllm/serve/server.py
@@ -18,14 +18,15 @@ import ast
 import asyncio
 import io
 import logging
-import pickle
 import uuid
+import warnings
 from typing import TYPE_CHECKING, Any, Optional
 
 import torch
 from fastapi import FastAPI, HTTPException, Request, Response
 
 from ....intervention.serialization import loads
+from ..engines.engine import merge_collected
 
 if TYPE_CHECKING:
     from ..vllm import VLLM
@@ -103,14 +104,59 @@ async def health() -> dict:
     return {"status": "ok"}
 
 
+@app.post("/v1/nnsight/register/{registration_id}")
+async def register(registration_id: str, request: Request) -> dict:
+    """Install a block on this server's engine, to run for every request it handles.
+
+    Body: the serialized block ``model.edit(serve=url)`` prepared on the client.
+    The client has no engine to ``collective_rpc`` into, so the install comes
+    over HTTP and this hands it to every rank — the same call the in-process form
+    makes. What the block saves rides the output of the request it ran on, so a
+    serve client reads it through ``tracer.result``.
+    """
+    if _model is None:
+        raise HTTPException(status_code=503, detail="Engine not ready")
+
+    # The client cannot check this — it has no engine — so the server does.
+    from ..registration import _warn_if_prefix_caching
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _warn_if_prefix_caching(_model)
+    for warning in caught:
+        logger.warning(str(warning.message))
+
+    payload = await request.body()
+    try:
+        await _model.vllm_entrypoint.collective_rpc(
+            "nnsight_register", args=(registration_id, payload)
+        )
+    except Exception as exception:
+        logger.exception("Failed to install edit %s", registration_id)
+        raise HTTPException(status_code=400, detail=str(exception))
+    return {"status": "ok", "id": registration_id}
+
+
+@app.post("/v1/nnsight/register/{registration_id}/clear")
+async def clear_registration(registration_id: str) -> dict:
+    """Stop running an installed block. Unknown ids are a no-op, so clearing twice is safe."""
+    if _model is None:
+        raise HTTPException(status_code=503, detail="Engine not ready")
+
+    await _model.vllm_entrypoint.collective_rpc(
+        "nnsight_clear_registered", args=(registration_id,)
+    )
+    return {"status": "ok", "id": registration_id}
+
+
 @app.post("/v1/nnsight/generate")
 async def generate(request: Request) -> Response:
     """Run a serialized trace and return its saved values.
 
     Body: ``RequestModel.serialize(tracer)`` bytes. Response: ``torch.save`` of
     ``{"saves": {name: value}, "error": <deferred error or None>}`` — saved values
-    only; generated tokens are not returned (a serve client reads ``.save()``d values,
-    not ``tracer.result``). A build error (a corrupt/incompatible trace) or a runtime
+    only, so read generated tokens by saving ``tracer.result``, which is served here
+    like anywhere else. A build error (a corrupt/incompatible trace) or a runtime
     intervention error both come back as the deferred ``error`` so the client re-raises
     the real exception type with its traceback, rather than an opaque HTTP error.
     """
@@ -145,20 +191,25 @@ async def generate(request: Request) -> Response:
         request_id = str(uuid.uuid4())
         collected = False
         try:
-            async for _ in engine.generate(
+            # The last streamed output is the finished ``RequestOutput``; the
+            # worker cannot build it and needs it to serve ``tracer.result``, so
+            # keep it and hand it back on the collect.
+            output = None
+            async for output in engine.generate(
                 prompt, param, request_id, lora_request=lora_request
             ):
                 pass
 
             results = await engine.collective_rpc(
-                "collect_nnsight", args=([request_id], [request_id])
+                "collect_nnsight",
+                args=([request_id], [request_id], {request_id: output}),
             )
             collected = True
-            payload = next((result for result in results if result is not None), None)
-            if payload is not None:
-                entry = pickle.loads(payload).get(request_id)
-                if entry is not None:
-                    return entry["saves"], entry["error"]
+            # Merged, not first-non-empty: under pipeline parallelism a trace's
+            # values and an installed block's come from different ranks.
+            entry = merge_collected(results).get(request_id)
+            if entry is not None:
+                return entry["saves"], entry["error"]
             return {}, None
         finally:
             # If this task is cancelled mid-generation (server shutdown, or a

--- a/src/nnsight/modeling/vllm/serve/server.py
+++ b/src/nnsight/modeling/vllm/serve/server.py
@@ -25,8 +25,7 @@ from typing import TYPE_CHECKING, Any, Optional
 import torch
 from fastapi import FastAPI, HTTPException, Request, Response
 
-from ....intervention.serialization import loads
-from ..engines.engine import merge_collected
+from ..engines.engine import acollect
 
 if TYPE_CHECKING:
     from ..vllm import VLLM
@@ -61,46 +60,44 @@ def set_model(model: "VLLM") -> None:
 def _build_tracer(body: bytes, compress: bool) -> Any:
     """Rebuild a runnable tracer from a serialized trace, bound to this model.
 
-    Mirrors [`RequestModel.deserialize`][nnsight.schema.request.RequestModel.deserialize] — recompile the block from its source
-    onto the tracer — but also restores the tracer's AST node. Deserialize drops it
-    (server-side mediators normally just run in place), yet here they are
-    re-serialized onto the engine's requests, which needs the AST; parsing the
-    shipped source back gives an equivalent node whose ``body`` reduces the same way.
+    [`RequestModel.deserialize`][nnsight.schema.request.RequestModel.deserialize]
+    does the work — recompile the block from its source onto the tracer — and this
+    adds the one thing it drops: the AST node. Server-side mediators normally just
+    run in place, so deserialize has no use for it, but here they are re-serialized
+    onto the engine's requests, which does; parsing the shipped source back gives
+    an equivalent node whose ``body`` reduces the same way.
+
+    Note that deserialize registers the source in ``linecache`` under the client's
+    filename (e.g. ``"<stdin>"``), so requests from different clients collide on
+    that process-global cache. Safe only because the whole build runs without an
+    await (see the module docstring): no two builds interleave, so the source a
+    traceback resolves — and the source read back here — is always the one just
+    written. An await added to the build path would break that.
     """
     import linecache
 
-    if compress:
-        import zstandard as zstd
+    from ....schema.request import RequestModel
 
-        body = zstd.ZstdDecompressor().decompress(body)
-
-    tracer, (source, glbls, variables) = loads(body, _persistent_objects)
-    frame = tracer.info.frame
-    filename = frame.f_code.co_filename
-    tracer.info.code = compile(source, filename, "exec").replace(
-        co_name=frame.f_code.co_name
-    )
-    # `filename` is the client's (e.g. "<stdin>"), so requests from different clients
-    # collide on this process-global cache. Safe only because the whole build runs
-    # without an await (see the module docstring): no two builds interleave, so the
-    # source a traceback resolves is always the one just written. An await added to
-    # the build path would break that — key by request id then.
-    linecache.cache[filename] = (
-        len(source),
-        None,
-        source.splitlines(keepends=True),
-        filename,
-    )
-    frame.f_globals = glbls
-    frame.f_locals = variables
+    tracer = RequestModel.deserialize(body, _persistent_objects, compress=compress)
+    source = "".join(linecache.cache[tracer.info.frame.f_code.co_filename][2])
     tracer.node = ast.parse(source)
     return tracer
 
 
-@app.get("/health")
-async def health() -> dict:
+def _ready() -> "VLLM":
+    """The dispatched engine, or a 503 — what every endpoint needs before it starts.
+
+    Both halves matter: `set_model` runs before the engine is built, so a request
+    arriving in between finds a model whose ``vllm_entrypoint`` is still None.
+    """
     if _model is None or _model.vllm_entrypoint is None:
         raise HTTPException(status_code=503, detail="Engine not ready")
+    return _model
+
+
+@app.get("/health")
+async def health() -> dict:
+    _ready()
     return {"status": "ok"}
 
 
@@ -114,21 +111,20 @@ async def register(registration_id: str, request: Request) -> dict:
     makes. What the block saves rides the output of the request it ran on, so a
     serve client reads it through ``tracer.result``.
     """
-    if _model is None:
-        raise HTTPException(status_code=503, detail="Engine not ready")
+    model = _ready()
 
     # The client cannot check this — it has no engine — so the server does.
     from ..registration import _warn_if_prefix_caching
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        _warn_if_prefix_caching(_model)
+        _warn_if_prefix_caching(model)
     for warning in caught:
         logger.warning(str(warning.message))
 
     payload = await request.body()
     try:
-        await _model.vllm_entrypoint.collective_rpc(
+        await model.vllm_entrypoint.collective_rpc(
             "nnsight_register", args=(registration_id, payload)
         )
     except Exception as exception:
@@ -140,10 +136,7 @@ async def register(registration_id: str, request: Request) -> dict:
 @app.post("/v1/nnsight/register/{registration_id}/clear")
 async def clear_registration(registration_id: str) -> dict:
     """Stop running an installed block. Unknown ids are a no-op, so clearing twice is safe."""
-    if _model is None:
-        raise HTTPException(status_code=503, detail="Engine not ready")
-
-    await _model.vllm_entrypoint.collective_rpc(
+    await _ready().vllm_entrypoint.collective_rpc(
         "nnsight_clear_registered", args=(registration_id,)
     )
     return {"status": "ok", "id": registration_id}
@@ -162,8 +155,7 @@ async def generate(request: Request) -> Response:
     """
     from ....intervention.errors import capture_exception
 
-    if _model is None:
-        raise HTTPException(status_code=503, detail="Engine not ready")
+    model = _ready()
 
     body = await request.body()
     compress = request.headers.get("nnsight-compress", "False").lower() == "true"
@@ -175,7 +167,7 @@ async def generate(request: Request) -> Response:
         _, (prompts, params, lora_requests), forward_kwargs = tracer.prepare(
             tracer.info.code
         )
-        _model._attach_mediators(params, **forward_kwargs)
+        model._attach_mediators(params, **forward_kwargs)
     except Exception as exception:
         logger.exception("Failed to build trace")
         return _payload({}, capture_exception(exception))
@@ -183,9 +175,9 @@ async def generate(request: Request) -> Response:
         # prepare appends this request's workers onto the shared interleaver; clear
         # them whether the build succeeded (they are serialized onto the request now)
         # or failed (or they would bleed into the next request's build).
-        _model.interleaver.cancel()
+        model.interleaver.cancel()
 
-    engine = _model.vllm_entrypoint
+    engine = model.vllm_entrypoint
 
     async def run_invoke(prompt: Any, param: Any, lora_request: Any) -> tuple:
         request_id = str(uuid.uuid4())
@@ -200,14 +192,8 @@ async def generate(request: Request) -> Response:
             ):
                 pass
 
-            results = await engine.collective_rpc(
-                "collect_nnsight",
-                args=([request_id], [request_id], {request_id: output}),
-            )
+            entry = await acollect(engine, request_id, output)
             collected = True
-            # Merged, not first-non-empty: under pipeline parallelism a trace's
-            # values and an installed block's come from different ranks.
-            entry = merge_collected(results).get(request_id)
             if entry is not None:
                 return entry["saves"], entry["error"]
             return {}, None
@@ -219,11 +205,7 @@ async def generate(request: Request) -> Response:
             # cancellation. Stock uvicorn does not cancel a handler on client
             # disconnect, so under it this path simply does not run.
             if not collected:
-                cleanup = asyncio.ensure_future(
-                    engine.collective_rpc(
-                        "collect_nnsight", args=([request_id], [request_id])
-                    )
-                )
+                cleanup = asyncio.ensure_future(acollect(engine, request_id))
                 _cleanups.add(cleanup)
                 cleanup.add_done_callback(_cleanups.discard)
                 await asyncio.shield(cleanup)
@@ -239,7 +221,7 @@ async def generate(request: Request) -> Response:
     all_saves: dict = {}
     first_error = None
     for result in results:
-        if isinstance(result, Exception):
+        if isinstance(result, BaseException):
             logger.exception("Generation failed", exc_info=result)
             if first_error is None:
                 first_error = capture_exception(result)

--- a/src/nnsight/modeling/vllm/tracer.py
+++ b/src/nnsight/modeling/vllm/tracer.py
@@ -22,8 +22,30 @@ from ...intervention.util import clear_shared_locals, shared_locals
 from ...tracing.util import Scope
 
 
+def no_barrier(n: int) -> None:
+    """Refuse a barrier, which this runtime cannot hold.
+
+    A barrier releases when ``n`` of a trace's blocks have reached it, which
+    needs them all running against one forward. Here each invoke is a separate
+    vLLM request, scheduled independently and possibly in different steps
+    entirely, so the blocks never coexist and the barrier would simply never
+    release — a hang rather than an error. Say so at the call instead.
+    """
+    raise NotImplementedError(
+        f"tracer.barrier({n}) cannot work on vLLM: each invoke is its own "
+        "request and the engine schedules them independently, so the blocks "
+        "never run against the same forward and the barrier would never "
+        "release. Compute the shared value outside the trace, or put both "
+        "prompts in one invoke."
+    )
+
+
 class VLLMTracer(InterleavingTracer):
     """An [`InterleavingTracer`][nnsight.intervention.tracer.InterleavingTracer] whose worker-building is callable on its own."""
+
+    def barrier(self, n: int) -> None:
+        """Not available here — see [`no_barrier`][nnsight.modeling.vllm.tracer.no_barrier]."""
+        no_barrier(n)
 
     def prepare(self, code: CodeType) -> tuple:
         """Build the trace's workers and combined call input, without running the model.
@@ -75,9 +97,15 @@ class VLLMTracer(InterleavingTracer):
         """Build the workers, run the forward interleaved, push results back."""
         try:
             mediators, args, kwargs = self.prepare(code)
-            self.envoy.interleave(self.fn, *args, **kwargs)
-            for mediator in mediators:
-                push_result(self.info.frame, mediator.lcls)
+            try:
+                self.envoy.interleave(self.fn, *args, **kwargs)
+            finally:
+                # Pushed even when the run raises. A block's error is deferred to
+                # the collect and re-raised out of `interleave`, so pushing only
+                # on success would hand back a frame with none of the values that
+                # did arrive — including the ones from the invokes that finished.
+                for mediator in mediators:
+                    push_result(self.info.frame, mediator.lcls)
         finally:
             # interleave clears the interleaver on its way out; do it here too so a
             # failure before it doesn't leave workers/batcher behind.

--- a/src/nnsight/modeling/vllm/tracer.py
+++ b/src/nnsight/modeling/vllm/tracer.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 from types import CodeType
 from typing import Any
 
-from ...intervention.batching import Batcher
 from ...intervention.interleaver import Mediator
 from ...intervention.tracer import InterleavingTracer
 from ...tracing.tracer import push_result
@@ -65,7 +64,7 @@ class VLLMTracer(InterleavingTracer):
         interleaver = self.envoy.interleaver
         # The batcher belongs to this trace; each Invoker adds its input to it through
         # self.tracer.batcher while the body runs to collect invokes.
-        self.batcher = Batcher(self.envoy)
+        self.batcher = self.envoy._batcher_class(self.envoy, self.kwargs)
         # >0 rows means direct input (one implicit invoke); 0 means invoke mode
         # (the body defines the batch via tracer.invoke(...)). Trace-level params
         # that aren't data go to the call.

--- a/src/nnsight/modeling/vllm/vllm.py
+++ b/src/nnsight/modeling/vllm/vllm.py
@@ -233,7 +233,16 @@ class VLLM(Remotable):
     # meta tree; the caller sets the tokenizer.
 
     def _load(self, repo_id: str, **kwargs: Any) -> "Module":
-        meta_model = self._load_meta(repo_id, **kwargs)
+        # A lazily built model already has its meta tree — `Meta.__init__` built one
+        # to write interventions against — and `_update` is about to re-point the
+        # envoy tree at whatever comes back. Building a second, structurally
+        # identical tree here only costs a full architecture instantiation and
+        # repopulates the global rope cache that `_load_meta` then has to clear
+        # again. `dispatch=True` skips `__init__`'s build and arrives here with
+        # nothing, so it still builds.
+        meta_model = self.__dict__.get("_module")
+        if meta_model is None:
+            meta_model = self._load_meta(repo_id, **kwargs)
 
         # The real engine brings up its own process group; the one __init__ made
         # to build the meta tree would collide with it. Only tear down a group this
@@ -491,7 +500,9 @@ class VLLM(Remotable):
         """Clear every edit still installed on the engine.
 
         The local form drops a list held on the envoy; here each edit lives on
-        the workers, so each is cleared through its own handle.
+        the workers, so each is cleared through its own handle — which means this
+        is synchronous-engine only, like `clear` itself. On ``mode="async"`` clear
+        each handle with ``await edit.aclear()`` instead.
         """
         for edit in list(self._installed_edits):
             edit.clear()

--- a/src/nnsight/modeling/vllm/vllm.py
+++ b/src/nnsight/modeling/vllm/vllm.py
@@ -79,7 +79,8 @@ class VLLM(Remotable):
             ...     logits = model.logits.save()
 
     Attributes:
-        vllm_entrypoint: The underlying ``vllm.LLM``, or None until dispatch.
+        vllm_entrypoint: The underlying ``vllm.LLM`` (sync) or ``AsyncLLM``
+            (async), or None until dispatch.
         tokenizer: The tokenizer vLLM resolved for the checkpoint.
     """
 
@@ -183,7 +184,7 @@ class VLLM(Remotable):
         CPU-only host (no CUDA at all) selects a CPU backend that never probes, so
         this is a no-op there too.
         """
-        if torch.cuda.is_available() and torch.cuda.device_count() > 0:
+        if torch.cuda.is_available():
             yield
             return
         from unittest import mock
@@ -218,13 +219,13 @@ class VLLM(Remotable):
         _ROPE_DICT.clear()
 
         self.tokenizer = cached_tokenizer_from_config(vllm_config.model_config)
-        if getattr(self.tokenizer, "pad_token", None) is None:
+        if self.tokenizer.pad_token is None:
             self.tokenizer.pad_token = self.tokenizer.eos_token
 
         return model
 
-    # vLLM already carries interventions through to the worker in this field, so
-    # the worker needs no transport of its own.
+    # The worker class vLLM instantiates in each of its processes; it installs the
+    # nnsight model runner, which is what deserializes and runs the blocks.
     _WORKER_CLS = "nnsight.modeling.vllm.workers.GPUWorker.NNsightGPUWorker"
 
     # A ready module (the worker-side runner wrapping the module vLLM already
@@ -372,14 +373,25 @@ class VLLM(Remotable):
 
         return TokensPrompt(prompt_token_ids=input_ids)
 
+    @staticmethod
+    def _sampling_kwargs(kwargs: dict) -> dict:
+        """A copy of `kwargs` with generation length spelled the way vLLM spells it.
+
+        vLLM's is ``max_tokens``; ``max_new_tokens`` is the ``LanguageModel`` API's
+        and is accepted on trace and generate alike, rewritten before it reaches
+        SamplingParams — where an unknown keyword now raises rather than being
+        quietly ignored. The copy is what lets a caller pass its own dict through
+        twice (``generate`` hands one to ``trace`` and keeps the original).
+        """
+        kwargs = dict(kwargs)
+        if "max_new_tokens" in kwargs and "max_tokens" not in kwargs:
+            kwargs["max_tokens"] = kwargs.pop("max_new_tokens")
+        return kwargs
+
     def trace(self, *inputs: Any, **kwargs: Any) -> Any:
         from .tracer import VLLMTracer
 
-        # vLLM generation length is `max_tokens`; accept `max_new_tokens` (from the
-        # LanguageModel API) on trace and generate alike, rewriting before it reaches
-        # SamplingParams (where an unknown kwarg now raises).
-        if "max_new_tokens" in kwargs and "max_tokens" not in kwargs:
-            kwargs["max_tokens"] = kwargs.pop("max_new_tokens")
+        kwargs = self._sampling_kwargs(kwargs)
 
         # `serve=url` runs the trace on a remote nnsight-serve engine; `api_key`
         # rides along with it. Pop both before they reach the base trace.
@@ -483,7 +495,6 @@ class VLLM(Remotable):
         """
         for edit in list(self._installed_edits):
             edit.clear()
-        self._installed_edits.clear()
 
     def generate(self, *inputs: Any, **kwargs: Any) -> Any:
         """Generate — as a trace when used as a ``with`` block, plainly when not.
@@ -537,9 +548,7 @@ class VLLM(Remotable):
         if not self.dispatched:
             self.dispatch()
 
-        kwargs = dict(kwargs)
-        if "max_new_tokens" in kwargs and "max_tokens" not in kwargs:
-            kwargs["max_tokens"] = kwargs.pop("max_new_tokens")
+        kwargs = self._sampling_kwargs(kwargs)
         lora_request = kwargs.pop("lora_request", None)
         params = SamplingParams(**kwargs)
 
@@ -566,26 +575,22 @@ class VLLM(Remotable):
         import asyncio
         import uuid
 
-        from .engines.engine import attach, merge_collected
+        from .engines.engine import acollect, attach
 
         engine = self.vllm_entrypoint
-        if isinstance(prompts, str) or not isinstance(prompts, (list, tuple)):
+        if not isinstance(prompts, (list, tuple)):
             prompts = [prompts]
 
         async def run(prompt: Any) -> Any:
             request_id = uuid.uuid4().hex
-            extra = {} if lora_request is None else {"lora_request": lora_request}
             output = None
-            async for output in engine.generate(prompt, params, request_id, **extra):
+            async for output in engine.generate(
+                prompt, params, request_id, lora_request=lora_request
+            ):
                 pass
             if output is None:
                 return None
-            entry = merge_collected(
-                await engine.collective_rpc(
-                    "collect_nnsight",
-                    args=([request_id], [request_id], {request_id: output}),
-                )
-            ).get(request_id)
+            entry = await acollect(engine, request_id, output)
             if entry is not None:
                 attach(output, entry)
             return output
@@ -624,9 +629,7 @@ class VLLM(Remotable):
             # pushed into the trace's variables — nor handed to
             # `merge_shared_saves`, which would read one name saved across many
             # requests as a single shared container and fold them together.
-            saves = getattr(output, "nnsight_saves", None)
-            if saves is None:
-                saves = getattr(output, "saves", {})
+            saves = getattr(output, "nnsight_saves", {})
             per_request_saves.append(saves)
             for name, value in saves.items():
                 mark(value)  # marking results after the run; no trace active to guard
@@ -665,12 +668,11 @@ class VLLM(Remotable):
 
         from ...tracing.tracer import skippable
 
-        attached, orphaned = [], []
+        attached = []
         for mediator in self.interleaver.mediators:
-            (attached if mediator.batch_group is not None else orphaned).append(mediator)
-
-        for mediator in orphaned:
-            if mediator.node is not None and skippable(mediator.node):
+            if mediator.batch_group is not None:
+                attached.append(mediator)
+            elif mediator.node is not None and skippable(mediator.node):
                 raise ValueError(
                     "A `tracer.invoke(...)` with no prompt has no vLLM request to run "
                     "on, so its interventions would be silently dropped. Each invoke is "
@@ -736,14 +738,6 @@ class VLLM(Remotable):
         state = super().__getstate__()
         # The engine is a live process handle; the far side has its own.
         state["vllm_entrypoint"] = None
-        state["_async_engine"] = self._async_engine
         if self.tokenizer is not None:
             self.tokenizer._persistent_id = "Tokenizer"
-        state["tokenizer"] = self.tokenizer
         return state
-
-    def __setstate__(self, state: dict) -> None:
-        super().__setstate__(state)
-        self.vllm_entrypoint = state["vllm_entrypoint"]
-        self._async_engine = state.get("_async_engine", False)
-        self.tokenizer = state["tokenizer"]

--- a/src/nnsight/modeling/vllm/vllm.py
+++ b/src/nnsight/modeling/vllm/vllm.py
@@ -505,6 +505,17 @@ class VLLM(Remotable):
 
         for mediator, param in zip(attached, params):
             param.extra_args = {"nnsight_mediator": dumps(mediator)}
+            # A prefix-cached token is served from the KV cache without a forward
+            # pass, so no hook fires for it and the intervention silently sees a
+            # short activation — the trace reads only the tokens that were
+            # recomputed. That is invisible at the call site (no error, just fewer
+            # rows), and it bites exactly when a prompt repeats or shares a prefix
+            # with an earlier one, which is the normal case for a dataset sweep.
+            # Interventions are worth more than the cache hit, so force the
+            # recompute. Older vLLM has no such field; there the cache is not
+            # consulted this way and the read is whole anyway.
+            if hasattr(param, "skip_reading_prefix_cache"):
+                param.skip_reading_prefix_cache = True
             for attr, value in kwargs.items():
                 if getattr(param, attr) == getattr(default, attr):
                     setattr(param, attr, value)

--- a/src/nnsight/modeling/vllm/vllm.py
+++ b/src/nnsight/modeling/vllm/vllm.py
@@ -405,6 +405,40 @@ class VLLM(Remotable):
         kwargs.setdefault("fn", self._call)
         return super().trace(*inputs, **kwargs)
 
+    def register(self, *, backend: Any = None) -> Any:
+        """Leave a block on the engine to run for every request it handles.
+
+        A trace carries its block on the request it rides, so a sweep pays to
+        serialize it once per prompt and only requests written as traces are
+        touched at all. A registration sends the block over once; the engine then
+        gives every request its own copy, whoever submitted it — an OpenAI-API
+        client on the same server included. Each copy saves into a scope of its
+        own, and the values wait on the worker until collected.
+
+        The block is written like a trace body against the same envoy tree. It
+        belongs to no particular request, so there is nothing to
+        ``tracer.invoke(...)`` — give it the locations you want and ``.save()``
+        what you want back.
+
+        Returns:
+            The [`Registration`][nnsight.modeling.vllm.registration.Registration]
+            the block's per-request values are collected through. Bind it with
+            ``as`` and keep it: it is also how the block is removed again.
+
+        Examples:
+            Read one layer out of everything the engine runs::
+
+                >>> with model.register() as registration:   # doctest: +SKIP
+                ...     hidden = model.model.layers[16].output[0].save()
+                >>> model.generate("Hello", max_tokens=5)    # doctest: +SKIP
+                >>> registration.collect()                   # doctest: +SKIP
+                {'0': {'hidden': tensor(...)}}
+                >>> registration.clear()                     # doctest: +SKIP
+        """
+        from .registration import RegisteringTracer
+
+        return RegisteringTracer(self, backend=backend)
+
     def generate(self, *inputs: Any, **kwargs: Any) -> Any:
         """Alias for `trace`, for parity with other models' ``generate``.
 

--- a/src/nnsight/modeling/vllm/vllm.py
+++ b/src/nnsight/modeling/vllm/vllm.py
@@ -245,6 +245,8 @@ class VLLM(Remotable):
         if meta_model is None:
             meta_model = self._load_meta(repo_id, **kwargs)
 
+        self._require_v1_model_runner()
+
         # The real engine brings up its own process group; the one __init__ made
         # to build the meta tree would collide with it. Only tear down a group this
         # construction created — never one the caller already had running.
@@ -257,6 +259,40 @@ class VLLM(Remotable):
             self.vllm_entrypoint = self._load_sync(repo_id, **kwargs)
 
         return meta_model
+
+    @staticmethod
+    def _require_v1_model_runner() -> None:
+        """Ask vLLM for the model runner nnsight instruments.
+
+        vLLM has two GPU model runners. nnsight's hooks arrive by subclassing the
+        original one and rebinding the name the worker resolves
+        ([`NNsightGPUWorker`][nnsight.modeling.vllm.workers.GPUWorker.NNsightGPUWorker]),
+        so on the other one the engine comes up with no instrumentation at all —
+        traces then fail at the first collect with a missing method rather than
+        anything that explains itself.
+
+        From vLLM 0.27 the second runner is the *default* for every non-MoE model
+        (`use_v2_model_runner` in vLLM's config: ``is_default_v2_architecture or
+        not is_moe``), so this is the ordinary case rather than an exotic one. The
+        switch is vLLM's own environment variable, which it consults ahead of its
+        defaults, and the engine's worker processes inherit it.
+
+        A caller who has asked for the other runner explicitly is told so, rather
+        than silently overridden or silently uninstrumented.
+        """
+        import os
+
+        key = "VLLM_USE_V2_MODEL_RUNNER"
+        asked = os.environ.get(key)
+        if asked not in (None, "", "0"):
+            raise NotImplementedError(
+                f"{key}={asked!r} selects vLLM's V2 GPU model runner, which "
+                "nnsight does not instrument yet — the engine would run with no "
+                "interventions installed. Unset it to trace, or drop nnsight and "
+                "use vLLM directly for that run."
+            )
+        # Older vLLM has no such setting and ignores it.
+        os.environ[key] = "0"
 
     def _load_sync(self, repo_id: str, **kwargs: Any) -> Any:
         from vllm import LLM

--- a/src/nnsight/modeling/vllm/vllm.py
+++ b/src/nnsight/modeling/vllm/vllm.py
@@ -109,6 +109,14 @@ class VLLM(Remotable):
             # and not once per construction (atexit does not dedupe).
             atexit.register(VLLM._cleanup_distributed)
 
+        # A vLLM parallel layer called ad hoc — a logit lens — takes and returns
+        # one rank's piece, where the caller is holding whole tensors.
+        # `ParallelEnvoy` puts that right; a caller passing `envoys` of their own
+        # replaces it wholesale.
+        from .envoys import parallel_envoys
+
+        kwargs.setdefault("envoys", parallel_envoys())
+
         super().__init__(*args, **kwargs)
 
     @staticmethod

--- a/src/nnsight/modeling/vllm/vllm.py
+++ b/src/nnsight/modeling/vllm/vllm.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import atexit
 import contextlib
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Callable
 
 import torch
@@ -321,9 +322,10 @@ class VLLM(Remotable):
     def _prompt(self, *inputs: Any) -> Any:
         """Convert one invoke's input into a vLLM prompt.
 
-        Accepts a string, a list of token ids, or a tokenizer's output dict. A
-        request is one sequence, so anything carrying several prompts is rejected
-        here rather than silently generating from the first.
+        Accepts a string, a list of token ids, a tokenizer's output, or one
+        of vLLM's own prompt dicts (``TokensPrompt``, ``TextPrompt``, and the
+        multimodal forms). A request is one sequence, so anything carrying several
+        prompts is rejected here rather than silently generating from the first.
         """
         from vllm.inputs import TokensPrompt
 
@@ -334,8 +336,17 @@ class VLLM(Remotable):
             )
         prompt = inputs[0]
 
-        if isinstance(prompt, dict):
-            return self._tokenized_prompt(prompt)
+        # `Mapping`, not `dict`: a tokenizer hands back a `BatchEncoding`, which is
+        # a `UserDict` and so fails an `isinstance(..., dict)` test — which is why
+        # the tokenizer-output path below was unreachable from an actual tokenizer.
+        if isinstance(prompt, Mapping):
+            # That output is ours to convert. Anything else is one of vLLM's own
+            # prompt dicts — `TypedDict`s, so plain dicts at runtime — and the
+            # engine knows them better than we do; taking those for tokenizer
+            # output is how `TokensPrompt(...)` came back as `KeyError: 'input_ids'`.
+            if "input_ids" in prompt:
+                return self._tokenized_prompt(prompt)
+            return prompt
         if isinstance(prompt, str):
             return prompt
         if isinstance(prompt, (list, tuple)):
@@ -349,7 +360,7 @@ class VLLM(Remotable):
             )
         return prompt
 
-    def _tokenized_prompt(self, inputs: dict) -> Any:
+    def _tokenized_prompt(self, inputs: Any) -> Any:
         """Convert a tokenizer's ``{input_ids, attention_mask}`` output to a prompt.
 
         vLLM has no padding to mask — a request is exactly its own tokens — so a
@@ -501,11 +512,23 @@ class VLLM(Remotable):
 
         The local form drops a list held on the envoy; here each edit lives on
         the workers, so each is cleared through its own handle — which means this
-        is synchronous-engine only, like `clear` itself. On ``mode="async"`` clear
-        each handle with ``await edit.aclear()`` instead.
+        is synchronous-engine only, like `clear` itself. Use `aclear_edits` on an
+        async engine, where it raises rather than half-clearing.
         """
         for edit in list(self._installed_edits):
             edit.clear()
+
+    async def aclear_edits(self) -> None:
+        """`clear_edits`, awaited — the async engine's form.
+
+        A separate method rather than a `clear_edits` that returns something
+        awaitable on an async engine: a coroutine nobody awaits never runs at
+        all, so the sync-looking call would leave every edit installed and say
+        nothing. That is the failure `Registration._rpc` refuses, and it is worth
+        refusing here too — `clear`/`aclear` already come in this pair.
+        """
+        for edit in list(self._installed_edits):
+            await edit.aclear()
 
     def generate(self, *inputs: Any, **kwargs: Any) -> Any:
         """Generate — as a trace when used as a ``with`` block, plainly when not.

--- a/src/nnsight/modeling/vllm/vllm.py
+++ b/src/nnsight/modeling/vllm/vllm.py
@@ -315,7 +315,13 @@ class VLLM(Remotable):
             kwargs = dict(kwargs)
             lora_requests.append(kwargs.pop("lora_request", None))
             prompts.append(self._prompt(*inputs))
-            params.append(SamplingParams(**kwargs))
+            param = SamplingParams(**kwargs)
+            # Which settings this invoke named, for `_attach_mediators` to leave
+            # alone. Recorded rather than inferred: the value a caller passed
+            # cannot be told from the one it would have had by default, and half
+            # of vLLM's defaults are the obvious thing to type.
+            param.nnsight_named = frozenset(kwargs)
+            params.append(param)
 
         return (prompts, params, lora_requests), {}
 
@@ -720,6 +726,12 @@ class VLLM(Remotable):
         keyword arguments (a typo'd sampling setting) are refused too, rather than
         silently ignored the way the fill loop otherwise would.
 
+        "Did not set them" is what the invoke recorded in `_batch`, not "still
+        equals vLLM's default". The two are not the same: ``temperature=1.0`` and
+        ``max_tokens=16`` *are* the defaults, so an invoke asking for either used
+        to have it overwritten by the trace-level setting while a neighbouring
+        ``temperature=0.99`` was honoured.
+
         Returns:
             The workers that were attached, in request order.
         """
@@ -760,8 +772,9 @@ class VLLM(Remotable):
             # consulted this way and the read is whole anyway.
             if hasattr(param, "skip_reading_prefix_cache"):
                 param.skip_reading_prefix_cache = True
+            named = getattr(param, "nnsight_named", frozenset())
             for attr, value in kwargs.items():
-                if getattr(param, attr) == getattr(default, attr):
+                if attr not in named:
                     setattr(param, attr, value)
 
         return attached

--- a/src/nnsight/modeling/vllm/vllm.py
+++ b/src/nnsight/modeling/vllm/vllm.py
@@ -651,31 +651,56 @@ class VLLM(Remotable):
         is where the tracer reads a block's results from once the run is over. A
         worker that raised carries its error back too; re-raise the first real one
         (a ``tracer.stop()`` is control flow and stays silent).
+
+        A name can come back more than once — one invoke per request, and one
+        sampled sequence per ``n`` within each — because the block ran once for
+        each. Those are separate values rather than copies of one thing, so they
+        come back as a list, in submission order. A name saved by exactly one run
+        stays that value, which is every trace that does not use several invokes
+        or ``n``; so does one whose runs all saved the same object, as they do for
+        ``tracer.result``, which is the request's single output however many
+        sequences sampled from it.
         """
         from ...intervention.errors import raise_deferred
         from ...tracing.tracer import mark
         from .collect import merge_shared_saves
 
         per_request_saves = []
-        for mediator, output in zip(mediators, outputs):
+        values: dict[str, list] = {}
+        for output in outputs:
             # The trace's own names only. `output.saves` also carries whatever a
             # registered block saved for this request, and those must not be
-            # pushed into the trace's variables — nor handed to
-            # `merge_shared_saves`, which would read one name saved across many
-            # requests as a single shared container and fold them together.
-            saves = getattr(output, "nnsight_saves", {})
-            per_request_saves.append(saves)
-            for name, value in saves.items():
-                mark(value)  # marking results after the run; no trace active to guard
-                mediator.lcls[name] = value
+            # pushed into the trace's variables.
+            sequences = getattr(output, "nnsight_sequences", None)
+            if not sequences:
+                sequences = [getattr(output, "nnsight_saves", {})]
+            per_request_saves.append(sequences[0])
+            for saves in sequences:
+                for name, value in saves.items():
+                    mark(value)  # results marked after the run; no trace to guard
+                    values.setdefault(name, []).append(value)
 
-        # A name saved above the invoke blocks ships back once per request,
-        # each copy carrying that request's writes. Merge the copies
-        # element-wise so the result reads as if every invoke had mutated one
-        # shared object (the local semantics). The merged containers are new
-        # objects; mark them saved so the result push keeps them.
-        for value in merge_shared_saves(mediators, per_request_saves).values():
+        # A name bound and saved above the invoke blocks is one object locally,
+        # and ships back once per request with that request's writes; merge those
+        # copies element-wise so the result reads as it would locally. The merged
+        # containers are new objects; mark them so the result push keeps them.
+        shared = merge_shared_saves(mediators, per_request_saves)
+        for value in shared.values():
             mark(value)
+
+        for name, found in values.items():
+            if name in shared:
+                continue
+            value = found[0]
+            # Several runs, but one object: `tracer.result` is the request's one
+            # output, served to every sequence's block, so it is not `n` values
+            # of anything. Identity is preserved across the collect, which pickles
+            # them together.
+            if len(found) > 1 and any(other is not value for other in found):
+                value = found
+                mark(value)  # the list itself is new, and is what gets pushed
+            for mediator in mediators:
+                mediator.lcls[name] = value
 
         for output in outputs:
             raise_deferred(getattr(output, "nnsight_error", None))

--- a/src/nnsight/modeling/vllm/vllm.py
+++ b/src/nnsight/modeling/vllm/vllm.py
@@ -41,8 +41,8 @@ class VLLM(Remotable):
     process. Sampling settings (``temperature``, ``max_tokens``, ``top_p``, ...)
     are passed to ``trace``/``invoke`` rather than configured on the model, since
     each invoke is its own vLLM request. Read generated tokens through
-    ``model.logits`` / ``model.samples`` (or the streamed output in async), not
-    ``tracer.result`` — the latter is not served here.
+    ``model.logits`` / ``model.samples`` under ``tracer.iter``, or the whole
+    finished request through ``tracer.result``.
 
     Examples:
         Single prompt, edit an activation, read the logits::
@@ -93,6 +93,9 @@ class VLLM(Remotable):
         # Whether this construction brought up the process group — so only then do we
         # tear it down (on dispatch and at exit), never a group nnsight found running.
         self._owns_distributed = False
+        # Edits installed on the engine, so `clear_edits` can reach them; a
+        # cleared one drops out (see registration.Registration.clear).
+        self._installed_edits: list = []
 
         # Model-parallel init has to happen before `Meta.__init__` opens its
         # meta-device context: vLLM builds real rank tensors here and later calls
@@ -405,39 +408,82 @@ class VLLM(Remotable):
         kwargs.setdefault("fn", self._call)
         return super().trace(*inputs, **kwargs)
 
-    def register(self, *, backend: Any = None) -> Any:
-        """Leave a block on the engine to run for every request it handles.
+    def edit(
+        self,
+        *,
+        inplace: bool = True,
+        serve: str | None = None,
+        api_key: str | None = None,
+        backend: Any = None,
+    ) -> Any:
+        """Install a block on the engine, to run for every request it handles.
 
-        A trace carries its block on the request it rides, so a sweep pays to
-        serialize it once per prompt and only requests written as traces are
-        touched at all. A registration sends the block over once; the engine then
-        gives every request its own copy, whoever submitted it — an OpenAI-API
-        client on the same server included. Each copy saves into a scope of its
-        own, and the values wait on the worker until collected.
+        The vLLM form of [`Envoy.edit`][nnsight.intervention.envoy.Envoy.edit].
+        An ordinary edit is replayed by the envoy that stores it, which here is
+        the client — where there are no weights, so it would never run. This
+        sends the block to the engine instead, where every request afterwards
+        gets its own copy: requests you trace, and requests submitted by
+        something that has never heard of nnsight.
+
+        What the block saves comes back on that request's output, as
+        ``output.saves`` — the same place a trace's values arrive. For a request
+        you are tracing, read it through ``tracer.result.saves``.
 
         The block is written like a trace body against the same envoy tree. It
         belongs to no particular request, so there is nothing to
-        ``tracer.invoke(...)`` — give it the locations you want and ``.save()``
-        what you want back.
+        ``tracer.invoke(...)``.
+
+        Args:
+            inplace: Only ``True``. An edit here lives on the engine every caller
+                shares, so unlike the local form there is no copy to edit
+                instead.
+            serve: An nnsight-serve URL to install the block on, the counterpart
+                of ``trace(..., serve=url)``. Without it the block goes to this
+                process's own engine.
+            api_key: Sent as the ``ndif-api-key`` header alongside ``serve``.
+            backend: Optional backend for the underlying trace.
 
         Returns:
-            The [`Registration`][nnsight.modeling.vllm.registration.Registration]
-            the block's per-request values are collected through. Bind it with
-            ``as`` and keep it: it is also how the block is removed again.
+            ``(tracer, edit)`` — the tracer, whose ``iter``/``all`` is what lets
+            the block follow a request across its generated tokens rather than
+            seeing only the prefill; and the handle to
+            [`clear`][nnsight.modeling.vllm.registration.Registration.clear] it
+            with. [`clear_edits`][nnsight.modeling.vllm.vllm.VLLM.clear_edits]
+            clears every one still installed.
 
         Examples:
             Read one layer out of everything the engine runs::
 
-                >>> with model.register() as registration:   # doctest: +SKIP
+                >>> with model.edit() as (tracer, edit):     # doctest: +SKIP
                 ...     hidden = model.model.layers[16].output[0].save()
-                >>> model.generate("Hello", max_tokens=5)    # doctest: +SKIP
-                >>> registration.collect()                   # doctest: +SKIP
-                {'0': {'hidden': tensor(...)}}
-                >>> registration.clear()                     # doctest: +SKIP
+                >>> outputs = model.generate(prompts, max_tokens=5)  # doctest: +SKIP
+                >>> outputs[3].saves["hidden"]               # doctest: +SKIP
+                >>> edit.clear()                             # doctest: +SKIP
+
+            Against a served engine, from a client with no GPU::
+
+                >>> with model.edit(serve="http://host:8000") as (tracer, edit):
+                ...     model.model.layers[16].output[0][:] = 0  # doctest: +SKIP
         """
         from .registration import RegisteringTracer
 
-        return RegisteringTracer(self, backend=backend)
+        if not inplace:
+            raise ValueError(
+                "a vLLM edit is installed on the engine itself, which every "
+                "caller shares — there is no copy to edit instead. Drop "
+                "inplace=False, or trace the requests you want to change."
+            )
+        return RegisteringTracer(self, backend=backend, serve=serve, api_key=api_key)
+
+    def clear_edits(self) -> None:
+        """Clear every edit still installed on the engine.
+
+        The local form drops a list held on the envoy; here each edit lives on
+        the workers, so each is cleared through its own handle.
+        """
+        for edit in list(self._installed_edits):
+            edit.clear()
+        self._installed_edits.clear()
 
     def generate(self, *inputs: Any, **kwargs: Any) -> Any:
         """Generate — as a trace when used as a ``with`` block, plainly when not.
@@ -449,11 +495,11 @@ class VLLM(Remotable):
         ``tracer.iter``, or through ``tracer.result``.
 
         Called without a ``with`` block it just runs the engine and hands back
-        vLLM's request outputs, so a registration's values — which arrive on
-        the output — can be read without reaching past the model for
+        vLLM's request outputs, so an edit's values — which arrive on the
+        output — can be read without reaching past the model for
         ``model.vllm_entrypoint``::
 
-            >>> with model.register() as (tracer, registration):  # doctest: +SKIP
+            >>> with model.edit() as (tracer, edit):              # doctest: +SKIP
             ...     hidden = model.model.layers[16].output[0].save()
             >>> outputs = model.generate(prompts, max_tokens=5)   # doctest: +SKIP
             >>> outputs[5].saves["hidden"]                        # doctest: +SKIP

--- a/src/nnsight/modeling/vllm/vllm.py
+++ b/src/nnsight/modeling/vllm/vllm.py
@@ -440,15 +440,111 @@ class VLLM(Remotable):
         return RegisteringTracer(self, backend=backend)
 
     def generate(self, *inputs: Any, **kwargs: Any) -> Any:
-        """Alias for `trace`, for parity with other models' ``generate``.
+        """Generate — as a trace when used as a ``with`` block, plainly when not.
 
-        vLLM generation is driven by ``max_tokens`` (``trace`` rewrites
-        ``max_new_tokens`` to it), so there is no forward/generate distinction to draw.
-        Read generated tokens through ``model.logits``/``model.samples`` under
-        ``tracer.iter``, not ``tracer.result`` — the latter is never served here and a
-        worker reading it would park forever.
+        ``with model.generate(...)`` is `trace`: vLLM has no forward/generate
+        split, so the two are the same thing and generation length is
+        ``max_tokens`` (``max_new_tokens`` is accepted and rewritten). Read the
+        generated tokens through ``model.logits``/``model.samples`` under
+        ``tracer.iter``, or through ``tracer.result``.
+
+        Called without a ``with`` block it just runs the engine and hands back
+        vLLM's request outputs, so a registration's values — which arrive on
+        the output — can be read without reaching past the model for
+        ``model.vllm_entrypoint``::
+
+            >>> with model.register() as (tracer, registration):  # doctest: +SKIP
+            ...     hidden = model.model.layers[16].output[0].save()
+            >>> outputs = model.generate(prompts, max_tokens=5)   # doctest: +SKIP
+            >>> outputs[5].saves["hidden"]                        # doctest: +SKIP
+
+        Which of the two it is comes from the call site — the same test
+        [`traceable`][nnsight.intervention.envoy.traceable] makes for a method
+        used either way: capturing a block that is not there raises, and that is
+        the signal to run plainly.
         """
-        return self.trace(*inputs, **kwargs)
+        from ...tracing.tracer import WithBlockNotFoundError
+
+        tracer = self.trace(*inputs, **kwargs)
+        try:
+            # Idempotent, and reads the caller's frame from the same depth
+            # `__enter__` would — so this only asks the question, and entering
+            # the block later still captures normally.
+            tracer.capture()
+        except WithBlockNotFoundError:
+            return self._generate(*inputs, **kwargs)
+        return tracer
+
+    def _generate(self, *inputs: Any, **kwargs: Any) -> Any:
+        """Run the engine with no block of this caller's own.
+
+        Registered blocks still run — they belong to the engine, not to the
+        caller — so their values come back on the outputs this returns.
+
+        Args:
+            *inputs: One prompt, or a list of them. Unlike a trace there is no
+                invoke to be one-per-request, so a list is simply a batch.
+            **kwargs: Sampling settings for the whole batch.
+        """
+        from vllm import SamplingParams
+
+        if not self.dispatched:
+            self.dispatch()
+
+        kwargs = dict(kwargs)
+        if "max_new_tokens" in kwargs and "max_tokens" not in kwargs:
+            kwargs["max_tokens"] = kwargs.pop("max_new_tokens")
+        lora_request = kwargs.pop("lora_request", None)
+        params = SamplingParams(**kwargs)
+
+        prompts = inputs[0] if len(inputs) == 1 else list(inputs)
+        if self._async_engine:
+            # An async engine has no call that runs to completion, so this cannot
+            # hand back outputs — it hands back the await that will. Same shape
+            # either way: `outputs = model.generate(...)` on a sync engine,
+            # `outputs = await model.generate(...)` on an async one.
+            return self._generate_async(prompts, params, lora_request)
+        return self.vllm_entrypoint.generate(
+            prompts, params, lora_request=lora_request
+        )
+
+    async def _generate_async(self, prompts: Any, params: Any, lora_request: Any) -> list:
+        """Drive the async engine to completion and collect, as the sync path does.
+
+        Each prompt is its own request, submitted together so the engine batches
+        them, and each is drained to its final output. The collect is done here
+        because nothing else will: the streaming backend runs only for traces
+        nnsight itself submitted, so without this a registered block's values
+        would have no way onto these outputs.
+        """
+        import asyncio
+        import uuid
+
+        from .engines.engine import attach, merge_collected
+
+        engine = self.vllm_entrypoint
+        if isinstance(prompts, str) or not isinstance(prompts, (list, tuple)):
+            prompts = [prompts]
+
+        async def run(prompt: Any) -> Any:
+            request_id = uuid.uuid4().hex
+            extra = {} if lora_request is None else {"lora_request": lora_request}
+            output = None
+            async for output in engine.generate(prompt, params, request_id, **extra):
+                pass
+            if output is None:
+                return None
+            entry = merge_collected(
+                await engine.collective_rpc(
+                    "collect_nnsight",
+                    args=([request_id], [request_id], {request_id: output}),
+                )
+            ).get(request_id)
+            if entry is not None:
+                attach(output, entry)
+            return output
+
+        return list(await asyncio.gather(*(run(prompt) for prompt in prompts)))
 
     def _call(
         self, prompts: list, params: list, lora_requests: list, **kwargs: Any
@@ -477,7 +573,14 @@ class VLLM(Remotable):
 
         per_request_saves = []
         for mediator, output in zip(mediators, outputs):
-            saves = getattr(output, "saves", {})
+            # The trace's own names only. `output.saves` also carries whatever a
+            # registered block saved for this request, and those must not be
+            # pushed into the trace's variables — nor handed to
+            # `merge_shared_saves`, which would read one name saved across many
+            # requests as a single shared container and fold them together.
+            saves = getattr(output, "nnsight_saves", None)
+            if saves is None:
+                saves = getattr(output, "saves", {})
             per_request_saves.append(saves)
             for name, value in saves.items():
                 mark(value)  # marking results after the run; no trace active to guard

--- a/src/nnsight/modeling/vllm/workers/GPUWorker.py
+++ b/src/nnsight/modeling/vllm/workers/GPUWorker.py
@@ -27,10 +27,15 @@ class NNsightGPUWorker(Worker):
         super().__init__(*args, **kwargs)
 
     def collect_nnsight(
-        self, request_ids: list[str], finished_request_ids: Optional[list[str]] = None
+        self,
+        request_ids: list[str],
+        finished_request_ids: Optional[list[str]] = None,
+        outputs: Optional[dict] = None,
     ) -> Optional[bytes]:
         """Return this worker's saved values, as ``collective_rpc`` reaches it here."""
-        return self.model_runner.collect_nnsight(request_ids, finished_request_ids)
+        return self.model_runner.collect_nnsight(
+            request_ids, finished_request_ids, outputs
+        )
 
     def nnsight_request_count(self) -> int:
         """How many requests this worker's runner still tracks, via ``collective_rpc``."""
@@ -39,12 +44,6 @@ class NNsightGPUWorker(Worker):
     def nnsight_register(self, registration_id: str, payload: bytes) -> None:
         """Install a block this worker runs for every request (``collective_rpc``)."""
         return self.model_runner.nnsight_register(registration_id, payload)
-
-    def nnsight_collect_registered(
-        self, registration_id: str, clear: bool = True
-    ) -> Optional[bytes]:
-        """Return what a registration's finished requests saved (``collective_rpc``)."""
-        return self.model_runner.nnsight_collect_registered(registration_id, clear)
 
     def nnsight_clear_registered(self, registration_id: str) -> None:
         """Remove a registration from this worker (``collective_rpc``)."""

--- a/src/nnsight/modeling/vllm/workers/GPUWorker.py
+++ b/src/nnsight/modeling/vllm/workers/GPUWorker.py
@@ -35,3 +35,17 @@ class NNsightGPUWorker(Worker):
     def nnsight_request_count(self) -> int:
         """How many requests this worker's runner still tracks, via ``collective_rpc``."""
         return self.model_runner.nnsight_request_count()
+
+    def nnsight_register(self, registration_id: str, payload: bytes) -> None:
+        """Install a block this worker runs for every request (``collective_rpc``)."""
+        return self.model_runner.nnsight_register(registration_id, payload)
+
+    def nnsight_collect_registered(
+        self, registration_id: str, clear: bool = True
+    ) -> Optional[bytes]:
+        """Return what a registration's finished requests saved (``collective_rpc``)."""
+        return self.model_runner.nnsight_collect_registered(registration_id, clear)
+
+    def nnsight_clear_registered(self, registration_id: str) -> None:
+        """Remove a registration from this worker (``collective_rpc``)."""
+        return self.model_runner.nnsight_clear_registered(registration_id)

--- a/tests/test_fragments.py
+++ b/tests/test_fragments.py
@@ -120,6 +120,15 @@ class TestGating:
 
         assert ("read", "model.output") in fragments.calls
 
+    def test_targeted_cache_gathers_its_subscription(self, model):
+        fragments = Recorder(locations={"model.output"})
+        model.interleaver.fragments = fragments
+        with model.trace(torch.randn(1, 4)) as tracer:
+            cache = tracer.cache(modules=[model])
+
+        assert ("whole", "model.output") in fragments.calls
+        assert cache["model"].output.shape[-1] == 8
+
 
 class TestLifecycle:
     def test_the_tree_is_walked_past_instrument(self, model):

--- a/tests/test_interleaving.py
+++ b/tests/test_interleaving.py
@@ -11,6 +11,7 @@ from nnsight.intervention.interleaver import (
     Interleaver,
     Mediator,
     OutOfOrderError,
+    Pending,
 )
 
 
@@ -71,7 +72,7 @@ class TestMediator:
         assert med.alive
         # A park carries the occurrence tag for the iteration the worker wants
         # (0 by default).
-        assert med.pending == (Event.VALUE, "loc.i0")
+        assert med.pending == Pending(Event.VALUE, "loc", 0)
 
     def test_handle_value_match_resumes_and_finishes(self):
         store = {}
@@ -88,7 +89,7 @@ class TestMediator:
         med.start()
         med.handle("other", 1)
         assert med.alive
-        assert med.pending == (Event.VALUE, "loc.i0")
+        assert med.pending == Pending(Event.VALUE, "loc", 0)
         assert "got" not in store
 
     def test_handle_is_noop_when_done(self):
@@ -100,24 +101,33 @@ class TestMediator:
         assert not med.alive
 
     def test_value_helper_parks_on_value_event(self):
-        # Mediator.value(loc) should yield a (VALUE, loc.i0) event and return the
-        # served value back into the worker.
+        # Mediator.value(loc) should park on (VALUE, loc, occurrence 0) and
+        # return the served value back into the worker.
         store = {}
         med = make_mediator("store['got'] = Mediator.value('here')", store=store)
         med.start()
-        assert med.pending == (Event.VALUE, "here.i0")
+        assert med.pending == Pending(Event.VALUE, "here", 0)
         med.handle("here", 42)
         assert store["got"] == 42
 
     def test_event_tags_location_with_iteration(self):
-        # Mediator.event(kind, location) tags the location with the worker's
-        # current iteration before switching the tuple to the parent.
+        # Mediator.event(kind, location) records the worker's current iteration
+        # alongside the location before switching to the parent.
         store = {}
         med = make_mediator(
             "store['got'] = Mediator.event(Event.VALUE, 'loc')", store=store
         )
         med.start()
-        assert med.pending == (Event.VALUE, "loc.i0")
+        assert med.pending == Pending(Event.VALUE, "loc", 0)
+
+    def test_pending_prints_as_location_and_occurrence(self):
+        # The location and occurrence are separate fields so the model side can
+        # match on either without building a string, but an error message wants
+        # them rejoined — printing is what OutOfOrderError interpolates.
+        assert str(Pending(Event.VALUE, "model.layers.16.output", 2)) == (
+            "model.layers.16.output.i2"
+        )
+        assert f"{Pending(Event.SWAP, 'loc', 0, 'edit')}" == "loc.i0"
 
     def test_iteration_binds_read_to_that_occurrence(self):
         # With iteration set to 1, a read waits past the model's first visit to a
@@ -128,11 +138,17 @@ class TestMediator:
             "store['got'] = Mediator.value('loc')",
             store=store,
         )
-        med.start()
-        assert med.pending == (Event.VALUE, "loc.i1")
-        med.handle("loc", "first")  # occurrence 0 — ignored, worker stays parked
-        assert med.alive and "got" not in store
-        med.handle("loc", "second")  # occurrence 1 — served
+        # Driven through an Interleaver rather than by calling `med.handle`
+        # directly: counting the visits is the interleaver's job (a worker parked
+        # elsewhere is never asked, so it could not count them itself), and this
+        # test is about which visit the read binds to.
+        il = Interleaver()
+        il.mediators.append(med)
+        with il:
+            assert med.pending == Pending(Event.VALUE, "loc", 1)
+            il.handle("loc", "first")  # occurrence 0 — ignored, worker stays parked
+            assert med.alive and "got" not in store
+            il.handle("loc", "second")  # occurrence 1 — served
         assert store["got"] == "second"
         assert not med.alive
 
@@ -168,6 +184,40 @@ class TestInterleaver:
         il.mediators.append(make_mediator("pass"))  # never started -> not dangling
         il.cancel()
         assert il.mediators == []
+
+    def test_parked_index_is_rebuilt_each_run(self):
+        # `parked` tells handle which locations are worth walking the workers for.
+        # The worker list is appended to and cleared in place rather than replaced,
+        # so an index only rebuilt on assignment goes stale: it would keep last
+        # run's locations forever and the skip would stop firing.
+        il = Interleaver()
+        first = requester({}, "a")
+        il.mediators.append(first)
+        with il:
+            assert il.parked == {"a"}
+        il.cancel()
+
+        second = requester({}, "b")
+        il.mediators.append(second)
+        with il:
+            assert il.parked == {"b"}, "last run's locations leaked into this one"
+
+    def test_caching_does_not_stick_across_runs(self):
+        # A cache forces the slow path at every location. Left set after the run
+        # that opened it, it would quietly cost every later trace on the same model
+        # the walk this index exists to skip.
+        il = Interleaver()
+        il.mediators.append(requester({}, "a"))
+        with il:
+            # A cache is opened from inside a running block, which is why
+            # tracer.cache() sets this directly rather than it being derived at
+            # entry — `start` has already reset the worker's cache list by then.
+            il.caching = True
+        il.cancel()
+
+        il.mediators.append(requester({}, "b"))
+        with il:
+            assert not il.caching, "caching stayed on after the caching run ended"
 
     def test_check_dangling_throws_into_parked_worker(self):
         il = Interleaver()

--- a/tests/test_interleaving.py
+++ b/tests/test_interleaving.py
@@ -5,6 +5,7 @@ import nnsight
 import torch.nn as nn
 from greenlet import getcurrent
 
+from nnsight.intervention.barrier import Barrier
 from nnsight.intervention.envoy import Envoy
 from nnsight.intervention.interleaver import (
     Event,
@@ -175,6 +176,7 @@ class TestInterleaver:
         il.mediators.append(requester(s1))
         il.mediators.append(requester(s2))
         with il:
+            assert il.waiting == {"loc": 2}
             il.handle("loc", 7)
         assert s1["got"] == 7
         assert s2["got"] == 7
@@ -185,39 +187,127 @@ class TestInterleaver:
         il.cancel()
         assert il.mediators == []
 
-    def test_parked_index_is_rebuilt_each_run(self):
-        # `parked` tells handle which locations are worth walking the workers for.
-        # The worker list is appended to and cleared in place rather than replaced,
-        # so an index only rebuilt on assignment goes stale: it would keep last
-        # run's locations forever and the skip would stop firing.
+    def test_waiting_index_is_rebuilt_each_run(self):
+        # A prior run's wait count must not leak into the next run.
         il = Interleaver()
         first = requester({}, "a")
         il.mediators.append(first)
         with il:
-            assert il.parked == {"a"}
+            assert il.waiting == {"a": 1}
         il.cancel()
 
         second = requester({}, "b")
         il.mediators.append(second)
         with il:
-            assert il.parked == {"b"}, "last run's locations leaked into this one"
+            assert il.waiting == {"b": 1}
 
-    def test_caching_does_not_stick_across_runs(self):
-        # A cache forces the slow path at every location. Left set after the run
-        # that opened it, it would quietly cost every later trace on the same model
-        # the walk this index exists to skip.
+    def test_cache_routes_do_not_stick_across_runs(self):
+        class Cache:
+            def subscriptions(self):
+                return {"a.output": ("a", "output")}
+
         il = Interleaver()
-        il.mediators.append(requester({}, "a"))
+        first = requester({}, "a")
+        il.mediators.append(first)
         with il:
-            # A cache is opened from inside a running block, which is why
-            # tracer.cache() sets this directly rather than it being derived at
-            # entry — `start` has already reset the worker's cache list by then.
-            il.caching = True
+            first.caches.append(Cache())
+            il.reindex()
+            assert "a.output" in il.observers
         il.cancel()
 
-        il.mediators.append(requester({}, "b"))
+        second = requester({}, "b")
+        il.mediators.append(second)
         with il:
-            assert not il.caching, "caching stayed on after the caching run ended"
+            assert not il.observers
+
+    def test_only_ready_waiters_are_served(self):
+        il = Interleaver()
+        target, other = requester({}, "target"), requester({}, "other")
+        il.mediators.extend([target, other])
+        called = []
+        original = other.handle
+
+        def spy(*args):
+            called.append(args)
+            return original(*args)
+
+        other.handle = spy
+        with il:
+            il.handle("target", 1)
+
+        assert not called
+        assert other.iterations["target"] == 1
+
+    def test_waiting_route_moves_with_a_worker(self):
+        store = {}
+        mediator = make_mediator(
+            "store['a'] = Mediator.value('a')\n"
+            "store['b'] = Mediator.value('b')",
+            store=store,
+        )
+        il = Interleaver()
+        il.mediators.append(mediator)
+
+        with il:
+            assert il.waiting == {"a": 1}
+            il.handle("a", 1)
+            assert il.waiting == {"b": 1}
+            il.handle("b", 2)
+
+        assert store == {"a": 1, "b": 2}
+
+    def test_barrier_repark_uses_the_next_provider_occurrence(self):
+        # The first worker has already had its current occurrence counted when
+        # the second worker releases it from the barrier. Its next read of loc
+        # must therefore wait for the next hook, not be stranded on occurrence 0.
+        store = {}
+        barrier = Barrier(2)
+        first = make_mediator(
+            "store['first'] = Mediator.value('loc')\n"
+            "getcurrent().mediator().iteration = None\n"
+            "barrier()\n"
+            "store['after'] = Mediator.value('loc')",
+            store=store,
+            barrier=barrier,
+        )
+        second = make_mediator(
+            "store['second'] = Mediator.value('loc')\nbarrier()",
+            store=store,
+            barrier=barrier,
+        )
+        il = Interleaver()
+        il.mediators.extend([first, second])
+
+        with il:
+            il.handle("loc", 1)
+            assert first.pending == Pending(Event.VALUE, "loc", 1)
+            il.handle("loc", 2)
+
+        assert store == {"first": 1, "second": 1, "after": 2}
+
+    def test_targeted_cache_observes_only_its_subscription(self):
+        class Cache:
+            def __init__(self):
+                self.observed = []
+
+            def subscriptions(self):
+                return {"target.output": ("target", "output")}
+
+            def observe_selected(self, selected, value):
+                self.observed.append((selected, value))
+
+        il = Interleaver()
+        mediator = make_mediator("pass")
+        il.mediators.append(mediator)
+        cache = Cache()
+
+        with il:
+            mediator.caches.append(cache)
+            il.reindex()
+            il.handle("other.output", 1)
+            il.handle("target.output", 2)
+
+        assert cache.observed == [(('target', 'output'), 2)]
 
     def test_check_dangling_throws_into_parked_worker(self):
         il = Interleaver()
@@ -606,14 +696,11 @@ class TestCache:
         assert torch.equal(cache.model.l1.output, cache["model.l1"].output)
         assert torch.equal(cache.l1.output, cache["model.l1"].output)
 
-    def test_cache_after_partial_run_misses_earlier(self, envoy, model, x):
-        # A cache created after an intervention that parks at l2 misses the earlier
-        # l1 (already run this forward) but still captures l2 (the park point).
-        with envoy.trace(x) as tracer:
-            envoy.l2.output = envoy.l2.output  # parks at l2.output, past l1
-            cache = tracer.cache()
-        assert "model.l1" not in cache
-        assert cache["model.l2"].output is not None
+    def test_cache_must_be_created_before_model_access(self, envoy, x):
+        with pytest.raises(ValueError, match="before reading or modifying"):
+            with envoy.trace(x) as tracer:
+                envoy.l2.output = envoy.l2.output
+                tracer.cache(modules=[envoy.l2])
 
     def test_cache_captures_skipped_output(self, envoy, x):
         with envoy.trace(x) as tracer:

--- a/tests/vllm/conftest.py
+++ b/tests/vllm/conftest.py
@@ -55,6 +55,28 @@ def vllm_gpt2():
 
 
 @pytest.fixture(scope="module")
+def vllm_gpt2_uncached():
+    """A gpt2 with prefix caching off, which a registration needs.
+
+    A prefix-cached token is served without a forward pass, so no hook fires for
+    it and a registered block sees fewer rows than the prompt has — silently. A
+    trace asks for its own request to be recomputed; a registration rides requests
+    it did not create and cannot, so the cache has to be off at the engine.
+    """
+    from nnsight.modeling.vllm import VLLM
+
+    if GPU_COUNT < 1:
+        pytest.skip("vLLM tests need a GPU")
+    return VLLM(
+        "gpt2",
+        tensor_parallel_size=1,
+        gpu_memory_utilization=0.1,
+        enable_prefix_caching=False,
+        dispatch=True,
+    )
+
+
+@pytest.fixture(scope="module")
 def vllm_qwen_ref():
     """A single-rank Qwen, the unsharded reference the parallel runs compare to."""
     from nnsight.modeling.vllm import VLLM

--- a/tests/vllm/redteam_repros.py
+++ b/tests/vllm/redteam_repros.py
@@ -1,0 +1,156 @@
+"""Focused, executable adversarial probes for the vLLM integration.
+
+This is deliberately not named ``test_*.py``: it prints the raw observations a
+red-team report needs and each mode owns one vLLM engine process.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+import nnsight
+
+
+def sync_save_collision() -> None:
+    """Does a trace save overwrite a same-named registered save on result?"""
+    from nnsight.modeling.vllm import VLLM
+
+    model = VLLM("gpt2", dispatch=True, gpu_memory_utilization=0.1,
+                 enable_prefix_caching=False)
+    with model.edit() as (_, registration):
+        same = nnsight.save("registered")
+    try:
+        with model.trace("The Eiffel Tower is in", max_tokens=1,
+                         temperature=0.0) as tracer:
+            same = nnsight.save("trace")
+            result = tracer.result.save()
+        print("SYNC_COLLISION local_same=", same)
+        print("SYNC_COLLISION result_saves=", result.saves)
+        print("SYNC_COLLISION request_count=", model.vllm_entrypoint.llm_engine
+              .engine_core.collective_rpc("nnsight_request_count"))
+    finally:
+        registration.clear()
+
+
+def sync_registration_matrix() -> None:
+    """Probe registration scope, output-name collisions, and cache ordering."""
+    from nnsight.modeling.vllm import VLLM
+
+    model = VLLM("gpt2", dispatch=True, gpu_memory_utilization=0.1,
+                 enable_prefix_caching=False)
+    try:
+        events = []
+        with model.edit() as (_, shared_registration):
+            events.append("ran")
+            snapshot = nnsight.save(list(events))
+        try:
+            shared = model.generate(["One", "Two"], max_tokens=1, temperature=0.0)
+            print("SYNC_SHARED_CLOSURE snapshots=",
+                  [output.saves["snapshot"] for output in shared])
+        finally:
+            shared_registration.clear()
+
+        with model.edit() as (_, first_registration):
+            same = nnsight.save("first")
+        with model.edit() as (_, second_registration):
+            same = nnsight.save("second")
+        try:
+            collision = model.generate(["One"], max_tokens=1, temperature=0.0)[0]
+            print("SYNC_TWO_REGISTRATIONS_SAME_NAME saves=", collision.saves)
+        finally:
+            first_registration.clear()
+            second_registration.clear()
+
+        try:
+            with model.trace("One", max_tokens=1, temperature=0.0) as tracer:
+                value = model.logits
+                cache = tracer.cache()
+        except Exception as error:
+            print("SYNC_CACHE_AFTER_READ error=", type(error).__name__, str(error))
+        else:
+            print("SYNC_CACHE_AFTER_READ unexpectedly_succeeded=", cache)
+    finally:
+        # This is a synchronous engine; process exit owns its workers.
+        pass
+
+
+def tensor_parallel_parameter_probe() -> None:
+    """Contrast a gathered activation with an un-gathered model parameter."""
+    from nnsight.modeling.vllm import VLLM
+
+    model = VLLM("Qwen/Qwen2.5-0.5B", dispatch=True, tensor_parallel_size=2,
+                 gpu_memory_utilization=0.1)
+    with model.trace("Hello", max_tokens=1, temperature=0.0):
+        # vLLM's parallel linear returns a tuple; save its tensor payload, as the
+        # integration's TP regression tests do.
+        activation = model.model.layers[0].self_attn.qkv_proj.output[0].save()
+        weight = model.lm_head.weight.save()
+    print("TP_PARAMETER activation_shape=", tuple(activation.shape))
+    print("TP_PARAMETER lm_head_shape=", tuple(weight.shape))
+    print("TP_PARAMETER tokenizer_vocab=", model.tokenizer.vocab_size)
+
+
+async def async_registration_and_foreign_leak() -> None:
+    """Exercise untested async registration and inspect a foreign request's save."""
+    from nnsight.modeling.vllm import VLLM
+    from nnsight.modeling.vllm.engines.engine import merge_collected
+    from vllm import SamplingParams
+
+    model = VLLM("gpt2", mode="async", dispatch=True,
+                 gpu_memory_utilization=0.1, enable_prefix_caching=False)
+    engine = model.vllm_entrypoint
+    registration = None
+    try:
+        async with model.edit() as (_, registration):
+            tag = nnsight.save("registered")
+
+        outputs = await model.generate(["The Eiffel Tower is in"], max_tokens=1,
+                                       temperature=0.0)
+        print("ASYNC_REGISTER generated_saves=", outputs[0].saves)
+
+        request_ids = [f"redteamforeign{i}" for i in range(12)]
+
+        async def foreign(request_id: str) -> None:
+            async for _ in engine.generate(
+                "The capital of Japan is",
+                SamplingParams(max_tokens=1, temperature=0.0), request_id,
+            ):
+                pass
+
+        await asyncio.gather(*(foreign(request_id) for request_id in request_ids))
+        print("ASYNC_FOREIGN request_count_before_collect=",
+              await engine.collective_rpc("nnsight_request_count"))
+        collected = merge_collected(await engine.collective_rpc(
+            "collect_nnsight", args=(request_ids, request_ids)
+        ))
+        print("ASYNC_FOREIGN delayed_collect_count=", len(collected))
+        print("ASYNC_FOREIGN delayed_collect_tags=",
+              {key: value["registered"]["tag"] for key, value in collected.items()})
+    finally:
+        if registration is not None:
+            await registration.aclear()
+        try:
+            engine.shutdown()
+        except Exception:
+            pass
+        await asyncio.sleep(1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("probe", choices=("sync-collision", "sync-matrix",
+                                            "async-registration", "tp-parameter"))
+    args = parser.parse_args()
+    if args.probe == "sync-collision":
+        sync_save_collision()
+    elif args.probe == "sync-matrix":
+        sync_registration_matrix()
+    elif args.probe == "tp-parameter":
+        tensor_parallel_parameter_probe()
+    else:
+        asyncio.run(async_registration_and_foreign_leak())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/vllm/test_async.py
+++ b/tests/vllm/test_async.py
@@ -350,3 +350,52 @@ class TestAsyncClearEdits:
             assert not edit.cleared
         finally:
             async_loop.run_until_complete(model.aclear_edits())
+
+
+class TestAsyncSeveralSequences:
+    """``n > 1`` on a streaming engine: the values ride the completions."""
+
+    @torch.no_grad()
+    def test_the_finished_output_carries_one_set_per_sequence(
+        self, vllm_gpt2_async, async_loop, ET_prompt
+    ):
+        model = vllm_gpt2_async
+
+        async def run():
+            with model.trace(ET_prompt, max_tokens=3, temperature=1.0,
+                             seed=0, n=2) as tracer:
+                hidden = model.transformer.h[5].output.save()
+
+            last = None
+            async for output in tracer.backend:
+                last = output
+
+            assert len(last.outputs) == 2
+            prompt_rows = len(model.tokenizer.encode(ET_prompt))
+            for completion in last.outputs:
+                assert completion.saves["hidden"].shape[0] == prompt_rows
+            assert (
+                last.outputs[0].saves["hidden"]
+                is not last.outputs[1].saves["hidden"]
+            )
+
+        async_loop.run_until_complete(run())
+
+    @torch.no_grad()
+    def test_no_worker_is_left_behind(self, vllm_gpt2_async, async_loop, ET_prompt):
+        model = vllm_gpt2_async
+
+        async def run():
+            for _ in range(3):
+                with model.trace(ET_prompt, max_tokens=2, temperature=1.0,
+                                 seed=0, n=2) as tracer:
+                    hidden = model.transformer.h[5].output.save()
+                async for _ in tracer.backend:
+                    pass
+
+            counts = await model.vllm_entrypoint.collective_rpc(
+                "nnsight_request_count"
+            )
+            assert counts == [0] * len(counts)
+
+        async_loop.run_until_complete(run())

--- a/tests/vllm/test_async.py
+++ b/tests/vllm/test_async.py
@@ -307,3 +307,46 @@ class TestAsyncEngine:
             assert vllm_gpt2_async.tokenizer.decode(last.saves["steps"][0]) == " Paris"
 
         async_loop.run_until_complete(run())
+
+
+class TestAsyncClearEdits:
+    """Clearing installed edits on an engine whose workers can only be awaited."""
+
+    @torch.no_grad()
+    def test_aclear_edits_clears_every_one(self, vllm_gpt2_async, async_loop,
+                                           ET_prompt):
+        model = vllm_gpt2_async
+
+        async def run():
+            async with model.edit() as (tracer, deep):
+                deep_hidden = model.transformer.h[8].output.save()
+            async with model.edit() as (tracer, shallow):
+                shallow_hidden = model.transformer.h[2].output.save()
+
+            assert model._installed_edits == [deep, shallow]
+
+            await model.aclear_edits()
+
+            assert deep.cleared and shallow.cleared
+            assert model._installed_edits == []
+
+        async_loop.run_until_complete(run())
+
+    @torch.no_grad()
+    def test_the_synchronous_form_refuses(self, vllm_gpt2_async, async_loop):
+        # It would have to await the workers from outside the loop they run on.
+        # Refusing beats half-clearing, or clearing nothing and saying so.
+        model = vllm_gpt2_async
+
+        async def install():
+            async with model.edit() as (tracer, edit):
+                hidden = model.transformer.h[5].output.save()
+            return edit
+
+        edit = async_loop.run_until_complete(install())
+        try:
+            with pytest.raises(NotImplementedError, match="aclear_edits"):
+                model.clear_edits()
+            assert not edit.cleared
+        finally:
+            async_loop.run_until_complete(model.aclear_edits())

--- a/tests/vllm/test_async.py
+++ b/tests/vllm/test_async.py
@@ -370,14 +370,23 @@ class TestAsyncSeveralSequences:
             async for output in tracer.backend:
                 last = output
 
-            assert len(last.outputs) == 2
             prompt_rows = len(model.tokenizer.encode(ET_prompt))
+
+            # Every sequence's values, which is what the collect produced. Not
+            # `last.outputs`: vLLM streams a request's sequences as they finish,
+            # so the final streamed output carries only the completions that
+            # ended in that step — often one of the two.
+            assert len(last.nnsight_sequences) == 2
+            for saves in last.nnsight_sequences:
+                assert saves["hidden"].shape[0] == prompt_rows
+            assert (
+                last.nnsight_sequences[0]["hidden"]
+                is not last.nnsight_sequences[1]["hidden"]
+            )
+
+            # Whichever completions this output does carry have theirs attached.
             for completion in last.outputs:
                 assert completion.saves["hidden"].shape[0] == prompt_rows
-            assert (
-                last.outputs[0].saves["hidden"]
-                is not last.outputs[1].saves["hidden"]
-            )
 
         async_loop.run_until_complete(run())
 

--- a/tests/vllm/test_lora.py
+++ b/tests/vllm/test_lora.py
@@ -1,0 +1,165 @@
+"""Interventions on a request that carries a LoRA adapter.
+
+vLLM applies an adapter by swapping punica kernels in around the base layers, so
+a traced module's ``.output`` is the *adapted* value and an edit lands on top of
+it. Nothing in nnsight knows about LoRA — ``lora_request`` rides through
+``trace``/``invoke`` to ``SamplingParams``'s sibling argument — which is exactly
+what these confirm: the same reads and writes work with an adapter attached, and
+the adapter is really in the forward.
+
+The adapter is written here rather than downloaded: PEFT's on-disk format is an
+``adapter_config.json`` and a safetensors file of ``lora_A``/``lora_B`` matrices,
+so a deterministic one can be built for whatever base model the box has cached.
+That also means the test knows the adapter is non-trivial — a randomly
+initialized ``lora_B`` is zero in real checkpoints, which would change nothing.
+"""
+
+import json
+
+import pytest
+import torch
+
+pytest.importorskip("vllm")
+
+BASE = "meta-llama/Llama-3.2-1B"
+# Large enough that the adapted logits are unmistakably different, small enough
+# that the model still produces ordinary text.
+SCALE = 0.02
+RANK = 8
+
+
+@pytest.fixture(scope="module")
+def lora_path(tmp_path_factory):
+    """A deterministic rank-8 LoRA on every layer's q_proj and v_proj."""
+    from safetensors.torch import save_file
+    from transformers import AutoConfig
+
+    config = AutoConfig.from_pretrained(BASE)
+    heads, kv_heads = config.num_attention_heads, config.num_key_value_heads
+    head_dim = getattr(config, "head_dim", config.hidden_size // heads)
+    sizes = {
+        "q_proj": heads * head_dim,
+        "v_proj": kv_heads * head_dim,
+    }
+
+    generator = torch.Generator().manual_seed(0)
+    weights = {}
+    for layer in range(config.num_hidden_layers):
+        for name, out_features in sizes.items():
+            stem = f"base_model.model.model.layers.{layer}.self_attn.{name}"
+            weights[f"{stem}.lora_A.weight"] = torch.randn(
+                RANK, config.hidden_size, generator=generator
+            ) * SCALE
+            # Not zeros: a freshly initialized adapter is a no-op, and a no-op
+            # adapter would pass a test that never applied it.
+            weights[f"{stem}.lora_B.weight"] = torch.randn(
+                out_features, RANK, generator=generator
+            ) * SCALE
+
+    directory = tmp_path_factory.mktemp("lora")
+    save_file(weights, str(directory / "adapter_model.safetensors"))
+    (directory / "adapter_config.json").write_text(
+        json.dumps(
+            {
+                "peft_type": "LORA",
+                "task_type": "CAUSAL_LM",
+                "base_model_name_or_path": BASE,
+                "r": RANK,
+                "lora_alpha": 2 * RANK,
+                "lora_dropout": 0.0,
+                "bias": "none",
+                "target_modules": list(sizes),
+            }
+        )
+    )
+    return str(directory)
+
+
+@pytest.fixture(scope="module")
+def vllm_lora():
+    if torch.cuda.device_count() < 1:
+        pytest.skip("LoRA tests need a GPU")
+    from nnsight.modeling.vllm import VLLM
+
+    return VLLM(
+        BASE,
+        enable_lora=True,
+        max_lora_rank=RANK,
+        gpu_memory_utilization=0.25,
+        dispatch=True,
+    )
+
+
+def request(path, id=1):
+    from vllm.lora.request import LoRARequest
+
+    return LoRARequest("nnsight-test", id, path)
+
+
+class TestLoRA:
+    @torch.no_grad()
+    def test_the_adapter_is_in_the_forward(self, vllm_lora, lora_path, ET_prompt):
+        with vllm_lora.trace(ET_prompt, temperature=0.0, top_p=1):
+            base = vllm_lora.logits.save()
+        with vllm_lora.trace(
+            ET_prompt, temperature=0.0, top_p=1, lora_request=request(lora_path)
+        ):
+            adapted = vllm_lora.logits.save()
+
+        assert not torch.allclose(base.float(), adapted.float())
+
+    @torch.no_grad()
+    def test_a_read_sees_the_adapted_value(self, vllm_lora, lora_path, ET_prompt):
+        # vLLM fuses q/k/v into one `qkv_proj`, and the adapter covers the q and
+        # v slices of it, so its output must differ; a read that saw only the base
+        # projection would come back identical.
+        with vllm_lora.trace(ET_prompt, temperature=0.0, top_p=1):
+            base = vllm_lora.model.layers[5].self_attn.qkv_proj.output[0].save()
+        with vllm_lora.trace(
+            ET_prompt, temperature=0.0, top_p=1, lora_request=request(lora_path)
+        ):
+            adapted = vllm_lora.model.layers[5].self_attn.qkv_proj.output[0].save()
+
+        assert base.shape == adapted.shape
+        assert not torch.allclose(base.float(), adapted.float())
+
+    @torch.no_grad()
+    def test_an_edit_lands_on_an_adapted_request(self, vllm_lora, lora_path, ET_prompt):
+        with vllm_lora.trace(
+            ET_prompt, temperature=0.0, top_p=1, lora_request=request(lora_path)
+        ):
+            clean = vllm_lora.logits.save()
+        with vllm_lora.trace(
+            ET_prompt, temperature=0.0, top_p=1, lora_request=request(lora_path)
+        ):
+            vllm_lora.model.layers[10].output[0][:] = 0
+            edited = vllm_lora.logits.save()
+
+        assert not torch.allclose(clean.float(), edited.float())
+
+    @torch.no_grad()
+    def test_adapted_and_base_requests_batch_together(
+        self, vllm_lora, lora_path, ET_prompt
+    ):
+        # Continuous batching mixes them in one forward; each invoke's read must
+        # be its own request's, not whichever adapter the batch happened to hold.
+        with vllm_lora.trace(temperature=0.0, top_p=1) as tracer:
+            with tracer.invoke(ET_prompt, lora_request=request(lora_path)):
+                adapted = vllm_lora.logits.save()
+            with tracer.invoke(ET_prompt):
+                base = vllm_lora.logits.save()
+
+        assert not torch.allclose(base.float(), adapted.float())
+
+    @torch.no_grad()
+    def test_generation_runs_with_an_adapter(self, vllm_lora, lora_path, MSG_prompt):
+        with vllm_lora.trace(
+            MSG_prompt,
+            temperature=0.0,
+            top_p=1,
+            max_tokens=3,
+            lora_request=request(lora_path),
+        ) as tracer:
+            result = tracer.result.save()
+
+        assert len(result.outputs[0].token_ids) == 3

--- a/tests/vllm/test_moe_batching.py
+++ b/tests/vllm/test_moe_batching.py
@@ -237,7 +237,13 @@ class TestFragmentPolicy:
         group, and ``tp_size``/``ep_size`` are properties off that group — none of
         which exists off-engine, so bypass it and answer for them directly.
         """
-        from vllm.model_executor.layers.fused_moe import FusedMoE
+        FusedMoE = getattr(
+            __import__("vllm.model_executor.layers.fused_moe", fromlist=["x"]),
+            "FusedMoE",
+            None,
+        )
+        if FusedMoE is None:
+            pytest.skip("this vLLM has no FusedMoE; see TestModularMoEPolicy")
 
         class StubMoE(FusedMoE):
             def __init__(self):
@@ -350,3 +356,86 @@ class TestReplicatedLinearsAreNotPieces:
 
         assert _is_piece(replicated, side) is False
         assert _is_piece(sharded, side) is True
+
+
+class TestModularMoEPolicy:
+    """The 0.27 layer reduces its own output; what it leaves partial, and when.
+
+    vLLM 0.27 rebuilt the fused-experts layer around a factory and a modular
+    kernel. The flags that used to say whether the output was still a per-rank
+    partial are gone, replaced by the guard in ``MoERunner._maybe_all_reduce`` —
+    so the layer is whole unless one of that guard's conditions says otherwise.
+
+    Runs on any vLLM: `_is_piece` picks its branch on whether the layer carries a
+    ``moe_config``, so a stub with one exercises the 0.27 rule wherever it is run.
+    """
+
+    @staticmethod
+    def _stub(tp=2, ep=1, skip_final_all_reduce=False, is_sequence_parallel=False,
+              fused_output_is_reduced=False):
+        """A layer with the config `_is_piece` reads, and nothing else.
+
+        Deliberately not a subclass of the real one: 0.27's `MoERunner` is
+        abstract and answers some of these names with read-only properties, and
+        0.26's class does not exist on 0.27. `_is_piece` finds the class through
+        `_moe_layer`, so the test points that at the stub instead — which leaves
+        the policy itself as the only thing under test, on either version.
+        """
+
+        class Parallel:
+            pass
+
+        class Config:
+            pass
+
+        parallel = Parallel()
+        parallel.tp_size, parallel.ep_size = tp, ep
+        config = Config()
+        config.moe_parallel_config = parallel
+        config.skip_final_all_reduce = skip_final_all_reduce
+        config.is_sequence_parallel = is_sequence_parallel
+
+        class Stub:
+            pass
+
+        stub = Stub()
+        stub.moe_config = config
+        stub._fused_output_is_reduced = fused_output_is_reduced
+        return stub
+
+    @staticmethod
+    def _is_piece(stub, side):
+        from unittest import mock
+
+        from nnsight.modeling.vllm import fragments
+
+        with mock.patch.object(
+            fragments, "_moe_layer", return_value=type(stub)
+        ):
+            return fragments._is_piece(stub, side)
+
+    @pytest.mark.parametrize(
+        "config, expected, why",
+        [
+            (dict(), False, "the layer all-reduces its own output"),
+            (dict(skip_final_all_reduce=True), True, "the reduce was deferred"),
+            (dict(skip_final_all_reduce=True, tp=1, ep=1), False, "one rank"),
+            (dict(skip_final_all_reduce=True, fused_output_is_reduced=True), False,
+             "the kernel already reduced it"),
+            (dict(skip_final_all_reduce=True, is_sequence_parallel=True), False,
+             "split by rows, not a partial sum"),
+        ],
+    )
+    def test_only_a_deferred_reduce_leaves_a_piece(self, config, expected, why):
+        assert self._is_piece(self._stub(**config), "output") is expected, why
+
+    def test_the_input_is_never_a_piece(self):
+        assert self._is_piece(self._stub(skip_final_all_reduce=True), "input") is False
+
+    def test_the_group_size_comes_off_the_config(self):
+        from nnsight.modeling.vllm.fragments import _moe_group_size
+
+        # Expert parallelism moves the ranks from tp to ep; the product is the
+        # group either way.
+        assert _moe_group_size(self._stub(tp=2, ep=1)) == 2
+        assert _moe_group_size(self._stub(tp=1, ep=4)) == 4

--- a/tests/vllm/test_moe_batching.py
+++ b/tests/vllm/test_moe_batching.py
@@ -289,3 +289,64 @@ class TestFragmentPolicy:
         sharded = fragments.fragment("m.output", torch.full((2, 4), 6.0))
 
         assert torch.allclose(sharded, torch.full((2, 4), 6.0 / (tp * ep)))
+
+
+class TestReplicatedLinearsAreNotPieces:
+    """A `disable_tp=True` linear is replicated, so nothing about it is a piece.
+
+    vLLM lets a model opt one layer out of tensor parallelism — DeepSeek-V2's
+    `fused_qkv_a_proj` does, and the branch beside it uses a `ReplicatedLinear`
+    for the same role — by setting the layer's own ``tp_size`` to 1 while the
+    engine stays sharded. Its own forward guards every collective on
+    ``tp_size > 1`` for that reason. Reading the engine's world size instead
+    would gather a tensor every rank already holds whole: the value comes back
+    ``world_size``x too wide, built of identical copies, and an edit written
+    against it goes into the next matmul at the wrong shape — silently, both ways.
+
+    Runs without GPUs, like `TestFragmentPolicy`: the decision is a pure function
+    of the module's parallel config. No cached checkpoint uses `disable_tp`, so a
+    stub is the only way to pin it.
+    """
+
+    @staticmethod
+    def _stub(cls, tp, **attributes):
+        """A real linear subclass (so ``isinstance`` holds) with its config stubbed.
+
+        The real ``__init__`` reads the live process group, which does not exist
+        off-engine, so bypass it and set what `_is_piece` reads.
+        """
+
+        class Stub(cls):
+            def __init__(self):
+                torch.nn.Module.__init__(self)
+                self.tp_size = tp
+                for name, value in attributes.items():
+                    setattr(self, name, value)
+
+        return Stub()
+
+    @pytest.mark.parametrize("side", ["input", "output"])
+    def test_a_replicated_column_linear_is_never_a_piece(self, side):
+        from vllm.model_executor.layers.linear import ColumnParallelLinear
+
+        from nnsight.modeling.vllm.fragments import _is_piece
+
+        # gather_output=False is what makes a *sharded* column linear a piece.
+        replicated = self._stub(ColumnParallelLinear, tp=1, gather_output=False)
+        sharded = self._stub(ColumnParallelLinear, tp=2, gather_output=False)
+
+        assert _is_piece(replicated, side) is False
+        assert _is_piece(sharded, side) is (side == "output")
+
+    @pytest.mark.parametrize("side", ["input", "output"])
+    def test_a_replicated_row_linear_is_never_a_piece(self, side):
+        from vllm.model_executor.layers.linear import RowParallelLinear
+
+        from nnsight.modeling.vllm.fragments import _is_piece
+
+        config = dict(input_is_parallel=True, reduce_results=False)
+        replicated = self._stub(RowParallelLinear, tp=1, **config)
+        sharded = self._stub(RowParallelLinear, tp=2, **config)
+
+        assert _is_piece(replicated, side) is False
+        assert _is_piece(sharded, side) is True

--- a/tests/vllm/test_moe_batching.py
+++ b/tests/vllm/test_moe_batching.py
@@ -60,6 +60,34 @@ def _gpus_with_free_memory(min_free_mib: int) -> int:
     return count
 
 
+def _experts_output_is_partial() -> bool:
+    """Whether this vLLM leaves a fused-experts output as a per-rank partial.
+
+    Through 0.26 it does — the block all-reduces a few lines later, which is what
+    the tests below use as their oracle. From 0.27 the layer reduces its own
+    output (`MoERunner._maybe_all_reduce`), and measuring it on a two-rank
+    Qwen1.5-MoE confirms it: both ranks hand back the identical tensor. There is
+    then no partial to sum, no gather to check, and nothing to re-split — so
+    these read something that does not exist there.
+
+    What they check on 0.27 instead — that a read matches what the module really
+    produced, and that a write reaches the block once when nothing is
+    re-split — still wants writing.
+    """
+    from vllm.model_executor.layers import fused_moe
+
+    return hasattr(fused_moe, "FusedMoE")
+
+
+requires_partial_experts = pytest.mark.skipif(
+    not _experts_output_is_partial(),
+    reason=(
+        "this vLLM reduces the fused-experts output itself, so there is no "
+        "per-rank partial for these to assemble; 0.27-shaped equivalents are "
+        "not written yet"
+    ),
+)
+
 requires_two_gpus = pytest.mark.skipif(
     _gpus_with_free_memory(MIN_FREE_MIB) < 2,
     reason=f"needs 2 GPUs with {MIN_FREE_MIB} MiB free each",
@@ -133,6 +161,7 @@ def _block_output(mlp):
 
 
 @requires_two_gpus
+@requires_partial_experts
 @torch.no_grad()
 def test_experts_output_read_is_the_full_value(vllm_moe_tp):
     # The block output IS the all-reduce of the per-rank partials, so the two
@@ -146,6 +175,7 @@ def test_experts_output_read_is_the_full_value(vllm_moe_tp):
 
 
 @requires_two_gpus
+@requires_partial_experts
 @torch.no_grad()
 def test_swapped_experts_output_reaches_the_block_once(vllm_moe_tp):
     # The block computes all_reduce(a' + b') from whatever the write-back left on
@@ -171,6 +201,7 @@ def test_swapped_experts_output_reaches_the_block_once(vllm_moe_tp):
 
 
 @requires_two_gpus
+@requires_partial_experts
 @torch.no_grad()
 def test_each_invoke_reads_its_own_rows(vllm_moe_tp):
     # Continuous batching packs both requests into one flat slab; the gather runs
@@ -199,6 +230,7 @@ def test_each_invoke_reads_its_own_rows(vllm_moe_tp):
 
 
 @requires_two_gpus
+@requires_partial_experts
 @torch.no_grad()
 def test_an_installed_block_reads_the_full_value(vllm_moe_tp):
     # An edit runs per request on every rank, the same as a trace's block, so its

--- a/tests/vllm/test_moe_batching.py
+++ b/tests/vllm/test_moe_batching.py
@@ -84,6 +84,9 @@ def vllm_moe_tp(request):
         MODEL,
         tensor_parallel_size=2,
         enable_expert_parallel=request.param,
+        # Off so an installed block sees whole prompts (a cached token runs no
+        # forward). The traced reads below are single-prompt and unaffected.
+        enable_prefix_caching=False,
         gpu_memory_utilization=GPU_MEMORY_UTILIZATION,
         dispatch=True,
     )
@@ -92,6 +95,29 @@ def vllm_moe_tp(request):
     del model
     gc.collect()
     torch.cuda.empty_cache()
+
+
+def _assert_gathered(experts_out, block_out, what):
+    """The two per-rank partials sum to the block's own all-reduced output.
+
+    Which they only do if the read was gathered — an ungathered partial is the
+    right shape and roughly half the value.
+    """
+    experts_sum = (experts_out[0] + experts_out[1]).float().cpu()
+    block = block_out.float().cpu()
+
+    cosine = torch.nn.functional.cosine_similarity(
+        experts_sum.flatten(), block.flatten(), dim=0
+    ).item()
+    max_delta = (experts_sum - block).abs().max().item()
+
+    assert cosine >= READ_MIN_COSINE, (
+        f"{what} read back a per-rank partial rather than the full value: "
+        f"cos={cosine:.6f} against its own block output"
+    )
+    assert max_delta <= READ_MAX_DELTA, (
+        f"{what} diverges from its own block output: max|delta|={max_delta:.4f}"
+    )
 
 
 def _block_output(mlp):
@@ -116,22 +142,7 @@ def test_experts_output_read_is_the_full_value(vllm_moe_tp):
         experts_out = mlp.experts.output.save()
         block_out = _block_output(mlp)
 
-    experts_sum = (experts_out[0] + experts_out[1]).float().cpu()
-    block = block_out.float().cpu()
-
-    cosine = torch.nn.functional.cosine_similarity(
-        experts_sum.flatten(), block.flatten(), dim=0
-    ).item()
-    max_delta = (experts_sum - block).abs().max().item()
-
-    assert cosine >= READ_MIN_COSINE, (
-        "experts.output read back a per-rank partial rather than the full "
-        f"value: cos={cosine:.6f} against its own block output"
-    )
-    assert max_delta <= READ_MAX_DELTA, (
-        f"experts.output diverges from its own block output: "
-        f"max|delta|={max_delta:.4f}"
-    )
+    _assert_gathered(experts_out, block_out, "experts.output")
 
 
 @requires_two_gpus
@@ -157,6 +168,56 @@ def test_swapped_experts_output_reaches_the_block_once(vllm_moe_tp):
         f"(a missing write-back divide double-counts it): "
         f"max|delta|={max_delta:.4f}"
     )
+
+
+@requires_two_gpus
+@torch.no_grad()
+def test_each_invoke_reads_its_own_rows(vllm_moe_tp):
+    # Continuous batching packs both requests into one flat slab; the gather runs
+    # once over the whole of it and the rows are handed back per request. If the
+    # split and the gather disagreed, one invoke would read the other's rows —
+    # still summing to *a* block output, but not to its own.
+    short, long = "Paris", PROMPT
+
+    with vllm_moe_tp.trace(temperature=0.0, top_p=1, max_tokens=1) as tracer:
+        with tracer.invoke(short):
+            short_mlp = vllm_moe_tp.model.layers[LAYER].mlp
+            short_experts = short_mlp.experts.output.save()
+            short_block = _block_output(short_mlp)
+        with tracer.invoke(long):
+            long_mlp = vllm_moe_tp.model.layers[LAYER].mlp
+            long_experts = long_mlp.experts.output.save()
+            long_block = _block_output(long_mlp)
+
+    # Each request's own prompt length, not the batch's.
+    assert short_experts[0].shape[0] < long_experts[0].shape[0]
+    assert short_experts[0].shape[0] == short_block.shape[0]
+    assert long_experts[0].shape[0] == long_block.shape[0]
+
+    _assert_gathered(short_experts, short_block, "the short invoke's read")
+    _assert_gathered(long_experts, long_block, "the long invoke's read")
+
+
+@requires_two_gpus
+@torch.no_grad()
+def test_an_installed_block_reads_the_full_value(vllm_moe_tp):
+    # An edit runs per request on every rank, the same as a trace's block, so its
+    # read has to be gathered too — and it arrives on the request's output rather
+    # than in a variable, from whichever ranks reported it.
+    with vllm_moe_tp.edit() as (tracer, edit):
+        mlp = vllm_moe_tp.model.layers[LAYER].mlp
+        experts_out = mlp.experts.output.save()
+        block_out = _block_output(mlp)
+    try:
+        saves = vllm_moe_tp.generate(
+            [PROMPT], max_tokens=1, temperature=0.0, top_p=1
+        )[0].saves
+
+        _assert_gathered(
+            saves["experts_out"], saves["block_out"], "an installed block's read"
+        )
+    finally:
+        edit.clear()
 
 
 class TestFragmentPolicy:

--- a/tests/vllm/test_ray.py
+++ b/tests/vllm/test_ray.py
@@ -35,6 +35,21 @@ def vllm_qwen_ray():
     )
 
 
+@pytest.fixture(scope="module")
+def vllm_qwen_ray_uncached():
+    """The same, with prefix caching off — what an installed edit needs."""
+    from nnsight.modeling.vllm import VLLM
+
+    return VLLM(
+        "Qwen/Qwen2.5-0.5B",
+        tensor_parallel_size=2,
+        distributed_executor_backend="ray",
+        enable_prefix_caching=False,
+        gpu_memory_utilization=0.2,
+        dispatch=True,
+    )
+
+
 class TestRayExecutor:
     @torch.no_grad()
     def test_basic_logit(self, vllm_qwen_ray, ET_prompt):
@@ -79,3 +94,71 @@ class TestRayExecutor:
 
         assert et is not msg
         assert vllm_qwen_ray.tokenizer.decode(et.argmax(dim=-1)) == " Paris"
+
+
+class TestRayEdits:
+    """`model.edit()` over Ray — install by RPC, values home by another.
+
+    Worth its own coverage: the install is a ``collective_rpc`` to Ray actors
+    rather than to multiprocessing workers, and the collect that carries a
+    registered value home runs on a thread that never ran the block — the
+    thread-local bookkeeping `collect_nnsight` does is a no-op there, so the
+    values have to survive without it.
+    """
+
+    @torch.no_grad()
+    def test_untraced_requests_carry_their_own_values(self, vllm_qwen_ray_uncached):
+        model = vllm_qwen_ray_uncached
+        prompts = ["The Eiffel Tower is in", "Hello world", "A"]
+
+        with model.edit() as (tracer, edit):
+            hidden = model.model.layers[10].output[0].save()
+        try:
+            outputs = model.generate(prompts, max_tokens=3, temperature=0.0,
+                                     ignore_eos=True)
+
+            for output in outputs:
+                assert "hidden" in output.saves
+                assert output.saves["hidden"].shape[0] == len(
+                    output.prompt_token_ids
+                )
+            assert len({id(o.saves["hidden"]) for o in outputs}) == len(outputs)
+        finally:
+            edit.clear()
+
+    @torch.no_grad()
+    def test_a_sharded_read_is_gathered(self, vllm_qwen_ray_uncached, ET_prompt):
+        # A column-parallel output read from an installed block comes back whole,
+        # measured against the same read from a trace — one rank's shard would be
+        # the right dtype and half the width.
+        model = vllm_qwen_ray_uncached
+
+        with model.trace(ET_prompt, temperature=0.0, top_p=1):
+            traced = model.model.layers[5].self_attn.qkv_proj.output[0].save()
+
+        with model.edit() as (tracer, edit):
+            qkv = model.model.layers[5].self_attn.qkv_proj.output[0].save()
+        try:
+            output = model.generate([ET_prompt], max_tokens=1, temperature=0.0,
+                                    ignore_eos=True)[0]
+
+            assert output.saves["qkv"].shape == traced.shape
+            # Every rank gathers and reports the same whole value; the earliest
+            # rank's is the one kept, so it lands where a traced value would
+            # rather than on whichever rank answered last.
+            assert output.saves["qkv"].device == traced.device
+            assert torch.allclose(output.saves["qkv"].float(), traced.float())
+        finally:
+            edit.clear()
+
+    @torch.no_grad()
+    def test_clear_stops_it(self, vllm_qwen_ray_uncached, ET_prompt):
+        model = vllm_qwen_ray_uncached
+
+        with model.edit() as (tracer, edit):
+            hidden = model.model.layers[10].output[0].save()
+        model.clear_edits()
+
+        output = model.generate([ET_prompt], max_tokens=2, temperature=0.0,
+                                ignore_eos=True)[0]
+        assert "hidden" not in getattr(output, "saves", {})

--- a/tests/vllm/test_registration.py
+++ b/tests/vllm/test_registration.py
@@ -1,0 +1,188 @@
+"""Blocks registered on the engine, which run for every request it handles.
+
+A trace rides one request; a registration is installed once and applies to
+everything the engine runs afterwards, including requests nnsight never created.
+What it saves comes back on that request's ``RequestOutput``, by the same collect
+a traced value uses, and is dropped as it goes.
+"""
+
+import pytest
+import torch
+
+pytest.importorskip("vllm")
+
+import nnsight  # noqa: E402
+
+
+def sampling(max_tokens: int = 3):
+    from vllm import SamplingParams
+
+    return SamplingParams(temperature=0.0, max_tokens=max_tokens, ignore_eos=True)
+
+
+class TestRegistration:
+    @torch.no_grad()
+    def test_untraced_requests_carry_their_own_values(self, vllm_gpt2_uncached):
+        model = vllm_gpt2_uncached
+        prompts = ["The Eiffel Tower is in", "Hello world", "A"]
+
+        with model.register() as (tracer, registration):
+            hidden = model.transformer.h[5].output.save()
+        try:
+            outputs = model.generate(prompts, max_tokens=3, temperature=0.0,
+                                     ignore_eos=True)
+
+            assert len(outputs) == len(prompts)
+            for output in outputs:
+                # Its own value, sized to its own prompt.
+                assert "hidden" in output.saves
+                assert output.saves["hidden"].shape[0] == len(
+                    output.prompt_token_ids
+                )
+            # Not one object shared between them.
+            assert len({id(o.saves["hidden"]) for o in outputs}) == len(outputs)
+        finally:
+            registration.clear()
+
+    @torch.no_grad()
+    def test_clear_stops_it(self, vllm_gpt2_uncached, ET_prompt):
+        model = vllm_gpt2_uncached
+
+        with model.register() as (tracer, registration):
+            hidden = model.transformer.h[5].output.save()
+        registration.clear()
+
+        outputs = model.generate([ET_prompt], max_tokens=2, temperature=0.0,
+                                 ignore_eos=True)
+        assert "hidden" not in getattr(outputs[0], "saves", {})
+
+    @torch.no_grad()
+    def test_several_registrations_keep_their_own_names(self, vllm_gpt2_uncached,
+                                                        ET_prompt):
+        model = vllm_gpt2_uncached
+
+        with model.register() as (tracer, deep_reg):
+            deep = model.transformer.h[8].output.save()
+        with model.register() as (tracer, shallow_reg):
+            shallow = model.transformer.h[2].output.save()
+        try:
+            saves = model.generate([ET_prompt], max_tokens=2, temperature=0.0,
+                                   ignore_eos=True)[0].saves
+            # Both ran on the one request, each with a scope of its own.
+            assert {"deep", "shallow"} <= set(saves)
+            assert saves["deep"].shape == saves["shallow"].shape
+        finally:
+            deep_reg.clear()
+            shallow_reg.clear()
+
+    @torch.no_grad()
+    def test_iteration_follows_the_generated_tokens(self, vllm_gpt2_uncached,
+                                                    ET_prompt):
+        # Without the tracer's iter/all a registered block finishes inside the
+        # prefill and never sees a generated token.
+        model = vllm_gpt2_uncached
+        steps = 4
+
+        with model.register() as (tracer, registration):
+            readout = nnsight.save([])
+            for step in tracer.iter[:steps]:
+                readout.append(model.transformer.h[5].output[-1])
+        try:
+            outputs = model.generate([ET_prompt], max_tokens=steps,
+                                     temperature=0.0, ignore_eos=True)
+            assert len(outputs[0].saves["readout"]) == steps
+        finally:
+            registration.clear()
+
+    @torch.no_grad()
+    def test_edits_every_request(self, vllm_gpt2_uncached, ET_prompt):
+        model = vllm_gpt2_uncached
+        before = model.generate([ET_prompt], max_tokens=3, temperature=0.0,
+                                ignore_eos=True)[0].outputs[0].text
+
+        with model.register() as (tracer, registration):
+            model.transformer.h[5].output[:] = 0
+        try:
+            during = model.generate([ET_prompt], max_tokens=3, temperature=0.0,
+                                    ignore_eos=True)[0].outputs[0].text
+        finally:
+            registration.clear()
+        after = model.generate([ET_prompt], max_tokens=3, temperature=0.0,
+                               ignore_eos=True)[0].outputs[0].text
+
+        assert during != before
+        assert after == before
+
+    @torch.no_grad()
+    def test_a_trace_reaches_its_registered_value_through_result(
+        self, vllm_gpt2_uncached, ET_prompt
+    ):
+        model = vllm_gpt2_uncached
+
+        with model.register() as (tracer, registration):
+            hidden = model.transformer.h[5].output.save()
+        try:
+            with model.trace(ET_prompt, temperature=0.0, max_tokens=2,
+                             ignore_eos=True) as tracer:
+                own = model.transformer.h[2].output.save()
+                result = tracer.result.save()
+
+            # The trace's own value arrives as a variable; the registration's
+            # rides the output it is handed.
+            assert own is not None
+            assert "hidden" in result.saves
+            # What the block was handed is the snapshot taken at collect time, so
+            # it carries the registered value and the generation but not the
+            # trace's own saves — those are what that collect is computing, and
+            # one of them is this object.
+            assert "own" not in result.saves
+            assert result.outputs[0].token_ids
+        finally:
+            registration.clear()
+
+
+class TestGenerateWithoutABlock:
+    @torch.no_grad()
+    def test_returns_request_outputs(self, vllm_gpt2, ET_prompt):
+        outputs = vllm_gpt2.generate([ET_prompt], max_tokens=3, temperature=0.0,
+                                     ignore_eos=True)
+
+        assert isinstance(outputs, list) and len(outputs) == 1
+        assert outputs[0].outputs[0].text
+        assert len(outputs[0].outputs[0].token_ids) == 3
+
+    @torch.no_grad()
+    def test_still_traces_inside_a_with_block(self, vllm_gpt2, ET_prompt):
+        with vllm_gpt2.generate(ET_prompt, temperature=0.0, max_tokens=1) as tracer:
+            logits = vllm_gpt2.logits.save()
+
+        assert logits.shape[-1] == vllm_gpt2.tokenizer.vocab_size
+
+    @torch.no_grad()
+    def test_max_new_tokens_is_accepted(self, vllm_gpt2, ET_prompt):
+        outputs = vllm_gpt2.generate([ET_prompt], max_new_tokens=2,
+                                     temperature=0.0, ignore_eos=True)
+        assert len(outputs[0].outputs[0].token_ids) == 2
+
+
+class TestResult:
+    @torch.no_grad()
+    def test_result_is_the_finished_request_output(self, vllm_gpt2, ET_prompt):
+        with vllm_gpt2.trace(ET_prompt, temperature=0.0, max_tokens=3,
+                             ignore_eos=True) as tracer:
+            result = tracer.result.save()
+
+        assert type(result).__name__ == "RequestOutput"
+        assert len(result.outputs[0].token_ids) == 3
+
+    @torch.no_grad()
+    def test_each_invoke_gets_its_own(self, vllm_gpt2, ET_prompt, MSG_prompt):
+        with vllm_gpt2.trace(temperature=0.0, max_tokens=2,
+                             ignore_eos=True) as tracer:
+            with tracer.invoke(ET_prompt):
+                first = tracer.result.save()
+            with tracer.invoke(MSG_prompt):
+                second = tracer.result.save()
+
+        assert first.request_id != second.request_id
+        assert first.prompt != second.prompt

--- a/tests/vllm/test_registration.py
+++ b/tests/vllm/test_registration.py
@@ -26,7 +26,7 @@ class TestRegistration:
         model = vllm_gpt2_uncached
         prompts = ["The Eiffel Tower is in", "Hello world", "A"]
 
-        with model.register() as (tracer, registration):
+        with model.edit() as (tracer, registration):
             hidden = model.transformer.h[5].output.save()
         try:
             outputs = model.generate(prompts, max_tokens=3, temperature=0.0,
@@ -48,7 +48,7 @@ class TestRegistration:
     def test_clear_stops_it(self, vllm_gpt2_uncached, ET_prompt):
         model = vllm_gpt2_uncached
 
-        with model.register() as (tracer, registration):
+        with model.edit() as (tracer, registration):
             hidden = model.transformer.h[5].output.save()
         registration.clear()
 
@@ -61,9 +61,9 @@ class TestRegistration:
                                                         ET_prompt):
         model = vllm_gpt2_uncached
 
-        with model.register() as (tracer, deep_reg):
+        with model.edit() as (tracer, deep_reg):
             deep = model.transformer.h[8].output.save()
-        with model.register() as (tracer, shallow_reg):
+        with model.edit() as (tracer, shallow_reg):
             shallow = model.transformer.h[2].output.save()
         try:
             saves = model.generate([ET_prompt], max_tokens=2, temperature=0.0,
@@ -83,7 +83,7 @@ class TestRegistration:
         model = vllm_gpt2_uncached
         steps = 4
 
-        with model.register() as (tracer, registration):
+        with model.edit() as (tracer, registration):
             readout = nnsight.save([])
             for step in tracer.iter[:steps]:
                 readout.append(model.transformer.h[5].output[-1])
@@ -100,7 +100,7 @@ class TestRegistration:
         before = model.generate([ET_prompt], max_tokens=3, temperature=0.0,
                                 ignore_eos=True)[0].outputs[0].text
 
-        with model.register() as (tracer, registration):
+        with model.edit() as (tracer, registration):
             model.transformer.h[5].output[:] = 0
         try:
             during = model.generate([ET_prompt], max_tokens=3, temperature=0.0,
@@ -119,7 +119,7 @@ class TestRegistration:
     ):
         model = vllm_gpt2_uncached
 
-        with model.register() as (tracer, registration):
+        with model.edit() as (tracer, registration):
             hidden = model.transformer.h[5].output.save()
         try:
             with model.trace(ET_prompt, temperature=0.0, max_tokens=2,
@@ -139,6 +139,63 @@ class TestRegistration:
             assert result.outputs[0].token_ids
         finally:
             registration.clear()
+
+
+class TestEditHandles:
+    @torch.no_grad()
+    def test_clear_edits_clears_every_one(self, vllm_gpt2_uncached, ET_prompt):
+        model = vllm_gpt2_uncached
+
+        with model.edit() as (tracer, deep):
+            deep_hidden = model.transformer.h[8].output.save()
+        with model.edit() as (tracer, shallow):
+            shallow_hidden = model.transformer.h[2].output.save()
+
+        model.clear_edits()
+
+        assert deep.cleared and shallow.cleared
+        assert model._installed_edits == []
+        saves = getattr(
+            model.generate([ET_prompt], max_tokens=2, temperature=0.0,
+                           ignore_eos=True)[0],
+            "saves",
+            {},
+        )
+        assert "deep_hidden" not in saves and "shallow_hidden" not in saves
+
+    @torch.no_grad()
+    def test_a_cleared_edit_drops_out_of_the_list(self, vllm_gpt2_uncached):
+        model = vllm_gpt2_uncached
+
+        with model.edit() as (tracer, edit):
+            hidden = model.transformer.h[5].output.save()
+        assert model._installed_edits == [edit]
+
+        edit.clear()
+        assert model._installed_edits == []
+        # Clearing twice is a no-op, not an error.
+        edit.clear()
+
+    def test_inplace_false_is_refused(self, vllm_gpt2_uncached):
+        # There is no copy to edit instead — the engine is what every caller shares.
+        with pytest.raises(ValueError, match="inplace"):
+            vllm_gpt2_uncached.edit(inplace=False)
+
+
+class TestBarrierIsRefused:
+    """Each invoke is its own request, so the blocks never meet — say so."""
+
+    def test_in_a_trace(self, vllm_gpt2):
+        with pytest.raises(NotImplementedError, match="barrier"):
+            with vllm_gpt2.trace(temperature=0.0, max_tokens=1) as tracer:
+                barrier = tracer.barrier(2)
+
+    def test_in_an_edit(self, vllm_gpt2_uncached):
+        # Not entered: an edit's body runs per request on the worker, so calling
+        # it there would only surface as that request's deferred error.
+        tracer = vllm_gpt2_uncached.edit()
+        with pytest.raises(NotImplementedError, match="barrier"):
+            tracer.barrier(2)
 
 
 class TestGenerateWithoutABlock:

--- a/tests/vllm/test_registration.py
+++ b/tests/vllm/test_registration.py
@@ -141,6 +141,37 @@ class TestRegistration:
             registration.clear()
 
 
+class TestAnEditThatRaises:
+    """An installed block's error ends its request, not the engine.
+
+    This is the case edits exist for — requests from something that has never
+    heard of nnsight — so a broken block gets to run on traffic that cannot
+    anticipate it, once per request, for as long as it stays installed.
+    """
+
+    @torch.no_grad()
+    def test_the_engine_survives_and_keeps_answering(self, vllm_gpt2_uncached,
+                                                     ET_prompt):
+        model = vllm_gpt2_uncached
+
+        with model.edit() as (tracer, edit):
+            hidden = model.transformer.h[5].output.save()
+            raise ValueError("boom, every request")
+        try:
+            # Long enough to run the forwards that used to trip it.
+            outputs = model.generate([ET_prompt], max_tokens=4, temperature=0.0,
+                                     ignore_eos=True)
+            assert len(outputs) == 1
+            assert outputs[0].outputs[0].token_ids
+        finally:
+            edit.clear()
+
+        # And once it is gone, everything is as before.
+        after = model.generate([ET_prompt], max_tokens=2, temperature=0.0,
+                               ignore_eos=True)
+        assert after[0].outputs[0].token_ids
+
+
 class TestEditHandles:
     @torch.no_grad()
     def test_clear_edits_clears_every_one(self, vllm_gpt2_uncached, ET_prompt):

--- a/tests/vllm/test_requests.py
+++ b/tests/vllm/test_requests.py
@@ -13,6 +13,8 @@ import torch
 
 pytest.importorskip("vllm")
 
+import nnsight  # noqa: E402
+
 
 def _worker_request_state(worker):
     """Read a worker's request bookkeeping, run there via ``collective_rpc``.
@@ -248,3 +250,150 @@ class TestConcurrentGeneration:
         assert len(et) == 3
         assert len(msg) == 3
         assert vllm_gpt2.tokenizer.batch_decode(msg) == [" New", " York", " City"]
+
+
+class TestSeveralSequences:
+    """``n > 1``: one prompt, several sampled continuations.
+
+    vLLM fans the request into a child per sequence, each of which runs its own
+    copy of the block against its own rows. So there are `n` of every saved
+    value, and they come back as a list — one entry per sequence, in order.
+    """
+
+    @torch.no_grad()
+    def test_saves_come_back_one_per_sequence(self, vllm_gpt2, ET_prompt):
+        with vllm_gpt2.trace(ET_prompt, max_tokens=3, temperature=1.0, seed=0, n=2):
+            hidden = vllm_gpt2.transformer.h[5].output.save()
+
+        assert isinstance(hidden, list) and len(hidden) == 2
+        prompt_rows = len(vllm_gpt2.tokenizer.encode(ET_prompt))
+        for value in hidden:
+            assert value.shape[0] == prompt_rows
+
+    @torch.no_grad()
+    def test_one_sequence_is_still_one_value(self, vllm_gpt2, ET_prompt):
+        # The list is what "more than one" looks like; n=1 is unchanged.
+        with vllm_gpt2.trace(ET_prompt, max_tokens=3, temperature=0.0):
+            hidden = vllm_gpt2.transformer.h[5].output.save()
+
+        assert isinstance(hidden, torch.Tensor)
+
+    @torch.no_grad()
+    def test_the_result_is_one_object_not_one_per_sequence(
+        self, vllm_gpt2, ET_prompt
+    ):
+        # A request has one output carrying n completions, and every sequence's
+        # block is served that same object — so it is not n values of anything.
+        with vllm_gpt2.trace(
+            ET_prompt, max_tokens=3, temperature=1.0, seed=0, n=2
+        ) as tracer:
+            result = tracer.result.save()
+
+        assert type(result).__name__ == "RequestOutput"
+        assert len(result.outputs) == 2
+
+    @torch.no_grad()
+    def test_each_completion_carries_its_own(self, vllm_gpt2_uncached, ET_prompt):
+        # An installed block runs once per sequence too, and its values ride the
+        # completion they belong to — next to that sequence's text and token ids.
+        # This is the shape an async or serve caller reads, where there is no
+        # variable to push a list into.
+        model = vllm_gpt2_uncached
+
+        with model.edit() as (tracer, edit):
+            hidden = model.transformer.h[5].output.save()
+        try:
+            output = model.generate([ET_prompt], max_tokens=3, temperature=1.0,
+                                    seed=0, n=2)[0]
+
+            assert len(output.outputs) == 2
+            prompt_rows = len(model.tokenizer.encode(ET_prompt))
+            for completion in output.outputs:
+                assert completion.saves["hidden"].shape[0] == prompt_rows
+            # Each sequence's own object, not one shared between them.
+            assert (
+                output.outputs[0].saves["hidden"]
+                is not output.outputs[1].saves["hidden"]
+            )
+        finally:
+            edit.clear()
+
+    @torch.no_grad()
+    def test_the_sequences_diverge_where_they_should(self, vllm_gpt2, ET_prompt):
+        # Same prompt, so the prefill matches; the sampled steps are each
+        # sequence's own.
+        with vllm_gpt2.trace(
+            ET_prompt, max_tokens=4, temperature=1.0, seed=0, n=2
+        ) as tracer:
+            steps = nnsight.save([])
+            for _ in tracer.iter[:4]:
+                steps.append(vllm_gpt2.samples)
+            result = tracer.result.save()
+
+        assert isinstance(steps, list) and len(steps) == 2
+        first, second = (
+            [int(step.flatten()[0]) for step in sequence] for sequence in steps
+        )
+        assert first == list(result.outputs[0].token_ids)
+        assert second == list(result.outputs[1].token_ids)
+
+    @torch.no_grad()
+    def test_no_worker_is_left_behind(self, vllm_gpt2, ET_prompt):
+        # The child requests are named "{index}_{parent}"; when that went
+        # unmatched nothing was collected and nothing was ever freed.
+        engine = vllm_gpt2.vllm_entrypoint.llm_engine
+
+        for _ in range(3):
+            with vllm_gpt2.trace(ET_prompt, max_tokens=2, temperature=1.0,
+                                 seed=0, n=2):
+                hidden = vllm_gpt2.transformer.h[5].output.save()
+
+        assert engine.collective_rpc("nnsight_request_count") == [0]
+
+
+class TestSameNameAcrossInvokes:
+    """Several invokes saving one name: separate values, not copies of one."""
+
+    @torch.no_grad()
+    def test_each_invoke_keeps_its_own(self, vllm_gpt2, ET_prompt, MSG_prompt):
+        # This is the shape every steering/patching recipe has. Merging them kept
+        # only the last, so three prompts came back holding one prompt's value.
+        with vllm_gpt2.trace(temperature=0.0, max_tokens=1) as tracer:
+            with tracer.invoke(ET_prompt):
+                hidden = vllm_gpt2.transformer.h[5].output.save()
+            with tracer.invoke(MSG_prompt):
+                hidden = vllm_gpt2.transformer.h[5].output.save()
+
+        assert isinstance(hidden, list) and len(hidden) == 2
+        # In invoke order, each sized to its own prompt.
+        assert hidden[0].shape[0] == len(vllm_gpt2.tokenizer.encode(ET_prompt))
+        assert hidden[1].shape[0] == len(vllm_gpt2.tokenizer.encode(MSG_prompt))
+
+    @torch.no_grad()
+    def test_distinct_names_are_untouched(self, vllm_gpt2, ET_prompt, MSG_prompt):
+        with vllm_gpt2.trace(temperature=0.0, max_tokens=1) as tracer:
+            with tracer.invoke(ET_prompt):
+                et = vllm_gpt2.transformer.h[5].output.save()
+            with tracer.invoke(MSG_prompt):
+                msg = vllm_gpt2.transformer.h[5].output.save()
+
+        assert isinstance(et, torch.Tensor) and isinstance(msg, torch.Tensor)
+        assert et.shape[0] != msg.shape[0]
+
+    @torch.no_grad()
+    def test_a_container_saved_above_the_invokes_still_merges(
+        self, vllm_gpt2, ET_prompt, MSG_prompt
+    ):
+        # One object locally, so its per-request copies merge slot-wise rather
+        # than coming back as a list of copies.
+        with vllm_gpt2.trace(temperature=0.0, max_tokens=1) as tracer:
+            rows = nnsight.save([None, None])
+            with tracer.invoke(ET_prompt):
+                rows[0] = vllm_gpt2.transformer.h[5].output
+            with tracer.invoke(MSG_prompt):
+                rows[1] = vllm_gpt2.transformer.h[5].output
+
+        assert len(rows) == 2
+        assert rows[0] is not None and rows[1] is not None
+        assert rows[0].shape[0] == len(vllm_gpt2.tokenizer.encode(ET_prompt))
+        assert rows[1].shape[0] == len(vllm_gpt2.tokenizer.encode(MSG_prompt))

--- a/tests/vllm/test_requests.py
+++ b/tests/vllm/test_requests.py
@@ -397,3 +397,55 @@ class TestSameNameAcrossInvokes:
         assert rows[0] is not None and rows[1] is not None
         assert rows[0].shape[0] == len(vllm_gpt2.tokenizer.encode(ET_prompt))
         assert rows[1].shape[0] == len(vllm_gpt2.tokenizer.encode(MSG_prompt))
+
+
+class TestPerInvokeSampling:
+    """An invoke's own sampling settings survive the trace-level ones.
+
+    Trace-level settings fill in for whatever an invoke did not name. Working out
+    "did not name" by comparing against a fresh `SamplingParams` cannot tell the
+    value a caller passed from the one it would have had anyway — so an invoke
+    asking for a setting that happens to be vLLM's default had it silently
+    replaced, which is most of the values anyone types.
+    """
+
+    @torch.no_grad()
+    def test_a_default_valued_setting_is_still_the_invokes(self, vllm_gpt2,
+                                                           ET_prompt, MSG_prompt):
+        # 16 is vLLM's own default max_tokens, and 3 is not; both are this
+        # invoke's business, and the trace-level 4 applies to neither.
+        with vllm_gpt2.trace(temperature=0.0, max_tokens=4) as tracer:
+            with tracer.invoke(ET_prompt, max_tokens=16, ignore_eos=True):
+                long = tracer.result.save()
+            with tracer.invoke(MSG_prompt, max_tokens=3, ignore_eos=True):
+                short = tracer.result.save()
+
+        assert len(long.outputs[0].token_ids) == 16
+        assert len(short.outputs[0].token_ids) == 3
+
+    @torch.no_grad()
+    def test_the_trace_level_setting_still_fills_in(self, vllm_gpt2, ET_prompt,
+                                                    MSG_prompt):
+        with vllm_gpt2.trace(temperature=0.0, max_tokens=4, ignore_eos=True) as tracer:
+            with tracer.invoke(ET_prompt):
+                first = tracer.result.save()
+            with tracer.invoke(MSG_prompt, max_tokens=2):
+                second = tracer.result.save()
+
+        assert len(first.outputs[0].token_ids) == 4
+        assert len(second.outputs[0].token_ids) == 2
+
+    @torch.no_grad()
+    def test_a_default_valued_temperature_is_kept(self, vllm_gpt2, ET_prompt):
+        # temperature=1.0 is the default, and asking for it against a greedy
+        # trace has to mean sampling. Two draws at temperature 1 diverge; two
+        # greedy ones cannot.
+        texts = set()
+        for seed in (0, 1, 2, 3):
+            with vllm_gpt2.trace(temperature=0.0, max_tokens=6) as tracer:
+                with tracer.invoke(ET_prompt, temperature=1.0, seed=seed,
+                                   ignore_eos=True):
+                    result = tracer.result.save()
+            texts.add(result.outputs[0].text)
+
+        assert len(texts) > 1, f"every draw came back identical: {texts}"

--- a/tests/vllm/test_serve.py
+++ b/tests/vllm/test_serve.py
@@ -105,9 +105,13 @@ class TestGpulessClient:
 
         from nnsight.modeling.vllm import VLLM
 
+        # `max_memory_allocated` too (vLLM's loader reports peak memory around the
+        # load): on a host that really has no GPU it returns 0, but here CUDA may
+        # already be initialized by an earlier test in this process, and it then
+        # rejects the device index the mocked count implies.
         with mock.patch("torch.cuda.is_available", return_value=False), mock.patch(
             "torch.cuda.device_count", return_value=0
-        ):
+        ), mock.patch("torch.cuda.max_memory_allocated", return_value=0):
             model = VLLM("gpt2")
 
         assert model.tokenizer is not None
@@ -171,3 +175,59 @@ class TestServe:
         with serve_client.trace(ET_prompt, temperature=0.0, top_p=1, serve=serve_url):
             logits = serve_client.logits.save()
         assert serve_client.tokenizer.decode(logits.argmax(dim=-1)) == " Paris"
+
+
+class TestServeResult:
+    @torch.no_grad()
+    def test_result_comes_back(self, serve_client, serve_url, ET_prompt):
+        # The server hands the finished RequestOutput to the collect, so saving
+        # `tracer.result` is how a serve client reads generated tokens.
+        with serve_client.trace(
+            ET_prompt, temperature=0.0, top_p=1, max_tokens=3, serve=serve_url
+        ) as tracer:
+            result = tracer.result.save()
+
+        assert type(result).__name__ == "RequestOutput"
+        assert len(result.outputs[0].token_ids) == 3
+
+
+class TestServeEdit:
+    """`model.edit(serve=url)` — the block installs over HTTP, on the server's engine."""
+
+    @torch.no_grad()
+    def test_edit_runs_for_a_served_trace(self, serve_client, serve_url, ET_prompt):
+        with serve_client.edit(serve=serve_url) as (tracer, edit):
+            hidden = serve_client.transformer.h[5].output.save()
+        try:
+            with serve_client.trace(
+                ET_prompt, temperature=0.0, top_p=1, max_tokens=1, serve=serve_url
+            ) as tracer:
+                result = tracer.result.save()
+
+            # The edit's value rides the output of the request it ran on.
+            assert "hidden" in result.saves
+        finally:
+            edit.clear()
+
+    @torch.no_grad()
+    def test_clear_stops_it(self, serve_client, serve_url, ET_prompt):
+        with serve_client.edit(serve=serve_url) as (tracer, edit):
+            hidden = serve_client.transformer.h[5].output.save()
+        edit.clear()
+
+        with serve_client.trace(
+            ET_prompt, temperature=0.0, top_p=1, max_tokens=1, serve=serve_url
+        ) as tracer:
+            result = tracer.result.save()
+
+        assert "hidden" not in getattr(result, "saves", {})
+
+    @torch.no_grad()
+    def test_the_client_stays_gpuless(self, serve_client, serve_url):
+        # Installing must not dispatch an engine on the client — it has no weights.
+        with serve_client.edit(serve=serve_url) as (tracer, edit):
+            hidden = serve_client.transformer.h[5].output.save()
+        try:
+            assert not serve_client.dispatched
+        finally:
+            edit.clear()

--- a/tests/vllm/test_tensor_parallel.py
+++ b/tests/vllm/test_tensor_parallel.py
@@ -221,3 +221,44 @@ class TestShardedEdit:
         tp_logits = _zero_all(vllm_qwen_tp, path, ET_prompt)
 
         assert tp_logits.argmax(dim=-1).item() == ref_logits.argmax(dim=-1).item()
+
+
+class TestEveryRankWindsUp:
+    """Cleanup is per rank, not just the one whose values go home.
+
+    Every rank runs the block, so every rank holds a worker, its greenlet, and
+    whatever that greenlet captured. Only rank 0's values are reported, and the
+    collect used to return early on the others — leaving all of it in place for
+    the life of the engine. `nnsight_request_count` is the gauge, and the reason
+    the leak survived is that the one test using it looked only at `counts[0]`.
+    """
+
+    @torch.no_grad()
+    def test_no_worker_is_left_on_any_rank(self, vllm_qwen_tp, ET_prompt):
+        model = vllm_qwen_tp
+        engine = model.vllm_entrypoint.llm_engine
+
+        for _ in range(3):
+            with model.trace(ET_prompt, temperature=0.0, top_p=1):
+                hidden = model.model.layers[LAYER].output[0].save()
+
+        counts = engine.collective_rpc("nnsight_request_count")
+        assert len(counts) > 1, "expected more than one rank"
+        assert counts == [0] * len(counts), f"workers left behind per rank: {counts}"
+
+    @torch.no_grad()
+    def test_an_installed_block_leaves_nothing_either(self, vllm_qwen_tp, ET_prompt):
+        model = vllm_qwen_tp
+        engine = model.vllm_entrypoint.llm_engine
+
+        with model.edit() as (tracer, edit):
+            hidden = model.model.layers[LAYER].output[0].save()
+        try:
+            for _ in range(3):
+                model.generate([ET_prompt], max_tokens=2, temperature=0.0,
+                               ignore_eos=True)
+
+            counts = engine.collective_rpc("nnsight_request_count")
+            assert counts == [0] * len(counts), f"workers left behind: {counts}"
+        finally:
+            edit.clear()

--- a/tests/vllm/test_tracing.py
+++ b/tests/vllm/test_tracing.py
@@ -455,6 +455,43 @@ class TestDeferredErrors:
         assert vllm_gpt2.tokenizer.decode(logits.argmax(dim=-1)) == " Paris"
 
     @torch.no_grad()
+    def test_a_raise_after_the_first_read_spares_the_engine(self, vllm_gpt2,
+                                                            ET_prompt):
+        # Both halves matter, and the test above has neither: the raise lands
+        # *after* the block has parked once, so its worker is dead while still
+        # holding a location, and `ignore_eos` keeps the request running past the
+        # step that would have retired it. The dead worker is then served again —
+        # and switching into a finished greenlet returns the arguments straight
+        # back, which used to store an activation where an event belongs and kill
+        # the engine core inside vLLM's own state update, taking every tenant's
+        # request with it.
+        with pytest.raises(RuntimeError, match="ValueError"):
+            with vllm_gpt2.trace(ET_prompt, temperature=0.0, max_tokens=4,
+                                 ignore_eos=True):
+                hidden = vllm_gpt2.transformer.h[5].output.save()
+                raise ValueError("after the first read")
+
+        with vllm_gpt2.trace(ET_prompt, temperature=0.0, top_p=1):
+            logits = vllm_gpt2.logits.save()
+        assert vllm_gpt2.tokenizer.decode(logits.argmax(dim=-1)) == " Paris"
+
+    @torch.no_grad()
+    def test_a_raise_inside_an_iter_loop_spares_the_engine(self, vllm_gpt2,
+                                                           ET_prompt):
+        # The same, reached the way a generation loop reaches it.
+        with pytest.raises(RuntimeError, match="ValueError"):
+            with vllm_gpt2.trace(ET_prompt, temperature=0.0, max_tokens=6,
+                                 ignore_eos=True) as tracer:
+                for step in tracer.iter[:6]:
+                    logits = vllm_gpt2.logits.save()
+                    if step == 1:
+                        raise ValueError("mid-loop")
+
+        with vllm_gpt2.trace(ET_prompt, temperature=0.0, top_p=1):
+            logits = vllm_gpt2.logits.save()
+        assert vllm_gpt2.tokenizer.decode(logits.argmax(dim=-1)) == " Paris"
+
+    @torch.no_grad()
     def test_out_of_order_read_surfaces(self, vllm_gpt2, ET_prompt):
         # Reading a layer the forward already ran past leaves the worker parked with
         # nowhere to be served. When the request finishes it is surfaced as an

--- a/tests/vllm/test_tracing.py
+++ b/tests/vllm/test_tracing.py
@@ -571,3 +571,68 @@ class TestCache:
         assert outputs[0].shape[0] == n_prompt
         assert outputs[1].shape[0] == 1
         assert outputs[2].shape[0] == 1
+
+
+class TestLazyDispatch:
+    """Building without ``dispatch=True``, then tracing.
+
+    The path a user takes when they construct a model and only later run
+    something on it: `__init__` builds the meta tree, and the first trace calls
+    `dispatch`, which brings up the engine and re-points the tree at it. Every
+    other test here dispatches eagerly, so nothing else covers it.
+    """
+
+    @torch.no_grad()
+    def test_first_trace_dispatches_and_reads(self, ET_prompt):
+        from nnsight.modeling.vllm import VLLM
+
+        model = VLLM("gpt2", gpu_memory_utilization=0.1)
+        assert not model.dispatched
+        # The meta tree is there to write interventions against before any engine.
+        assert model.tokenizer is not None
+        assert model.transformer.h[5] is not None
+
+        with model.trace(ET_prompt, temperature=0.0, top_p=1):
+            hidden = model.transformer.h[5].output.save()
+            logits = model.logits.save()
+
+        assert model.dispatched
+        assert hidden.shape[0] == len(model.tokenizer.encode(ET_prompt))
+        assert model.tokenizer.decode(logits.argmax(dim=-1)) == " Paris"
+
+    @torch.no_grad()
+    def test_dispatch_does_not_rebuild_the_meta_tree(self, ET_prompt):
+        # `__init__` already built one, and dispatch is about to re-point the envoy
+        # tree at whatever `_load` returns — so building a second, identical tree
+        # is a whole architecture instantiation for nothing.
+        from unittest import mock
+
+        from nnsight.modeling.vllm import VLLM
+
+        model = VLLM("gpt2", gpu_memory_utilization=0.1)
+        tree = model._module
+
+        with mock.patch.object(
+            model, "_load_meta", side_effect=AssertionError("rebuilt the meta tree")
+        ):
+            model.dispatch()
+
+        assert model.dispatched
+        assert model._module is tree
+
+    @torch.no_grad()
+    def test_an_edit_written_before_dispatch_still_lands(self, ET_prompt):
+        # `edit()` dispatches for itself, since the block has to go to an engine.
+        from nnsight.modeling.vllm import VLLM
+
+        model = VLLM("gpt2", gpu_memory_utilization=0.1,
+                     enable_prefix_caching=False)
+        with model.edit() as (tracer, edit):
+            hidden = model.transformer.h[5].output.save()
+        try:
+            assert model.dispatched
+            output = model.generate([ET_prompt], max_tokens=2, temperature=0.0,
+                                    ignore_eos=True)[0]
+            assert output.saves["hidden"].shape[0] == len(output.prompt_token_ids)
+        finally:
+            edit.clear()

--- a/tests/vllm/test_tracing.py
+++ b/tests/vllm/test_tracing.py
@@ -636,3 +636,66 @@ class TestLazyDispatch:
             assert output.saves["hidden"].shape[0] == len(output.prompt_token_ids)
         finally:
             edit.clear()
+
+
+class TestPromptForms:
+    """What one invoke will take as its prompt.
+
+    vLLM's own prompt dicts are `TypedDict`s — plain dicts at runtime — so they
+    used to be taken for a tokenizer's output and die on `KeyError: 'input_ids'`.
+    """
+
+    @torch.no_grad()
+    def test_a_string(self, vllm_gpt2, ET_prompt):
+        with vllm_gpt2.trace(ET_prompt, temperature=0.0, top_p=1):
+            logits = vllm_gpt2.logits.save()
+        assert vllm_gpt2.tokenizer.decode(logits.argmax(dim=-1)) == " Paris"
+
+    @torch.no_grad()
+    def test_a_token_id_list(self, vllm_gpt2, ET_prompt):
+        ids = vllm_gpt2.tokenizer.encode(ET_prompt)
+        with vllm_gpt2.trace(ids, temperature=0.0, top_p=1):
+            logits = vllm_gpt2.logits.save()
+        assert vllm_gpt2.tokenizer.decode(logits.argmax(dim=-1)) == " Paris"
+
+    @torch.no_grad()
+    def test_a_tokenizer_output(self, vllm_gpt2, ET_prompt):
+        inputs = vllm_gpt2.tokenizer(ET_prompt)
+        with vllm_gpt2.trace(inputs, temperature=0.0, top_p=1):
+            logits = vllm_gpt2.logits.save()
+        assert vllm_gpt2.tokenizer.decode(logits.argmax(dim=-1)) == " Paris"
+
+    @torch.no_grad()
+    def test_a_vllm_tokens_prompt(self, vllm_gpt2, ET_prompt):
+        from vllm import TokensPrompt
+
+        ids = vllm_gpt2.tokenizer.encode(ET_prompt)
+        with vllm_gpt2.trace(
+            TokensPrompt(prompt_token_ids=ids), temperature=0.0, top_p=1
+        ):
+            hidden = vllm_gpt2.transformer.h[5].output.save()
+            logits = vllm_gpt2.logits.save()
+
+        assert hidden.shape[0] == len(ids)
+        assert vllm_gpt2.tokenizer.decode(logits.argmax(dim=-1)) == " Paris"
+
+    @torch.no_grad()
+    def test_a_vllm_text_prompt(self, vllm_gpt2, ET_prompt):
+        with vllm_gpt2.trace({"prompt": ET_prompt}, temperature=0.0, top_p=1):
+            logits = vllm_gpt2.logits.save()
+        assert vllm_gpt2.tokenizer.decode(logits.argmax(dim=-1)) == " Paris"
+
+    @torch.no_grad()
+    def test_each_invoke_takes_its_own_form(self, vllm_gpt2, ET_prompt, MSG_prompt):
+        # The forms mix freely, since each invoke is converted on its own.
+        from vllm import TokensPrompt
+
+        ids = vllm_gpt2.tokenizer.encode(MSG_prompt)
+        with vllm_gpt2.trace(temperature=0.0, top_p=1) as tracer:
+            with tracer.invoke(ET_prompt):
+                et = vllm_gpt2.logits.save()
+            with tracer.invoke(TokensPrompt(prompt_token_ids=ids)):
+                msg = vllm_gpt2.logits.save()
+
+        assert vllm_gpt2.tokenizer.decode(et.argmax(dim=-1)) == " Paris"
+        assert vllm_gpt2.tokenizer.decode(msg.argmax(dim=-1)) == " New"

--- a/tests/vllm/test_tracing.py
+++ b/tests/vllm/test_tracing.py
@@ -130,9 +130,13 @@ class TestSampling:
                 for _ in tracer.iter[0:3]:
                     greedy.append(vllm_gpt2.samples.item())
 
-        assert vllm_gpt2.tokenizer.batch_decode(
-            greedy
-        ) == [" New", " York", " City"]
+        # One id at a time: these are plain ints, and `batch_decode` reads a flat
+        # list of them as a sequence each in transformers 4 but as one sequence in
+        # transformers 5, so it cannot state this across both. (The other decodes
+        # in this suite pass tensors, which are unambiguous.)
+        assert [
+            vllm_gpt2.tokenizer.decode([token]) for token in greedy
+        ] == [" New", " York", " City"]
         assert sampled != greedy
 
     @torch.no_grad()
@@ -699,3 +703,31 @@ class TestPromptForms:
 
         assert vllm_gpt2.tokenizer.decode(et.argmax(dim=-1)) == " Paris"
         assert vllm_gpt2.tokenizer.decode(msg.argmax(dim=-1)) == " New"
+
+
+class TestModelRunnerSelection:
+    """nnsight instruments one of vLLM's two GPU model runners, and says so."""
+
+    def test_it_asks_for_the_runner_it_instruments(self):
+        # Set before the engine is built, since the worker processes inherit it.
+        import os
+
+        from nnsight.modeling.vllm import VLLM
+
+        os.environ.pop("VLLM_USE_V2_MODEL_RUNNER", None)
+        VLLM._require_v1_model_runner()
+        assert os.environ["VLLM_USE_V2_MODEL_RUNNER"] == "0"
+
+    def test_asking_for_the_other_one_is_refused(self):
+        # Overriding it silently would be worse: the engine comes up with no
+        # instrumentation and the first collect fails with a missing method.
+        import os
+
+        from nnsight.modeling.vllm import VLLM
+
+        os.environ["VLLM_USE_V2_MODEL_RUNNER"] = "1"
+        try:
+            with pytest.raises(NotImplementedError, match="V2 GPU model runner"):
+                VLLM._require_v1_model_runner()
+        finally:
+            os.environ.pop("VLLM_USE_V2_MODEL_RUNNER", None)


### PR DESCRIPTION
28 commits against `0.8`, 54 files, +4631/-629. Two distinct bodies of work, listed separately because they were reviewed differently.

## vLLM and the interleaver (21 commits)

Pre-existing work on this branch:

- **Edits on the engine** — `register()` renamed to `edit()`, blocks installed so they run for every request, `aclear_edits`, edits over `serve`, barriers refused.
- **`n>1` sampling** — one prompt, several sequences; a saved name comes back as a list, one entry per sequence.
- **Per-invoke sampling parameters** survive the trace-level ones, including when the value equals vLLM's own default.
- **Prompt forms** — strings, token-id lists, tokenizer output, and vLLM's `TokensPrompt`/`TextPrompt`.
- **MoE** — the fragment policy ported to both 0.16 and 0.27's layer, the layer found by whatever that vLLM calls it, and a replicated linear correctly not treated as a fragment.
- **Correctness** — prefix-cached tokens forced to recompute so they still reach interventions; per-rank cleanup fixed; a finished worker treated as finished however it finished.
- **Performance** — the meta tree no longer rebuilt on dispatch, cached locations routed rather than disabling the skip, and only the workers with someone waiting consulted.

## Fixes from an interpretability sweep (7 commits)

Eighteen agents were each given a real interpretability workload, a GPU and nnsight, and asked to do the research and record where the library got in the way. These are the library defects that came out of it. Every one produced a **plausible wrong number** rather than an error, which is why they had gone unnoticed.

- **`cache: capture synchronously by default`** — `tracer.cache()` moved captures with `non_blocking=True` and nothing synchronised before they were read, so a capture off a CUDA device could be read mid-copy. Measured on GPT-2 at batch 128: 10/10 batches differed from a plain forward hook, up to 100% of elements wrong; 0/10 with the synchronous copy. The window scales with copy size, so it was invisible in tests and corrupted corpus-scale runs. `docs/usage/cache.md` had argued the async default was safe.
- **`interleaver: only store a worker's exception where one is read`** — `tracer.stop()` retained the entire run through a 32-hop cycle (mediator → EarlyStopException → traceback → the interrupted forward's frames → mediator). At batch 64, 1155 MiB held afterwards versus a 494.8 MiB baseline. The stored copy is only read by a deferring driver (vLLM), so it now moves after the re-raise. `stop()` becomes a 44% peak-memory reduction rather than a 16% penalty.
- **`transformers: correct position_ids for a single left-padded row`** — `_supply_position_ids` skipped its correction when the batch had one row, so the same prompt answered differently depending on whether another row shared its batch (`' the'` alone, `' Paris'` with a second copy).
- **`transformers: refuse a PEFT adapter that did not attach`** — peft matches adapter weights by name and silently drops what it cannot place; since `lora_B` starts at zero, a failed load is indistinguishable from a loaded adapter that does nothing. A model-organism run loaded all 496 `lora_B` matrices as zeros and nearly published base-vs-base as a result. Both the construction path and the adapter-*swap* path are covered.
- **`source: name the decorator when refusing a wrapped forward`** — "callable closes over free variables" now names the decorator that built the wrapper and the function it wraps, which turns a dead end into a diagnosis on Mamba's mixer.
- **Two documentation commits** — four claims that were measurably false (the async cache defence, bounding an `iter` loop as protection against early EOS, batched output being bit-identical to a solo run, and a vLLM-only MoE ablation recipe that is a silent no-op on transformers), plus Gemma-2/3 logit softcapping, permanent weight edits inside a trace, and 40 stale `.output[0]` block idioms.

## Testing

`tests/` (excluding `vllm`, which needs an environment this machine does not have): **808 passed**, the only failures being two pre-existing `TestColabUserdata` cases unrelated to these changes. The source-tracing suite passes 46/46, and the skills doc-block harness executes the edited recipes.

**The vLLM tests have not been run here** — `vllm.model_executor` is not importable in this environment. The interleaver change deliberately preserves the deferring path that vLLM depends on, so that path is the one thing worth exercising before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)