### PR TITLE
fix(util): traverse container subclasses so ModelOutput values are not silently skipped

### DIFF
--- a/src/nnsight/util.py
+++ b/src/nnsight/util.py
@@ -1,5 +1,6 @@
 """Module for utility functions and classes used throughout the package."""
 
+import copy
 import importlib
 from contextlib import AbstractContextManager
 from typing import Any, Callable, Collection, List, Optional, Type, TypeVar
@@ -11,6 +12,62 @@ from typing_extensions import Self
 
 T = TypeVar("T")
 C = TypeVar("C", bound=Collection[T])
+
+
+def _rebuild_tuple(data: tuple, items: List[Any]) -> tuple:
+    """Rebuild a ``tuple`` subclass from *items*, preserving its concrete type.
+
+    ``tuple`` subclasses do not share a constructor signature: ``namedtuple``
+    takes one argument per field, while ``torch.Size`` and the
+    ``torch.return_types.*`` structsequences take a single iterable. Try the
+    type-appropriate constructor and fall back to a plain ``tuple`` only if the
+    subclass cannot be rebuilt at all.
+    """
+
+    if hasattr(data, "_make"):
+        # namedtuple
+        return type(data)._make(items)
+
+    try:
+        # torch.Size, torch.return_types.*, and tuple subclasses that accept an
+        # iterable.
+        return type(data)(items)
+    except TypeError:
+        return tuple(items)
+
+
+def _apply_mapping(
+    data: dict, fn: Callable[[T], Any], cls: Type[T], inplace: bool
+) -> dict:
+    """Apply *fn* through a ``dict`` subclass, preserving its concrete type.
+
+    A shallow copy is mutated rather than the type being reconstructed from its
+    items, because subclasses such as HuggingFace's ``ModelOutput`` are
+    dataclasses whose ``__init__`` does not accept a mapping. Assigning through
+    ``__setitem__`` also keeps subclass invariants intact -- ``ModelOutput``, for
+    instance, mirrors every item onto the matching attribute, so
+    ``output.logits`` stays in sync with ``output["logits"]``.
+    """
+
+    new = data if inplace else copy.copy(data)
+
+    for key in list(data.keys()):
+        new[key] = apply(data[key], fn, cls, inplace=inplace)
+
+    return new
+
+
+def _apply_sequence(
+    data: list, fn: Callable[[T], Any], cls: Type[T], inplace: bool
+) -> list:
+    """Apply *fn* through a ``list`` subclass, preserving its concrete type."""
+
+    new = data if inplace else copy.copy(data)
+
+    for idx in range(len(data)):
+        new[idx] = apply(data[idx], fn, cls, inplace=inplace)
+
+    return new
 
 
 def apply(data: C, fn: Callable[[T], Any], cls: Type[T], inplace: bool = False) -> C:
@@ -55,6 +112,25 @@ def apply(data: C, fn: Callable[[T], Any], cls: Type[T], inplace: bool = False) 
             apply(data.start, fn, cls, inplace=inplace),
             apply(data.stop, fn, cls, inplace=inplace),
             apply(data.step, fn, cls, inplace=inplace),
+        )
+
+    # The checks above match the builtin container types exactly, which leaves
+    # every *subclass* of them untouched. That silently skips containers nnsight
+    # handles constantly -- a HuggingFace `ModelOutput` (an `OrderedDict`
+    # subclass) is what every top-level transformers module returns, and
+    # `namedtuple` / `torch.Size` / `torch.return_types.*` are ordinary module
+    # outputs too. Recurse into them as well, rebuilding the concrete type so
+    # callers still get a `ModelOutput` back (`.logits`, `.last_hidden_state`,
+    # ...) rather than a plain dict.
+    elif isinstance(data, dict):
+        return _apply_mapping(data, fn, cls, inplace)
+
+    elif isinstance(data, list):
+        return _apply_sequence(data, fn, cls, inplace)
+
+    elif isinstance(data, tuple):
+        return _rebuild_tuple(
+            data, [apply(_data, fn, cls, inplace=inplace) for _data in data]
         )
 
     return data
@@ -113,6 +189,41 @@ def applyn(data: C, fn: Callable[[T], Any], cls: Type[T], inplace: bool = False)
     #         apply(data.stop, fn, cls, inplace=inplace),
     #         apply(data.step, fn, cls, inplace=inplace),
     #     )
+
+    # Container subclasses -- see the matching comment in `apply`. Without these
+    # branches a batched write into a `ModelOutput` replaces nothing at all.
+    elif isinstance(data[0], dict):
+
+        new = copy.copy(data[0])
+
+        for key in list(data[0].keys()):
+            # A sibling may legitimately lack a key: `ModelOutput.keys()` only
+            # reports its non-`None` fields, so a user-supplied replacement need
+            # not carry every field the original has. Leave those alone rather
+            # than raising.
+            if all(key in _data for _data in data[1:]):
+                new[key] = applyn(
+                    [_data[key] for _data in data], fn, cls, inplace=inplace
+                )
+
+        return new
+
+    elif isinstance(data[0], (list, tuple)):
+
+        items = [
+            applyn([_data[i] for _data in data], fn, cls, inplace=inplace)
+            for i in range(len(data[0]))
+        ]
+
+        if isinstance(data[0], tuple):
+            return _rebuild_tuple(data[0], items)
+
+        new = copy.copy(data[0])
+
+        for i, item in enumerate(items):
+            new[i] = item
+
+        return new
 
     return data[0]
 

--- a/tests/test_container_types.py
+++ b/tests/test_container_types.py
@@ -1,0 +1,383 @@
+"""Tests for tensor traversal through container *subclasses*.
+
+``nnsight.util.apply`` / ``applyn`` walk a module's inputs and outputs to find
+tensors -- narrowing them to an invoke's batch slice, splicing a modified slice
+back in, moving them to a device, casting a dtype, detaching them for a cache.
+
+The builtin containers (``list``, ``tuple``, ``dict``) were the only ones
+recursed into, which silently excluded every *subclass* of them. That mattered
+because a HuggingFace ``ModelOutput`` is an ``OrderedDict`` subclass, and it is
+what every top-level ``transformers`` module returns -- so ``model.output`` and
+``model.transformer.output`` were skipped by all of the above, with no error.
+
+These tests pin the traversal itself (``TestApply`` / ``TestApplyN``) and the
+five user-visible behaviours that depend on it (``TestBatchedModelOutput``,
+``TestCacheModelOutput``).
+"""
+
+import collections
+
+import pytest
+import torch
+
+import nnsight
+from nnsight.util import apply, applyn
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _mark(tensor: torch.Tensor) -> torch.Tensor:
+    """A stand-in transformation: every visited tensor becomes all-ones."""
+    return torch.ones_like(tensor)
+
+
+def _all_marked(data) -> bool:
+    """True when at least one tensor was found and every one of them is marked."""
+
+    found = []
+
+    def walk(value):
+        if isinstance(value, torch.Tensor):
+            found.append(bool((value == 1).all()))
+        elif isinstance(value, dict):
+            for item in value.values():
+                walk(item)
+        elif isinstance(value, (list, tuple)):
+            for item in value:
+                walk(item)
+
+    walk(data)
+
+    return len(found) > 0 and all(found)
+
+
+def _rel_err(got: torch.Tensor, expected: torch.Tensor) -> float:
+    """Scale-invariant error, comparing only the trailing (unpadded) positions.
+
+    Batching an invoke alongside a longer prompt left-pads it, so the batched
+    value carries extra leading positions. The real tokens are right-aligned.
+    """
+
+    length = min(got.shape[1], expected.shape[1])
+    got, expected = got[:, -length:], expected[:, -length:]
+
+    return ((got - expected).norm() / expected.norm()).item()
+
+
+Point = collections.namedtuple("Point", ["x", "y"])
+
+
+class ListSubclass(list):
+    pass
+
+
+class DictSubclass(dict):
+    pass
+
+
+def _model_output(**fields):
+    from transformers.modeling_outputs import BaseModelOutputWithPast
+
+    return BaseModelOutputWithPast(**fields)
+
+
+# =============================================================================
+# apply / applyn
+# =============================================================================
+
+
+class TestApply:
+    """``apply`` must reach tensors inside container subclasses."""
+
+    @pytest.mark.parametrize(
+        "container",
+        [
+            pytest.param([torch.zeros(2)], id="list"),
+            pytest.param((torch.zeros(2),), id="tuple"),
+            pytest.param({"a": torch.zeros(2)}, id="dict"),
+            pytest.param(
+                collections.OrderedDict(a=torch.zeros(2)), id="OrderedDict"
+            ),
+            pytest.param(
+                collections.defaultdict(list, a=torch.zeros(2)), id="defaultdict"
+            ),
+            pytest.param(Point(torch.zeros(2), torch.zeros(2)), id="namedtuple"),
+            pytest.param(ListSubclass([torch.zeros(2)]), id="list_subclass"),
+            pytest.param(DictSubclass(a=torch.zeros(2)), id="dict_subclass"),
+            pytest.param([{"a": (torch.zeros(2),)}], id="nested"),
+        ],
+    )
+    def test_reaches_tensors(self, container):
+        assert _all_marked(apply(container, _mark, torch.Tensor))
+
+    @pytest.mark.parametrize(
+        "container",
+        [
+            pytest.param(collections.OrderedDict(a=torch.zeros(2)), id="OrderedDict"),
+            pytest.param(Point(torch.zeros(2), torch.zeros(2)), id="namedtuple"),
+            pytest.param(ListSubclass([torch.zeros(2)]), id="list_subclass"),
+            pytest.param(DictSubclass(a=torch.zeros(2)), id="dict_subclass"),
+        ],
+    )
+    def test_preserves_type(self, container):
+        assert type(apply(container, _mark, torch.Tensor)) is type(container)
+
+    def test_does_not_mutate_source_when_not_inplace(self):
+        container = collections.OrderedDict(a=torch.zeros(2))
+
+        apply(container, _mark, torch.Tensor)
+
+        assert bool((container["a"] == 0).all())
+
+    def test_inplace_mutates_source(self):
+        container = collections.OrderedDict(a=torch.zeros(2))
+
+        result = apply(container, _mark, torch.Tensor, inplace=True)
+
+        assert result is container
+        assert _all_marked(container)
+
+    def test_torch_size_is_rebuilt_not_downgraded(self):
+        # torch.Size is a tuple subclass holding no tensors: recursing into it
+        # must be a no-op that still hands back a torch.Size.
+        size = torch.Size([2, 3])
+
+        result = apply(size, _mark, torch.Tensor)
+
+        assert result == size
+        assert isinstance(result, torch.Size)
+
+    def test_torch_return_types_is_rebuilt(self):
+        # torch.return_types.* are structsequences: a tuple subclass whose
+        # constructor takes a single iterable rather than one arg per field.
+        returned = torch.max(torch.zeros(3, 3), dim=0)
+
+        result = apply(returned, _mark, torch.Tensor)
+
+        assert type(result) is type(returned)
+        assert _all_marked(result)
+
+    def test_tuple_subclass_with_incompatible_constructor(self):
+        class Fixed(tuple):
+            def __new__(cls, a, b):
+                return super().__new__(cls, (a, b))
+
+        result = apply(Fixed(torch.zeros(2), torch.zeros(2)), _mark, torch.Tensor)
+
+        # The concrete type cannot be rebuilt from an iterable, so a plain tuple
+        # is the documented fallback -- but the tensors are still transformed.
+        assert _all_marked(result)
+
+    def test_non_container_objects_are_left_alone(self):
+        class Opaque:
+            def __init__(self):
+                self.tensor = torch.zeros(2)
+
+        opaque = Opaque()
+
+        assert apply(opaque, _mark, torch.Tensor) is opaque
+        assert bool((opaque.tensor == 0).all())
+
+    def test_strings_are_not_traversed(self):
+        assert apply("hello", _mark, torch.Tensor) == "hello"
+
+
+class TestApplyN:
+    """``applyn`` zips several containers of the same shape together."""
+
+    def test_ordered_dict(self):
+        a = collections.OrderedDict(x=torch.zeros(2))
+        b = collections.OrderedDict(x=torch.ones(2))
+
+        result = applyn([a, b], lambda p, q: p + q, torch.Tensor)
+
+        assert type(result) is collections.OrderedDict
+        assert _all_marked(result)
+
+    def test_namedtuple(self):
+        a = Point(torch.zeros(2), torch.zeros(2))
+        b = Point(torch.ones(2), torch.ones(2))
+
+        result = applyn([a, b], lambda p, q: p + q, torch.Tensor)
+
+        assert type(result) is Point
+        assert _all_marked(result)
+
+    def test_list_subclass(self):
+        a = ListSubclass([torch.zeros(2)])
+        b = ListSubclass([torch.ones(2)])
+
+        result = applyn([a, b], lambda p, q: p + q, torch.Tensor)
+
+        assert type(result) is ListSubclass
+        assert _all_marked(result)
+
+    def test_key_missing_from_a_sibling_keeps_the_original(self):
+        # `ModelOutput.keys()` only reports its non-None fields, so a
+        # replacement value need not carry every key the original has.
+        a = collections.OrderedDict(x=torch.zeros(2), y=torch.zeros(2))
+        b = collections.OrderedDict(x=torch.ones(2))
+
+        result = applyn([a, b], lambda p, q: p + q, torch.Tensor)
+
+        assert bool((result["x"] == 1).all())
+        assert bool((result["y"] == 0).all())
+
+
+# =============================================================================
+# ModelOutput through the batching path
+# =============================================================================
+
+
+@pytest.mark.usefixtures("gpt2")
+class TestBatchedModelOutput:
+    """A ``ModelOutput`` must be narrowed and spliced like a tuple output.
+
+    ``model.output`` and ``model.transformer.output`` are ``ModelOutput``
+    instances. Before container subclasses were traversed, an invoke read the
+    *whole* batch through them, and a write through them landed on every other
+    invoke's rows.
+    """
+
+    PROMPT_A = "The Eiffel Tower is in the city of"
+    PROMPT_B = "Madison Square Garden is located in the city of"
+
+    @torch.no_grad()
+    def test_read_is_narrowed_to_the_invoke(self, gpt2: nnsight.LanguageModel):
+        with gpt2.trace() as tracer:
+            with tracer.invoke(self.PROMPT_A):
+                a_inner = gpt2.transformer.output.save()
+                a_top = gpt2.output.save()
+            with tracer.invoke(self.PROMPT_B):
+                b_inner = gpt2.transformer.output.save()
+                b_top = gpt2.output.save()
+
+        for value in (a_inner.last_hidden_state, a_top.logits):
+            assert value.shape[0] == 1
+        for value in (b_inner.last_hidden_state, b_top.logits):
+            assert value.shape[0] == 1
+
+        # Each invoke gets its own narrowed view, not one shared object.
+        assert a_top.logits is not b_top.logits
+
+    @torch.no_grad()
+    def test_read_matches_the_same_prompt_run_alone(
+        self, gpt2: nnsight.LanguageModel
+    ):
+        with gpt2.trace(self.PROMPT_A):
+            reference = gpt2.output.logits.save()
+        with gpt2.trace(self.PROMPT_B):
+            other_reference = gpt2.output.logits.save()
+
+        with gpt2.trace() as tracer:
+            with tracer.invoke(self.PROMPT_A):
+                batched = gpt2.output.logits.save()
+            with tracer.invoke(self.PROMPT_B):
+                gpt2.output.save()
+
+        assert _rel_err(batched, reference) < 1e-4
+        # Negative control: a wrong slice would look like the other prompt.
+        assert _rel_err(batched, other_reference) > 1e-2
+
+    @torch.no_grad()
+    def test_write_does_not_leak_into_other_invokes(
+        self, gpt2: nnsight.LanguageModel
+    ):
+        with gpt2.trace() as tracer:
+            with tracer.invoke(self.PROMPT_A):
+                base_a = gpt2.lm_head.output.save()
+            with tracer.invoke(self.PROMPT_B):
+                base_b = gpt2.lm_head.output.save()
+
+        with gpt2.trace() as tracer:
+            with tracer.invoke(self.PROMPT_A):
+                gpt2.transformer.output.last_hidden_state[:] = 0.0
+                edited_a = gpt2.lm_head.output.save()
+            with tracer.invoke(self.PROMPT_B):
+                edited_b = gpt2.lm_head.output.save()
+
+        assert not torch.allclose(edited_a, base_a, atol=1e-3)
+        assert torch.allclose(edited_b, base_b, atol=1e-3)
+
+    @torch.no_grad()
+    def test_attribute_and_item_stay_in_sync(self, gpt2: nnsight.LanguageModel):
+        # ModelOutput mirrors items onto attributes; rebuilding it through
+        # __setitem__ keeps that invariant, so `.logits` is the narrowed value.
+        with gpt2.trace() as tracer:
+            with tracer.invoke(self.PROMPT_A):
+                top = gpt2.output.save()
+            with tracer.invoke(self.PROMPT_B):
+                gpt2.output.save()
+
+        assert type(top).__name__.endswith("Output") or "Output" in type(top).__name__
+        assert top.logits is top["logits"]
+
+    @torch.no_grad()
+    def test_empty_invoke_still_sees_the_full_batch(
+        self, gpt2: nnsight.LanguageModel
+    ):
+        with gpt2.trace() as tracer:
+            with tracer.invoke(self.PROMPT_A):
+                pass
+            with tracer.invoke(self.PROMPT_B):
+                pass
+            with tracer.invoke():
+                full = gpt2.output.save()
+
+        assert full.logits.shape[0] == 2
+
+
+# =============================================================================
+# ModelOutput through the cache path
+# =============================================================================
+
+
+@pytest.mark.cache
+@pytest.mark.usefixtures("gpt2")
+class TestCacheModelOutput:
+    """``tracer.cache`` transformations must reach inside a ``ModelOutput``."""
+
+    @torch.no_grad()
+    def test_dtype_is_applied(self, gpt2: nnsight.LanguageModel):
+        with gpt2.trace("hello world") as tracer:
+            cache = tracer.cache(
+                modules=[gpt2.transformer], dtype=torch.float16
+            ).save()
+
+        output = cache["model.transformer"].output
+
+        assert output.last_hidden_state.dtype == torch.float16
+
+    @torch.no_grad()
+    def test_device_is_applied(self, gpt2: nnsight.LanguageModel):
+        with gpt2.trace("hello world") as tracer:
+            cache = tracer.cache(modules=[gpt2.transformer], device="cpu").save()
+
+        output = cache["model.transformer"].output
+
+        assert output.last_hidden_state.device.type == "cpu"
+
+    def test_detach_is_applied(self, gpt2: nnsight.LanguageModel):
+        # detach defaults to True; a ModelOutput that skipped it kept the whole
+        # autograd graph alive for as long as the cache was held.
+        with gpt2.trace("hello world") as tracer:
+            cache = tracer.cache(modules=[gpt2.transformer]).save()
+
+        output = cache["model.transformer"].output
+
+        assert output.last_hidden_state.grad_fn is None
+        assert not output.last_hidden_state.requires_grad
+
+    @torch.no_grad()
+    def test_narrowed_per_invoke(self, gpt2: nnsight.LanguageModel):
+        with gpt2.trace() as tracer:
+            with tracer.invoke("The Eiffel Tower is in the city of"):
+                first = tracer.cache(modules=[gpt2.transformer]).save()
+            with tracer.invoke("Madison Square Garden is located in the city of"):
+                second = tracer.cache(modules=[gpt2.transformer]).save()
+
+        for cache in (first, second):
+            output = cache["model.transformer"].output
+            assert output.last_hidden_state.shape[0] == 1


### PR DESCRIPTION
## Summary

`util.apply` and `util.applyn` decide which values nnsight is allowed to touch. They matched the builtin containers **exactly**:

```python
data_type = type(data)

if data_type == list: ...
elif data_type == tuple: ...
elif data_type == dict: ...
```

so every *subclass* of them fell through to `return data` untouched. A HuggingFace `ModelOutput` is an `OrderedDict` subclass, and it is what every top-level `transformers` module returns — which means `model.output` and `model.transformer.output` were invisible to all five callers of these helpers. `namedtuple`, `OrderedDict`, `defaultdict` and `torch.return_types.*` module outputs were skipped for the same reason.

Nothing raised. The traversal simply found no tensors, so each caller degraded silently.

## The five symptoms

Reproduced on `gpt2`, CPU, `dev` @ efe4244:

| Caller | Symptom |
|---|---|
| `Batcher.narrow` | An invoke reading `model.output` in a batched trace got the **whole batch**, and both invokes got the same object (`a.logits is b.logits` → `True`) |
| `Batcher.swap` | Writing through `model.transformer.output` inside one invoke landed on **every other invoke's rows** |
| `hooks.cache_output_hook` / `cache_input_hook` | `tracer.cache(...)` stored the full batch for a `ModelOutput` module |
| `Cache.add` | `cache(dtype=...)` / `cache(device=...)` left those tensors unconverted; the default `detach=True` never fired, so the cache pinned the autograd graph |
| `nnsight_forward`'s `__nnsight_skip__` merge | A multi-invoke `tracer.skip()` returned one invoke's value instead of the concatenation |

### Read leak

```python
with m.trace() as tracer:
    with tracer.invoke(A):
        a_h0    = m.transformer.h[0].output[0].save()   # plain tuple
        a_inner = m.transformer.output.save()           # BaseModelOutputWithPast
        a_top   = m.output.save()                       # CausalLMOutputWithPast
    with tracer.invoke(B):
        ...
```

```
h[0].output[0]            (plain tuple)   got=(1, 10, 768)      expected=(1, 10, 768)      OK
transformer.output.last_hidden_state      got=(2, 10, 768)      expected=(1, 10, 768)      *** WRONG ***
model.output.logits                       got=(2, 10, 50257)    expected=(1, 10, 50257)    *** WRONG ***
```

### Write leak

Zeroing hidden states in invoke 0 only:

```
invoke0 logits changed?  True   (expected True)
invoke1 logits changed?  True   (expected False)   <- clobbered
```

### Cache

```
cache(dtype=torch.float16):
  model.transformer        BaseModelOutputWithPast   dtypes=['torch.float32']  *** NOT CONVERTED ***
  model.transformer.h.0    tuple                     dtypes=['torch.float16']  OK
  model.lm_head            Tensor                    dtypes=['torch.float16']  OK

cache in a 2-invoke trace:
  model.transformer        BaseModelOutputWithPast   (2, 10, 768)  *** batch dim not 1 ***
```

This is the failure mode that worries me most: a batched-invoke user reading `model.output` gets a plausible tensor with a silently wrong batch dimension, and `cache(device=...)` silently leaves activations on the GPU it was asked to move them off.

## Fix

Recurse into `list` / `tuple` / `dict` subclasses too, rebuilding the concrete type so callers still get a `ModelOutput` back rather than a plain `dict`.

- **Mappings and lists** are rebuilt by mutating a shallow copy, not by reconstructing the type from its items — subclasses like `ModelOutput` are dataclasses whose `__init__` does not accept a mapping. Going through `__setitem__` also preserves `ModelOutput`'s item/attribute mirroring, so `.logits` stays in sync with `["logits"]` (asserted in the tests).
- **Tuples** use `_make` for namedtuples and the iterable constructor otherwise (`torch.Size`, `torch.return_types.*` structsequences), falling back to a plain tuple only when the subclass genuinely cannot be rebuilt.

The exact-type fast paths are untouched, so **the hot path is unchanged**: the new branches only run for values that previously fell straight through to `return data`. `Batcher.narrow` also still early-returns before any of this when `needs_batching` is `False`, so single-invoke traces do no extra work at all.

Deliberately out of scope: `collections.UserDict` / `UserList` and `transformers.BatchEncoding` are *not* `dict`/`list` subclasses (they are `MutableMapping`/`MutableSequence`), and objects like `DynamicCache` are not containers at all. Those keep today's behaviour — widening to the `abc` types is a bigger semantic question (`str` is a `Sequence`) and none of the symptoms above need it.

## Verification

Each invoke's narrowed `ModelOutput` now matches the same prompt traced alone to a relative error of **2e-7**, while differing from the *other* invoke's reference by **1.7e-1** — so the slice is right, not merely the shape.

`tests/test_container_types.py` adds 33 tests: the traversal itself (`apply`/`applyn` over 9 container shapes, type preservation, `inplace`, `torch.Size`, structsequences, a tuple subclass with an incompatible constructor, non-containers, strings) plus the five behaviours above. **18 of the 33 fail on `dev` and all 33 pass with this change.**

Full CI test list on CPU: `1 failed, 276 passed`. The one failure is `test_lm.py::TestGradients::test_backward_with_multiple_invokers`, which is already red on `dev` and `main` and is unrelated to this change (addressed separately in #693).

<sub>Run with `transformers` 5.15.1 / `torch` 2.9.1 on CPU. Verified this change introduces no failure difference under `transformers` 4.57.3 either.</sub>
