### PR TITLE
test(lm): fix the batched-gradient assertion that has kept CI red for a month

### DIFF
--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -24,6 +24,25 @@ def _test_serialize(tracer):
     pass
 
 
+def _grad_rel_err(got: torch.Tensor, expected: torch.Tensor) -> float:
+    """Relative error between two gradients, as a single scale-free number.
+
+    Gradient magnitudes here run to ~4e4, where one float32 ULP is already
+    ~4e-3, so an absolute tolerance says nothing useful. A normalised norm
+    ratio is comparable across tensors and is insensitive to individual
+    near-zero entries, where catastrophic cancellation makes the *elementwise*
+    relative error large even when the tensor as a whole is correct.
+
+    Batching left-pads a shorter prompt, so the batched gradient carries extra
+    leading positions; the real tokens are right-aligned.
+    """
+
+    length = min(got.shape[1], expected.shape[1])
+    got, expected = got[:, -length:], expected[:, -length:]
+
+    return ((got - expected).norm() / expected.norm()).item()
+
+
 # =============================================================================
 # Basic Generation and Tracing
 # =============================================================================
@@ -277,35 +296,77 @@ class TestGradients:
 
         assert not torch.all(hidden_states_grad1.eq(hidden_states_grad2))
 
-    def test_backward_with_multiple_invokers(self, gpt2: nnsight.LanguageModel):
+    # Distinct prompts, so a gradient taken from the wrong batch row is
+    # detectable. (With the same prompt in every invoke, returning another
+    # invoke's slice -- or the whole batch -- looks identical to success.)
+    GRAD_PROMPTS = (
+        "The quick brown fox jumps",
+        "Madison Square Garden is located in",
+        "A completely different sentence appears",
+    )
+
+    def _single_invoke_grad(self, gpt2: nnsight.LanguageModel, prompt: str):
+        """d(sum lm_head.output)/d(h[5].attn.c_proj.output) with no batching."""
+        with gpt2.trace() as tracer:
+            with tracer.invoke(prompt):
+                x = gpt2.transformer.h[5].attn.c_proj.output
+                with gpt2.lm_head.output.sum().backward():
+                    grad = x.grad.save()
+        return grad
+
+    @pytest.mark.parametrize(
+        "n_invokes, target",
+        [
+            (2, 1),  # last invoke
+            (2, 0),  # first invoke -- the batch slice does not start at 0 for
+            (3, 0),  # the others, so each position exercises a different offset
+            (3, 1),
+            (3, 2),
+        ],
+    )
+    def test_backward_with_multiple_invokers(
+        self, gpt2: nnsight.LanguageModel, n_invokes: int, target: int
+    ):
         """Regression for #664: a gradient requested inside a batched invoke.
 
         With two or more invokes sharing an input, each invoke's module output
-        is a storage-sharing view of the full batch; a backward hook on that view
-        never fires, raising MissedProviderError. The grad must (a) be provided
-        and (b) match the gradient computed for the same input in a single invoke.
+        is a storage-sharing view of the full batch; a backward hook on that
+        view never fires, raising MissedProviderError. The grad must (a) be
+        provided and (b) be *this* invoke's gradient rather than another row's.
+
+        Correctness is asserted as a relative-norm error rather than
+        ``allclose(..., atol=1e-5)``. These gradients reach ~4e4 in float32,
+        where a single ULP is ~4e-3, and the batched backward accumulates its
+        reductions in a different order than the unbatched one. Reproducing the
+        batch shape in plain HuggingFace gives the same discrepancy, and in
+        float64 the two agree to 5e-11 -- so the spread is float32 reduction
+        order, not a slicing bug. It is measured here at ~1e-5 relative, five
+        orders of magnitude below the ~1.2 relative error of picking the wrong
+        row, which is what this test needs to distinguish.
         """
-        prompt = "The quick brown fox jumps"
+        prompts = list(self.GRAD_PROMPTS[:n_invokes])
 
-        # Reference: single invoke, no batching.
-        with gpt2.trace() as tracer:
-            with tracer.invoke(prompt):
-                ref_x = gpt2.transformer.h[5].attn.c_proj.output
-                with gpt2.lm_head.output.sum().backward():
-                    ref_grad = ref_x.grad.save()
+        references = [self._single_invoke_grad(gpt2, prompt) for prompt in prompts]
 
-        # Two invokes share the input -> batching views in invoke 2.
         with gpt2.trace() as tracer:
-            with tracer.invoke(prompt):
-                gpt2.lm_head.output.save()
-            with tracer.invoke(prompt):
-                batched_x = gpt2.transformer.h[5].attn.c_proj.output
-                with gpt2.lm_head.output.sum().backward():
-                    batched_grad = batched_x.grad.save()
+            for index, prompt in enumerate(prompts):
+                with tracer.invoke(prompt):
+                    if index == target:
+                        x = gpt2.transformer.h[5].attn.c_proj.output
+                        with gpt2.lm_head.output.sum().backward():
+                            batched_grad = x.grad.save()
+                    else:
+                        gpt2.lm_head.output.save()
             _test_serialize(tracer)
 
         assert batched_grad is not None
-        assert torch.allclose(ref_grad, batched_grad, atol=1e-5)
+
+        assert _grad_rel_err(batched_grad, references[target]) < 1e-4
+
+        # Negative control: it must not be any other invoke's gradient.
+        for index, reference in enumerate(references):
+            if index != target:
+                assert _grad_rel_err(batched_grad, reference) > 1e-2
 
     def test_grad_edit_with_multiple_invokers(self, gpt2: nnsight.LanguageModel):
         """Editing a gradient inside a batched invoke must be applied (#664)."""


### PR DESCRIPTION
## Summary

`tests/test_lm.py::TestGradients::test_backward_with_multiple_invokers` has failed on **every push to `main` and `dev`** since it landed in #671 (2026-07-25). The test job has been red for a month:

```
FAILED tests/test_lm.py::TestGradients::test_backward_with_multiple_invokers[cpu] - assert False
======= 1 failed, 243 passed, 2 skipped, 1 xpassed, 6 warnings in 44.13s =======
```

**The gradient is correct. The assertion is not satisfiable.**

## Why the assertion cannot pass

```python
assert torch.allclose(ref_grad, batched_grad, atol=1e-5)
```

`d(sum lm_head.output)/d(h[5].attn.c_proj.output)` reaches **~4e4** in float32, where a single ULP is already ~4e-3 — 400× the tolerance. Running the same prompt batched vs. unbatched reorders the reductions through six layers of backward, so the two differ by ~1e-5 *relative* (0.7 absolute) regardless of what nnsight does.

Two independent controls confirm nnsight is not the source:

1. **Pure HuggingFace, no nnsight.** `retain_grad()` on the same submodule, `logits[i:i+1].sum().backward()`, same batch shape — reproduces the discrepancy *bit for bit*:

   ```
   nnsight  single-vs-batched: abs diff max = 1.07958984375   rel diff max = 0.06253758
   pure HF  single-vs-batched: abs diff max = 1.07958984375   rel diff max = 0.06253758
   ```

2. **float64.** The same comparison, same code, `dtype=torch.float64`:

   ```
   float32:  nnsight batched vs single-prompt reference -> absmax 6.6e-01, relmax 4.1e-02
   float64:  nnsight batched vs single-prompt reference -> absmax 2.7e-10, relmax 5.1e-11
   ```

   The error collapses by nine orders of magnitude when the mantissa grows. It is float32 reduction order, not a slicing bug.

I also checked the forward pass separately, in case left-padding was involved: nnsight's left-padded batch matches pure HF's left-padded batch exactly (`1.37e-04` on logits of magnitude 155, i.e. ~1e-6 relative), and dropping the derived `position_ids` moves that to `9.08e+01` — so #673's derivation is doing its job.

## The test also could not catch its own bug class

Both invokes used **the same prompt**:

```python
prompt = "The quick brown fox jumps"
with tracer.invoke(prompt): ...
with tracer.invoke(prompt): ...   # grad taken here
```

With identical inputs, returning invoke 0's gradient — or the entire batch — is indistinguishable from success. The test guards `MissedProviderError` (#664) but not "is this *my* gradient", which is the harder half.

It also only ever exercised the **last** invoke of **two**, so the batch-slice offset under test was always the same one.

## Changes

- **Assert on a normalised norm ratio** (`_grad_rel_err`) instead of `allclose`. It is scale-free and insensitive to individual near-zero entries, where cancellation makes the *elementwise* relative error large (0.06) even for a correct tensor. Measured spread is ~1e-5; threshold is 1e-4.
- **Distinct prompts per invoke**, so a wrong row is observable.
- **Negative control**: the result must *not* match any other invoke's gradient. Measured ~1.2 relative — four orders above the threshold.
- **Parametrised over which invoke takes the gradient**: first/last of two, and first/middle/last of three, so each batch-slice offset is exercised rather than only the final one.

## Does the new test have teeth?

Mutation test — force the gradient to always be read from batch row 0:

```diff
-shape, stride, offset = tensor.shape, tensor.stride(), tensor.storage_offset()
+shape, stride, offset = tensor.shape, tensor.stride(), 0  # MUTANT
```

```
new test vs mutant:
  FAILED ...test_backward_with_multiple_invokers[cpu-2-1]
  FAILED ...test_backward_with_multiple_invokers[cpu-3-1]
  FAILED ...test_backward_with_multiple_invokers[cpu-3-2]
  3 failed, 2 passed          <- exactly the cases whose target is not row 0

old test vs mutant:
  1 failed                    <- but it also failed without the mutant, so it
                                 cannot distinguish the two
```

## Result

Full CI test list on CPU, this branch:

```
248 passed, 2 skipped, 1 xpassed, 6 warnings in 146.87s
```

Green, with strictly more coverage than before (5 parametrised cases where there was 1).

Test-only change — no source files touched.

<sub>Run with `transformers` 5.15.1 / `torch` 2.9.1 on CPU.</sub>
