### PR TITLE
feat(backward): explain the freed autograd graph in terms of invokes

### DIFF
--- a/docs/gotchas/backward.md
+++ b/docs/gotchas/backward.md
@@ -3,7 +3,7 @@ title: Backward (Gradient) Pitfalls
 one_liner: Gradient tracing is a separate session — get .output values FIRST, .grad lives on tensors not modules, gradients flow in reverse.
 tags: [gotcha, backward, grad]
 related: [docs/usage/save.md, docs/concepts/threading-and-mediators.md]
-sources: [src/nnsight/intervention/tracing/backwards.py:69, src/nnsight/intervention/tracing/backwards.py:81, src/nnsight/__init__.py:154]
+sources: [src/nnsight/intervention/tracing/backwards.py:69, src/nnsight/intervention/tracing/backwards.py:81, src/nnsight/intervention/tracing/backwards.py:_explain_freed_graph, src/nnsight/intervention/batching.py, src/nnsight/__init__.py:154]
 ---
 
 # Backward (Gradient) Pitfalls
@@ -13,6 +13,7 @@ sources: [src/nnsight/intervention/tracing/backwards.py:69, src/nnsight/interven
 - `.grad` is on tensors, not modules. There's no `module.grad` — request gradients on the tensor you saved during the forward pass.
 - Gradient access order is the *reverse* of forward access order. If you accessed `h[5].output` then `h[10].output` on forward, request `.grad` for `h[10]`'s tensor before `h[5]`'s.
 - `retain_graph=True` is required if you call `.backward()` more than once on overlapping graphs.
+- All invokes in one trace share a single autograd graph, so one `.backward()` *per invoke* still counts as "more than once" — every invoke but the last needs `retain_graph=True`.
 - Standalone `with loss.backward():` outside any `model.trace()` works for simple cases — useful when you save the forward outputs first and want to inspect gradients afterward.
 
 ---
@@ -180,6 +181,60 @@ with model.trace("Hello"):
 
 ### Mitigation / how to spot it early
 - If you'll backward twice, the first call needs `retain_graph=True`. The last call doesn't (and skipping it frees memory).
+
+---
+
+## One `.backward()` per invoke still needs `retain_graph=True`
+
+### Symptom
+Each invoke calls `.backward()` exactly once, so nothing looks repeated — but the second invoke raises:
+
+```
+RuntimeError: The autograd graph for this trace has already been freed.
+
+Every invoke in a trace contributes to a single batched forward pass, so all
+invokes share one autograd graph. An earlier `.backward()` in the same trace
+freed the graph that this one needs.
+```
+
+### Cause
+Invokes are not separate runs. Every invoke's input is combined into **one** batch and the model is called **once** (`src/nnsight/intervention/batching.py`), so there is only one autograd graph for the whole trace. The first `.backward()` frees it and every later invoke is walking a graph that no longer exists.
+
+Before nnsight recognized this case you got autograd's raw message instead, which talks about backwarding "a second time" and never mentions invokes — so the obvious reading ("but I only called backward once here") sent people looking in the wrong place.
+
+### Wrong code
+```python
+with model.trace() as tracer:
+    with tracer.invoke(prompt_a):
+        x = model.transformer.h[5].output[0]
+        with model.lm_head.output.sum().backward():        # frees the graph
+            grad_a = x.grad.save()
+
+    with tracer.invoke(prompt_b):
+        y = model.transformer.h[5].output[0]
+        with model.lm_head.output.sum().backward():        # RuntimeError
+            grad_b = y.grad.save()
+```
+
+### Right code
+```python
+with model.trace() as tracer:
+    with tracer.invoke(prompt_a):
+        x = model.transformer.h[5].output[0]
+        with model.lm_head.output.sum().backward(retain_graph=True):
+            grad_a = x.grad.save()
+
+    with tracer.invoke(prompt_b):
+        y = model.transformer.h[5].output[0]
+        with model.lm_head.output.sum().backward():        # last one: let it free
+            grad_b = y.grad.save()
+```
+
+Each invoke still gets its own gradient — the loss inside an invoke is built from that invoke's slice of the batch, so backward only reaches its own rows.
+
+### Mitigation / how to spot it early
+- Count `.backward()` calls per **trace**, not per invoke. If the trace has more than one, all but the last need `retain_graph=True`.
+- If you don't need the gradients together, give each backward pass its own `model.trace()`. That frees the graph between passes and costs less memory than retaining it.
 
 ---
 

--- a/docs/gotchas/cross-invoke.md
+++ b/docs/gotchas/cross-invoke.md
@@ -14,6 +14,7 @@ sources: [src/nnsight/intervention/tracing/tracer.py:551, src/nnsight/interventi
 - `CONFIG.APP.CROSS_INVOKER` (default `True`) is what makes the cross-invoke variable flow happen at all. Setting it to `False` isolates each invoke (sometimes useful for debugging).
 - Empty `tracer.invoke()` (no positional args) operates on the entire batch from earlier invokes. It works on bare `NNsight` models because it does not call `_batch()`.
 - Decision rule: same module accessed in both invokes? → barrier. Different modules? → no barrier needed.
+- Invokes also share one **autograd graph**, so a `.backward()` in more than one invoke needs `retain_graph=True` on all but the last. See [backward.md](backward.md#one-backward-per-invoke-still-needs-retain_graphtrue).
 
 ---
 

--- a/src/nnsight/intervention/tracing/backwards.py
+++ b/src/nnsight/intervention/tracing/backwards.py
@@ -1,10 +1,86 @@
-from typing import Any, Callable
+from typing import Any, Callable, Optional, Tuple
 
 import torch
 
 from ...util import Patch
 from ..interleaver import Interleaver, Mediator
 from .invoker import Invoker
+
+# Autograd raises a bare ``RuntimeError`` when a freed graph is walked again;
+# there is no dedicated exception type or error code to match on.
+_GRAPH_FREED_MARKER = "backward through the graph a second time"
+
+_RETAIN_GRAPH_EXAMPLE = """    with model.trace() as tracer:
+        with tracer.invoke(prompt_a):
+            x = model.transformer.h[5].output[0]
+            with model.lm_head.output.sum().backward(retain_graph=True):
+                grad_a = x.grad.save()
+        with tracer.invoke(prompt_b):
+            y = model.transformer.h[5].output[0]
+            with model.lm_head.output.sum().backward():
+                grad_b = y.grad.save()"""
+
+
+def _retain_graph_requested(args: Tuple[Any, ...], kwargs: dict) -> bool:
+    """Whether this ``.backward()`` call asked for the graph to be retained.
+
+    Mirrors ``Tensor.backward(gradient=None, retain_graph=None, ...)``, so
+    ``retain_graph`` is the second positional parameter.
+    """
+
+    if "retain_graph" in kwargs:
+        return bool(kwargs["retain_graph"])
+
+    return len(args) > 1 and bool(args[1])
+
+
+def _explain_freed_graph(
+    error: RuntimeError, args: Tuple[Any, ...], kwargs: dict
+) -> Optional[RuntimeError]:
+    """Re-frame autograd's "graph freed" error in terms of nnsight's invokes.
+
+    Every invoke in a trace contributes to *one* batched forward pass, so they
+    also share one autograd graph. That makes a per-invoke ``.backward()`` look
+    independent when it is not: the first one frees the graph and the next
+    invoke fails inside ``torch.autograd``, with a message that never mentions
+    invokes and so reads as unrelated to the code that triggered it.
+
+    Returns ``None`` when the error is some other ``RuntimeError``, which the
+    caller then re-raises untouched.
+    """
+
+    if _GRAPH_FREED_MARKER not in str(error):
+        return None
+
+    if _retain_graph_requested(args, kwargs):
+        cause = (
+            "This `.backward()` passed `retain_graph=True`, so an earlier "
+            "`.backward()` in the same trace did not."
+        )
+    else:
+        cause = (
+            "An earlier `.backward()` in the same trace freed the graph that "
+            "this one needs."
+        )
+
+    lines = [
+        "The autograd graph for this trace has already been freed.",
+        "",
+        "Every invoke in a trace contributes to a single batched forward pass, "
+        "so all invokes share one autograd graph. " + cause,
+        "",
+        "Pass `retain_graph=True` to every `.backward()` except the last one:",
+        "",
+        _RETAIN_GRAPH_EXAMPLE,
+        "",
+        "The same applies to two `.backward()` calls inside one invoke. If you "
+        "do not need the gradients together, run each backward pass in its own "
+        "trace instead.",
+        "",
+        f"Original error from torch.autograd: {error}",
+    ]
+
+    return RuntimeError("\n".join(lines))
 
 
 def wrap_grad(interleaver: Interleaver):
@@ -152,6 +228,14 @@ class BackwardsTracer(Invoker):
             with interleaver:
                 self.fn(self.tensor, *self.args, **self.kwargs)
             interleaver.check_dangling_mediators()
+
+        except RuntimeError as error:
+            explained = _explain_freed_graph(error, self.args, self.kwargs)
+
+            if explained is None:
+                raise
+
+            raise explained from error
 
         finally:
             grad_patch.restore()

--- a/tests/test_backward_errors.py
+++ b/tests/test_backward_errors.py
@@ -1,0 +1,136 @@
+"""Tests for the diagnostics around a freed autograd graph.
+
+All invokes in a trace contribute to a single batched forward pass, so they
+also share a single autograd graph. One `.backward()` per invoke therefore
+still frees the graph for every invoke after it -- which surfaced as
+autograd's own "backward through the graph a second time" `RuntimeError`, a
+message that never mentions invokes and reads as unrelated to the code that
+triggered it.
+"""
+
+import pytest
+import torch
+
+import nnsight
+
+PROMPT_A = "The quick brown fox jumps"
+PROMPT_B = "Madison Square Garden is located in"
+
+
+def _rel_err(got: torch.Tensor, expected: torch.Tensor) -> float:
+    """Scale-free gradient comparison; batching left-pads the shorter prompt."""
+
+    length = min(got.shape[1], expected.shape[1])
+    got, expected = got[:, -length:], expected[:, -length:]
+
+    return ((got - expected).norm() / expected.norm()).item()
+
+
+def _single_invoke_grad(gpt2: nnsight.LanguageModel, prompt: str) -> torch.Tensor:
+    with gpt2.trace() as tracer:
+        with tracer.invoke(prompt):
+            x = gpt2.transformer.h[5].attn.c_proj.output
+            with gpt2.lm_head.output.sum().backward():
+                grad = x.grad.save()
+    return grad
+
+
+@pytest.mark.usefixtures("gpt2")
+class TestFreedGraphDiagnostic:
+    """The raised error must name the cause and the fix."""
+
+    def test_backward_in_two_invokes_explains_the_shared_graph(
+        self, gpt2: nnsight.LanguageModel
+    ):
+        with pytest.raises(Exception) as info:
+            with gpt2.trace() as tracer:
+                with tracer.invoke(PROMPT_A):
+                    x = gpt2.transformer.h[5].attn.c_proj.output
+                    with gpt2.lm_head.output.sum().backward():
+                        x.grad.save()
+                with tracer.invoke(PROMPT_B):
+                    y = gpt2.transformer.h[5].attn.c_proj.output
+                    with gpt2.lm_head.output.sum().backward():
+                        y.grad.save()
+
+        message = str(info.value)
+
+        # The cause, stated in nnsight's terms rather than autograd's.
+        assert "share one autograd graph" in message
+        assert "single batched forward pass" in message
+        # The fix, and the original error for anyone who needs it.
+        assert "retain_graph=True" in message
+        assert "Original error from torch.autograd" in message
+
+    def test_message_notes_when_retain_graph_was_already_passed(
+        self, gpt2: nnsight.LanguageModel
+    ):
+        # The failing call already retains; it is the *earlier* one that did not.
+        # The message should say so rather than suggesting a flag that is set.
+        with pytest.raises(Exception) as info:
+            with gpt2.trace() as tracer:
+                with tracer.invoke(PROMPT_A):
+                    x = gpt2.transformer.h[5].attn.c_proj.output
+                    with gpt2.lm_head.output.sum().backward():
+                        x.grad.save()
+                with tracer.invoke(PROMPT_B):
+                    y = gpt2.transformer.h[5].attn.c_proj.output
+                    with gpt2.lm_head.output.sum().backward(retain_graph=True):
+                        y.grad.save()
+
+        assert "did not" in str(info.value)
+
+    def test_unrelated_runtime_errors_are_not_reworded(
+        self, gpt2: nnsight.LanguageModel
+    ):
+        # Only the freed-graph message is translated; everything else must
+        # propagate with its own text intact.
+        with pytest.raises(Exception) as info:
+            with gpt2.trace(PROMPT_A):
+                logits = gpt2.lm_head.output
+                with logits.sum().backward(gradient=torch.zeros(3, 3)):
+                    pass
+
+        assert "share one autograd graph" not in str(info.value)
+
+
+@pytest.mark.usefixtures("gpt2")
+class TestRetainGraphAcrossInvokes:
+    """The documented fix must actually produce each invoke's own gradient."""
+
+    def test_retain_graph_on_all_but_last(self, gpt2: nnsight.LanguageModel):
+        reference_a = _single_invoke_grad(gpt2, PROMPT_A)
+        reference_b = _single_invoke_grad(gpt2, PROMPT_B)
+
+        with gpt2.trace() as tracer:
+            with tracer.invoke(PROMPT_A):
+                x = gpt2.transformer.h[5].attn.c_proj.output
+                with gpt2.lm_head.output.sum().backward(retain_graph=True):
+                    grad_a = x.grad.save()
+            with tracer.invoke(PROMPT_B):
+                y = gpt2.transformer.h[5].attn.c_proj.output
+                with gpt2.lm_head.output.sum().backward():
+                    grad_b = y.grad.save()
+
+        assert _rel_err(grad_a, reference_a) < 1e-4
+        assert _rel_err(grad_b, reference_b) < 1e-4
+
+        # Each invoke gets its own rows, not the other invoke's.
+        assert _rel_err(grad_a, reference_b) > 1e-2
+        assert _rel_err(grad_b, reference_a) > 1e-2
+
+    def test_three_invokes(self, gpt2: nnsight.LanguageModel):
+        prompts = [PROMPT_A, PROMPT_B, "A completely different sentence appears"]
+        references = [_single_invoke_grad(gpt2, prompt) for prompt in prompts]
+
+        grads = []
+        with gpt2.trace() as tracer:
+            for index, prompt in enumerate(prompts):
+                last = index == len(prompts) - 1
+                with tracer.invoke(prompt):
+                    x = gpt2.transformer.h[5].attn.c_proj.output
+                    with gpt2.lm_head.output.sum().backward(retain_graph=not last):
+                        grads.append(x.grad.save())
+
+        for index, (grad, reference) in enumerate(zip(grads, references)):
+            assert _rel_err(grad, reference) < 1e-4, f"invoke {index}"


### PR DESCRIPTION
## Summary

Calling `.backward()` in more than one invoke of a trace fails deep inside `torch.autograd`:

```python
with model.trace() as tracer:
    with tracer.invoke(prompt_a):
        x = model.transformer.h[5].attn.c_proj.output
        with model.lm_head.output.sum().backward():
            grad_a = x.grad.save()

    with tracer.invoke(prompt_b):
        y = model.transformer.h[5].attn.c_proj.output
        with model.lm_head.output.sum().backward():
            grad_b = y.grad.save()
```

```
RuntimeError: Trying to backward through the graph a second time (or directly
access saved tensors after they have already been freed). Saved intermediate
values of the graph are freed when you call .backward() or autograd.grad().
Specify retain_graph=True if you need to backward through the graph a second
time or if you need to access saved tensors after calling backward.
```

The message is accurate but points away from the cause. Each invoke calls `.backward()` exactly **once**, so "a second time" reads as describing someone else's code. And the real reason is a fact about nnsight, not about torch: **invokes are not separate runs.** Every invoke's input is combined into one batch and the model is called once, so the whole trace has a single autograd graph — and the first `.backward()` frees it for every invoke after it.

`docs/gotchas/backward.md` did cover `retain_graph`, but framed as "if you call `.backward()` more than once on overlapping graphs". One backward per invoke does not read as that, which is exactly why this is worth a dedicated diagnostic.

## Changes

**`_explain_freed_graph`** translates that one error. It matches autograd's message — a bare `RuntimeError` with no exception type or code to key off, so string matching is the only option, and it is narrow — then states the cause in nnsight's terms and shows the fix, keeping torch's original text appended:

```
RuntimeError: The autograd graph for this trace has already been freed.

Every invoke in a trace contributes to a single batched forward pass, so all
invokes share one autograd graph. An earlier `.backward()` in the same trace
freed the graph that this one needs.

Pass `retain_graph=True` to every `.backward()` except the last one:

    with model.trace() as tracer:
        with tracer.invoke(prompt_a):
            x = model.transformer.h[5].output[0]
            with model.lm_head.output.sum().backward(retain_graph=True):
                grad_a = x.grad.save()
        with tracer.invoke(prompt_b):
            y = model.transformer.h[5].output[0]
            with model.lm_head.output.sum().backward():
                grad_b = y.grad.save()

The same applies to two `.backward()` calls inside one invoke. If you do not
need the gradients together, run each backward pass in its own trace instead.

Original error from torch.autograd: Trying to backward through the graph a
second time ...
```

When the *failing* call already passed `retain_graph=True`, the message says the earlier one did not, rather than suggesting a flag that is already set. Any other `RuntimeError` is re-raised untouched.

**Docs**: adds the cross-invoke case as its own section in `docs/gotchas/backward.md` (symptom / cause / wrong code / right code / mitigation, matching the file's existing shape) and points at it from the `cross-invoke.md` TL;DR.

## Behaviour is unchanged

`retain_graph=True` across invokes already worked; it just wasn't discoverable. The tests pin that it produces each invoke's **own** gradient, against per-prompt single-invoke references:

- matching invoke: relative error ~1e-5
- every other invoke: ~1.2

for both two and three invokes.

## Not fixed here

nnsight could retain the graph implicitly for all but the last invoke and make the whole thing disappear. That trades peak memory for convenience on every batched trace and changes a default, so it felt like a maintainer's call rather than something to fold into an error message. Happy to follow up if you'd prefer that.

## Verification

`tests/test_backward_errors.py`, 5 tests — 2 fail on `dev`, all 5 pass here. Covers: the cause and fix appear in the message; the already-retaining variant; an unrelated `RuntimeError` is *not* reworded; `retain_graph` across two and three invokes yields the correct per-invoke gradients.

Full CI test list on CPU: `1 failed, 248 passed`. The one failure is `test_lm.py::TestGradients::test_backward_with_multiple_invokers`, already red on `dev` and `main` and unrelated to this change (addressed in #693).

<sub>Run with `transformers` 5.15.1 / `torch` 2.9.1 on CPU.</sub>
