### PR TITLE
test(serialization): make the serialization suite runnable and add it to CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -45,4 +45,8 @@ jobs:
           tests/test_mutual_recursion.py \
           tests/test_local_env.py \
           tests/test_local_simulation.py \
+          tests/test_dataclass_serialization.py \
+          tests/test_lambda_serialization.py \
+          tests/test_serialization_edge_cases.py \
+          tests/test_whitelist_serialization.py \
           --device cpu

--- a/src/nnsight/intervention/serialization.py
+++ b/src/nnsight/intervention/serialization.py
@@ -823,11 +823,18 @@ class CustomCloudPickler(cloudpickle.Pickler):
             if k in func_globals:
                 base_globals[k] = func_globals[k]
 
-        # SECURITY CHECK: Check function globals for prohibited modules/functions.
-        # This catches dangerous patterns like `import os; os.getcwd()` or
-        # `from subprocess import run; run(...)` where the prohibited object
-        # is captured in the function's globals.
-        captured_globals = slotstate.get("__globals__", {})
+        # NOTE: there is no prohibited-module check here. A lint-time blacklist
+        # (`PROHIBITED_MODULES` / `PROHIBITED_BUILTINS`, raising
+        # `PicklingProhibitedError`) used to run at this point and reject
+        # functions whose globals captured `os`, `subprocess`, `eval` and
+        # similar before they were serialized for NDIF. It is gone, along with
+        # the comment that used to describe it and a `captured_globals` local
+        # that nothing read -- which together left this reading as though the
+        # check were still here. Real sandboxing is server-side; if the
+        # client-side lint is wanted back it belongs on `slotstate["__globals__"]`
+        # right here, and the tests for it are already written (the
+        # `test_prohibited_*` cases in tests/test_serialization_edge_cases.py,
+        # currently skipped).
 
         # CLOSURE: Extract closure values and names.
         # For recursive/mutually recursive local functions, the closure may contain

--- a/tests/test_serialization_edge_cases.py
+++ b/tests/test_serialization_edge_cases.py
@@ -16,7 +16,31 @@ import torch
 
 sys.path.insert(0, "tests")
 
+from nnsight.intervention import serialization
 from nnsight.intervention.serialization import dumps, loads
+
+
+def _prohibited_error():
+    """``PicklingProhibitedError``, or skip if the lint check is not present.
+
+    ``PROHIBITED_MODULES`` / ``PROHIBITED_BUILTINS`` and their
+    ``PicklingProhibitedError`` were a lint-time check that raised before code
+    referencing ``os``, ``subprocess``, ``eval`` and friends was serialized for
+    NDIF. They are no longer in ``serialization.py``. Importing the exception at
+    call time -- and skipping rather than erroring -- keeps the rest of this
+    module collectable and makes these seven tests come back on their own if
+    the check is restored, instead of failing as ImportErrors that nothing runs.
+    """
+
+    error = getattr(serialization, "PicklingProhibitedError", None)
+
+    if error is None:
+        pytest.skip(
+            "serialization.PicklingProhibitedError is not present; the "
+            "lint-time prohibited-module check is not currently implemented"
+        )
+
+    return error
 
 
 def test_deserialized_helper_trace_uses_registered_linecache(tiny_model, tmp_path):
@@ -781,7 +805,7 @@ def test_imported_function_in_trace(tiny_model):
 
 def test_prohibited_module_os():
     """Test that functions using 'os' module are blocked."""
-    from nnsight.intervention.serialization import PicklingProhibitedError
+    PicklingProhibitedError = _prohibited_error()
     import os
 
     def dangerous_func():
@@ -801,7 +825,7 @@ def test_prohibited_module_os():
 
 def test_prohibited_module_subprocess():
     """Test that functions using 'subprocess' module are blocked."""
-    from nnsight.intervention.serialization import PicklingProhibitedError
+    PicklingProhibitedError = _prohibited_error()
     import subprocess
 
     def dangerous_func():
@@ -814,7 +838,7 @@ def test_prohibited_module_subprocess():
 
 def test_prohibited_module_socket():
     """Test that functions using 'socket' module are blocked."""
-    from nnsight.intervention.serialization import PicklingProhibitedError
+    PicklingProhibitedError = _prohibited_error()
     import socket
 
     def dangerous_func():
@@ -827,7 +851,7 @@ def test_prohibited_module_socket():
 
 def test_prohibited_module_shutil():
     """Test that functions using 'shutil' module are blocked."""
-    from nnsight.intervention.serialization import PicklingProhibitedError
+    PicklingProhibitedError = _prohibited_error()
     import shutil
 
     def dangerous_func():
@@ -864,7 +888,7 @@ def test_whitelisted_module_math():
 
 def test_prohibited_builtin_eval():
     """Test that functions referencing 'eval' builtin are blocked."""
-    from nnsight.intervention.serialization import PicklingProhibitedError
+    PicklingProhibitedError = _prohibited_error()
 
     # Capture eval as a closure variable
     dangerous_eval = eval
@@ -879,7 +903,7 @@ def test_prohibited_builtin_eval():
 
 def test_prohibited_builtin_exec():
     """Test that functions referencing 'exec' builtin are blocked."""
-    from nnsight.intervention.serialization import PicklingProhibitedError
+    PicklingProhibitedError = _prohibited_error()
 
     dangerous_exec = exec
 
@@ -896,7 +920,7 @@ def test_prohibited_builtin_open():
 
     Note: open() comes from the _io module (C implementation), not builtins.
     """
-    from nnsight.intervention.serialization import PicklingProhibitedError
+    PicklingProhibitedError = _prohibited_error()
 
     dangerous_open = open
 

--- a/tests/test_whitelist_serialization.py
+++ b/tests/test_whitelist_serialization.py
@@ -17,12 +17,86 @@ import torch
 sys.path.insert(0, "tests")
 
 from nnsight import LanguageModel
-from nnsight.intervention.serialization import (
-    SERVER_MODULES_WHITELIST,
-    _is_whitelisted_module,
-    dumps,
-    loads,
-)
+from nnsight.intervention import serialization
+from nnsight.intervention.serialization import dumps, loads
+
+
+def _whitelist_api():
+    """The module whitelist, or skip if it is no longer part of the API.
+
+    ``SERVER_MODULES_WHITELIST`` / ``_is_whitelisted_module`` were dropped from
+    ``serialization.py``. Importing them at module scope made all 12 tests in
+    this file an ImportError at collection -- including the nine that test
+    source serialization, which still works. Resolve them per-test instead, so
+    the rest of the file runs and these three come back automatically if the
+    API returns.
+    """
+
+    whitelist = getattr(serialization, "SERVER_MODULES_WHITELIST", None)
+    predicate = getattr(serialization, "_is_whitelisted_module", None)
+
+    if whitelist is None or predicate is None:
+        pytest.skip(
+            "serialization.SERVER_MODULES_WHITELIST / _is_whitelisted_module "
+            "are no longer part of the API"
+        )
+
+    return whitelist, predicate
+
+
+@pytest.fixture
+def registered_mymethods():
+    """Register ``mymethods`` by value for the duration of one test.
+
+    Serializing by source is opt-in: ``dumps`` emits a by-reference GLOBAL
+    (47 bytes, no source) until the owning module is registered, and the full
+    definition (887 bytes) once it is. The remote backend registers local
+    modules for you via ``get_local_env()`` before it calls ``dumps``, so the
+    registered state is what a remote trace actually serializes under.
+
+    ``register`` mutates a process-global set in cloudpickle, so without this
+    fixture the tests below only passed when an earlier test in the same
+    session happened to have registered the module first -- each of them
+    failed when run alone. Registration is undone on teardown so neither
+    ordering nor leakage can decide the result.
+    """
+
+    import mymethods.stateful
+    from cloudpickle.cloudpickle import unregister_pickle_by_value
+
+    from nnsight.ndif import register
+
+    register(mymethods.stateful)
+    try:
+        yield mymethods.stateful
+    finally:
+        unregister_pickle_by_value(mymethods.stateful)
+
+
+@pytest.fixture
+def unregistered_mymethods():
+    """Guarantee ``mymethods`` is *not* registered for the duration of one test.
+
+    Any trace in this session calls ``get_local_env()``, which registers local
+    modules process-wide, so by the time a later test runs the module is
+    already registered. Lift those entries out of cloudpickle's global set and
+    put them back on teardown, so the by-reference case can be asserted no
+    matter where in the file it runs.
+    """
+
+    import mymethods.stateful  # noqa: F401  (ensure the module is importable)
+    from cloudpickle.cloudpickle import _PICKLE_BY_VALUE_MODULES
+
+    removed = {
+        name
+        for name in _PICKLE_BY_VALUE_MODULES
+        if name == "mymethods" or name.startswith("mymethods.")
+    }
+    _PICKLE_BY_VALUE_MODULES.difference_update(removed)
+    try:
+        yield
+    finally:
+        _PICKLE_BY_VALUE_MODULES.update(removed)
 
 
 # =============================================================================
@@ -32,6 +106,8 @@ from nnsight.intervention.serialization import (
 
 def test_whitelisted_modules():
     """Test that core modules are in the whitelist."""
+    _, _is_whitelisted_module = _whitelist_api()
+
     assert _is_whitelisted_module("torch")
     assert _is_whitelisted_module("torch.nn")
     assert _is_whitelisted_module("torch.nn.functional")
@@ -42,6 +118,8 @@ def test_whitelisted_modules():
 
 def test_non_whitelisted_modules():
     """Test that user modules are NOT in the whitelist."""
+    _, _is_whitelisted_module = _whitelist_api()
+
     assert not _is_whitelisted_module("mymethods")
     assert not _is_whitelisted_module("mymethods.stateful")
     assert not _is_whitelisted_module("myproject")
@@ -50,6 +128,8 @@ def test_non_whitelisted_modules():
 
 def test_whitelist_includes_submodules():
     """Test that submodules of whitelisted packages are also whitelisted."""
+    _, _is_whitelisted_module = _whitelist_api()
+
     # torch submodules
     assert _is_whitelisted_module("torch.cuda")
     assert _is_whitelisted_module("torch.distributed")
@@ -65,7 +145,7 @@ def test_whitelist_includes_submodules():
 # =============================================================================
 
 
-def test_non_whitelisted_function_serialized_by_source():
+def test_non_whitelisted_function_serialized_by_source(registered_mymethods):
     """Test that functions from non-whitelisted modules are serialized by source."""
     from mymethods.stateful import normalize
 
@@ -86,7 +166,7 @@ def test_non_whitelisted_function_serialized_by_source():
     assert torch.allclose(norms, torch.ones_like(norms), atol=1e-5)
 
 
-def test_non_whitelisted_class_serialized_by_source():
+def test_non_whitelisted_class_serialized_by_source(registered_mymethods):
     """Test that classes from non-whitelisted modules can be serialized.
 
     Cloudpickle serializes classes using _make_skeleton_class with method
@@ -112,7 +192,7 @@ def test_non_whitelisted_class_serialized_by_source():
     assert stats.count == 2
 
 
-def test_non_whitelisted_instance_serialized_by_source():
+def test_non_whitelisted_instance_serialized_by_source(registered_mymethods):
     """Test that instances from non-whitelisted modules can be serialized.
 
     We verify that:
@@ -230,7 +310,7 @@ def test_module_state_isolation(tiny_model):
 
 
 @torch.no_grad()
-def test_serialization_includes_module_functions(tiny_model):
+def test_serialization_includes_module_functions(tiny_model, registered_mymethods):
     """Test that module-level functions are included in serialization."""
     from mymethods.stateful import normalize, get_call_count
 
@@ -247,27 +327,42 @@ def test_serialization_includes_module_functions(tiny_model):
     # This is a key difference from whole-module serialization
 
 
-def test_no_register_needed():
-    """Test that register() is no longer needed for user modules.
+def test_unregistered_module_is_serialized_by_reference(unregistered_mymethods):
+    """An unregistered local module pickles as a GLOBAL, with no source.
 
-    Previously, users had to call register(mymodule) before using functions
-    from that module in remote execution. With whitelist-based serialization,
-    this is no longer necessary.
+    This is the other half of the contract, and the reason the tests above
+    need an explicit fixture. It is asserted here on purpose rather than left
+    to whichever test happens to run first.
     """
-    # Import without calling register()
+    import mymethods.stateful
+
+    data = dumps(mymethods.stateful.normalize)
+
+    assert b"def normalize" not in data
+    # A by-reference pickle names the module and attribute and nothing else.
+    assert b"mymethods.stateful" in data
+    assert b"normalize" in data
+
+
+def test_register_switches_to_serialization_by_value(registered_mymethods):
+    """`register()` is what makes a local module's source travel with the job.
+
+    Named for what it checks: the previous version of this test asserted that
+    `register()` was unnecessary, which was true only under the whitelist
+    design that has since been removed. Without registration `dumps` emits a
+    GLOBAL the server cannot import.
+    """
     from mymethods.stateful import normalize
 
-    # Serialize - should work without register()
     data = dumps(normalize)
 
-    # Should contain source code
     assert b"def normalize" in data
 
-    # Deserialize should work
     restored = loads(data)
     x = torch.randn(3, 4)
     result = restored(x)
     assert result.shape == x.shape
+    assert torch.allclose(result.norm(dim=-1), torch.ones(3), atol=1e-5)
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

The four serialization test files are not in the CI list, and two of them had stopped working entirely without anyone noticing. This makes the suite runnable, removes the order-dependence in it, corrects a comment in `serialization.py` that claims a check which isn't there, and adds all four files to CI.

Found while checking which test files CI does *not* cover.

## What was broken

**1. `test_whitelist_serialization.py` did not collect at all.**

```
ImportError: cannot import name 'SERVER_MODULES_WHITELIST' from
'nnsight.intervention.serialization'
```

`SERVER_MODULES_WHITELIST` / `_is_whitelisted_module` were imported at module scope, so their removal took **all 12 tests** in the file down — including the nine that test source serialization and still pass. Seven tests in `test_serialization_edge_cases.py` failed the same way on `PicklingProhibitedError`.

Both are now resolved per-test and **skip with a stated reason** rather than erroring at import. The rest of each file runs, and these come back automatically if the APIs return — which felt better than deleting the maintainers' intent.

**2. Four tests were order-dependent and passed by accident.**

`test_no_register_needed`, `test_serialization_includes_module_functions`, and the two `*_serialized_by_source` tests all assert `b"def normalize" in dumps(normalize)`. Serializing by source is opt-in:

```
before register: 47 bytes, source embedded = False
after  register: 887 bytes, source embedded = True
```

`register` mutates a process-global set in cloudpickle (`_PICKLE_BY_VALUE_MODULES`), and every trace calls `get_local_env()`, which registers local modules. So these four passed in a whole-file run — and **every one of them failed when run alone**:

```
test_non_whitelisted_function_serialized_by_source  -> 1 failed
test_serialization_includes_module_functions        -> 1 failed
test_no_register_needed                             -> 1 failed
test_non_whitelisted_class_serialized_by_source     -> 1 failed
```

They now use a fixture that registers and unregisters around each test. A second fixture lifts the entries back out of the global set so the by-reference half of the contract can be asserted wherever in the file it runs. **Every test in the file now passes (or skips) in its own process.**

**3. `test_no_register_needed` asserted the opposite of current behaviour.**

Its premise — that `register()` is unnecessary — was true under the whitelist design that has since been removed. Without registration, `dumps` emits a GLOBAL the server cannot import, which is the `ModuleNotFoundError` that `docs/remote/register-local-modules.md` exists to prevent. Replaced with two tests that pin the real contract in both directions:

- `test_register_switches_to_serialization_by_value` — registration is what makes source travel with the job
- `test_unregistered_module_is_serialized_by_reference` — without it, the payload is a bare `GLOBAL mymethods.stateful normalize`

**4. `serialization.py` claimed a security check it no longer performs.**

```python
# SECURITY CHECK: Check function globals for prohibited modules/functions.
# This catches dangerous patterns like `import os; os.getcwd()` or
# `from subprocess import run; run(...)` where the prohibited object
# is captured in the function's globals.
captured_globals = slotstate.get("__globals__", {})

# CLOSURE: Extract closure values and names.
```

`captured_globals` is assigned and never read — it is the only remaining trace of the lint-time blacklist added in ccb1702c. Left as-is, this reads to anyone auditing the remote path as though input is being validated there. Replaced with a note stating the check is absent, where it would go, and that its tests are already written.

I have **not** restored the blacklist itself — see #695 for that question. It would start rejecting user code that references `pathlib`, `io`, `glob` and friends, which is a policy call rather than something to slip into a test-coverage PR.

## Result

```
before:  248 tests in CI
after:   323 passed, 12 skipped, 1 xpassed
```

75 previously-unrun tests, covering the path that ships user code to NDIF.

> [!NOTE]
> The CI run will stay red until #693 lands. `test_lm.py::TestGradients::test_backward_with_multiple_invokers` is already failing on `dev` and `main` and is unrelated to this change. Happy to rebase this on top of #693, or to drop the workflow change into a follow-up if you'd rather land the test repairs first.

<sub>Run with `transformers` 5.15.1 / `torch` 2.9.1 / `cloudpickle` 3.1.2 on CPU.</sub>
