### PR TITLE
fix(serialization): find the function's symtable child by type, not by count (Python 3.14)

### DIFF
--- a/src/nnsight/intervention/serialization.py
+++ b/src/nnsight/intervention/serialization.py
@@ -210,12 +210,20 @@ def _function_referenced_names(source: str) -> set[str]:
         return names
 
     top = symtable.symtable(source, "<sourced>", "exec")
-    # The source is one `def` (or `lambda`) at module level; its own table is the
-    # single child. Anything else, fall back to the block rule rather than guess.
-    children = top.get_children()
-    if len(children) != 1:
+    # The source is one `def` (or `lambda`) at module level, so exactly one child
+    # table is a function. Select it by type rather than by counting children:
+    # under PEP 649 (3.14+) every `def` also gets an `__annotate__` table of type
+    # "annotation", and PEP 695 generics add a "type_parameters" table, so a
+    # single `def` yields two or more children. Counting them sent every `def` to
+    # the block rule instead -- silently reinstating the capture this function
+    # exists to prevent. Anything other than exactly one function table, fall
+    # back rather than guess.
+    functions = [
+        child for child in top.get_children() if child.get_type() == "function"
+    ]
+    if len(functions) != 1:
         return _referenced_names(source)
-    return globals_of(children[0])
+    return globals_of(functions[0])
 
 
 def code_reduce(source: str, globals: dict, locals: dict, function: bool = False) -> tuple:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -135,6 +135,56 @@ class TestScopeFiltering:
         _, used_globals, _ = code_reduce(source, {"counter": 0}, {}, function=True)
         assert used_globals == {"counter": 0}
 
+    @pytest.mark.parametrize(
+        "source",
+        [
+            pytest.param("def f(x):\n    return g(x)\n", id="plain"),
+            pytest.param("def f(x: int) -> int:\n    return g(x)\n", id="annotated"),
+            pytest.param("def f(x=1):\n    return g(x)\n", id="default"),
+            pytest.param("f = lambda x: g(x)\n", id="lambda"),
+        ],
+    )
+    def test_scope_filter_survives_extra_symtable_children(self, source):
+        """The function's own symtable child must be found by type, not by count.
+
+        A single ``def`` does not yield a single child table on every Python.
+        Under PEP 649 (3.14+) it also gets an ``__annotate__`` table -- with or
+        without annotations present -- and PEP 695 generics add a
+        ``type_parameters`` table. Selecting the child by counting meant every
+        ``def`` fell through to the block rule on 3.14, so the whole filter was
+        silently inert there while the 3.12 CI runner stayed green.
+
+        ``x`` is the parameter, so it is local no matter what: if it ships, the
+        filter was bypassed.
+        """
+        _, used_globals, _ = code_reduce(
+            source, {"g": "g-mod", "x": "stale"}, {}, function=True
+        )
+
+        assert used_globals == {"g": "g-mod"}
+
+    def test_function_local_shadowing_an_unpicklable_global(self, tmp_path):
+        """End-to-end: the payload must not capture an unpicklable shadowed name.
+
+        This is the failure the filter was written for. A closed file cannot be
+        pickled at all, so capturing the enclosing scope's ``f`` does not merely
+        bloat the payload -- serializing it raises.
+        """
+        handle = open(tmp_path / "left-over.txt", "w")
+        handle.close()
+
+        source = (
+            "def load(path):\n"
+            "    with open(path) as f:\n"
+            "        return f.read()\n"
+        )
+
+        _, used_globals, _ = code_reduce(source, {"f": handle}, {}, function=True)
+
+        assert "f" not in used_globals
+        # Nothing left that pickle would choke on.
+        dumps(used_globals)
+
 
 class TestLambda:
     def test_simple_lambda(self):


### PR DESCRIPTION
Rebased onto `0.8` as requested in #696. This one is a bug I hit *because* I moved over — it is specific to 0.8 and not present on `dev`.

## Summary

`_function_referenced_names` filters a `def`'s serialized payload down to the names its body actually needs from outside it. Its own docstring gives the reason:

> a helper doing `with open(path) as f:` would drag in whatever `f` a notebook cell left lying around, and a closed file can't be pickled at all ("Cannot pickle closed files")

It located the function's `symtable` entry by counting children:

```python
children = top.get_children()
if len(children) != 1:
    return _referenced_names(source)   # block rule — captures locals
return globals_of(children[0])
```

A single module-level `def` does not produce a single child table on every Python. Under **PEP 649 (3.14+)** it also gets an `__annotate__` table — whether or not the `def` is annotated:

```pycon
>>> import symtable
>>> [(c.get_name(), c.get_type()) for c in symtable.symtable(
...     "def f(x):\n    return g(x)\n", "<s>", "exec").get_children()]
[('__annotate__', 'annotation'), ('f', 'function')]
```

So on 3.14 the guard is true for **every** `def`, the fallback runs every time, and the filter is inert — reinstating exactly the capture it exists to stop. PEP 695 generics add a `type_parameters` table for the same reason. Note `children[0]` is also the wrong table by then, so dropping the guard alone would not have been enough.

## Why CI didn't catch it

The two tests that already cover this — `test_function_locals_are_not_shipped` and `test_function_globals_still_ship` — **fail on 3.14 today**:

```
FAILED tests/test_serialization.py::TestScopeFiltering::test_function_locals_are_not_shipped
E   AssertionError: assert 'f' not in {'f': 'a-closed-file', 'json': 'json-mod', 'open': 'builtin'}

FAILED tests/test_serialization.py::TestScopeFiltering::test_function_globals_still_ship
E   Left contains 2 more items: {'x': 'stale', 'xs': 'stale'}
```

`.github/workflows/python-app.yml` runs Python 3.12, where PEP 649 is not active, so nothing surfaced it. `pyproject.toml` lists 3.14 as supported (`Programming Language :: Python :: 3.14`), so this is in scope rather than a future concern.

## Fix

Select the one child whose `get_type()` is `"function"`. That covers `def` and `lambda`, and is stable across versions — it does not care how many non-function tables a given Python decides to emit.

## Tests

- `test_scope_filter_survives_extra_symtable_children` — parametrised over plain / annotated / defaulted `def` and a lambda. `x` is the parameter, so it is local no matter what; if it ships, the filter was bypassed. (The lambda case passes without the fix — lambdas still yield one child — which is why it is worth pinning alongside the others.)
- `test_function_local_shadowing_an_unpicklable_global` — the original symptom end to end: a closed file handle in the enclosing scope, shadowed by a `with ... as f:` local. Capturing it doesn't merely bloat the payload; serializing raises.

## Result

Without the fix, **6 of 15** `TestScopeFiltering` tests fail on 3.14. With it, the full CPU suite is green:

```
856 passed, 7 skipped, 27 warnings
```

<sub>`0.8` @ 1f974f0, Python 3.14.3, `transformers` 5.15.1, `torch` 2.9.1, CPU. Also confirmed the fix is a no-op on the 3.12 path (one function table either way).</sub>
