### PR TITLE
fix(envoy): reject a `rename` alias that would shadow something

### DIFF
--- a/docs/usage/rename-modules.md
+++ b/docs/usage/rename-modules.md
@@ -122,9 +122,10 @@ You can also index a renamed `ModuleList` entry by its alias string:
   there is no post-hoc alias API.
 - **An alias that would shadow something raises at construction.** Aliases bind
   as plain attributes, so a name that is already taken — an `Envoy` attribute
-  (`output`, `input`, `trace`, ...), a sibling module, or an alias an earlier
-  key already claimed — would leave the original in the tree but unreachable by
-  name. That is reported when the model is built rather than surfacing later as
+  (`output`, `input`, `trace`, ...), a sibling module, an alias an earlier key
+  already claimed, or a name on the **wrapped model** (`config`, `weight`,
+  `eval`, and every other `nn.Module` attribute) — would leave the original
+  reachable only through the tree, not by name. That is reported when the model is built rather than surfacing later as
   an intervention landing on the wrong module:
 
   ```

--- a/docs/usage/rename-modules.md
+++ b/docs/usage/rename-modules.md
@@ -115,10 +115,25 @@ You can also index a renamed `ModuleList` entry by its alias string:
 
 - **Aliases bind on every envoy where the key resolves** — a single-component key
   (`{"mlp": "my_mlp"}`) renames the `mlp` on *every* block, not just the first.
+- **A key that names nothing is skipped, not an error.** That is what lets one
+  `rename` cover architectures that spell a module differently:
+  `{"attn": "att", "self_attn": "att"}` binds whichever of the two exists.
 - **Pass `rename=` at construction.** Aliases are bound during `Envoy.__init__`;
   there is no post-hoc alias API.
-- **Avoid alias names that collide with Envoy attributes** (`output`, `input`,
-  `trace`, ...). They will shadow or be shadowed by those attributes.
+- **An alias that would shadow something raises at construction.** Aliases bind
+  as plain attributes, so a name that is already taken — an `Envoy` attribute
+  (`output`, `input`, `trace`, ...), a sibling module, or an alias an earlier
+  key already claimed — would leave the original in the tree but unreachable by
+  name. That is reported when the model is built rather than surfacing later as
+  an intervention landing on the wrong module:
+
+  ```
+  ValueError: `rename` alias 'embed' for 'head' would shadow a child module of
+  that name on `model`. ...
+  ```
+
+  Aliasing a key to its own name (`{"attn": "attn"}`) is a no-op, not a
+  collision, so it stays usable alongside the cross-architecture pattern above.
 - **A dotted key mounts on the root; a leading-dot key mounts where it resolves.**
   Pick the form that matches where you want to reach the alias.
 

--- a/src/nnsight/intervention/envoy.py
+++ b/src/nnsight/intervention/envoy.py
@@ -231,6 +231,47 @@ class Envoy:
         # nothing more to override.
         self.__dict__[name] = envoy
 
+    def _alias_conflict(self, alias: str, path: str, target: Envoy) -> str | None:
+        """What ``alias`` would displace on this envoy, or ``None`` if nothing.
+
+        Aliases are bound with `object.__setattr__`, which overwrites whatever
+        name is already there without a word. Three things can be underneath:
+
+        * **Another alias** from an earlier ``rename`` entry whose key also
+          resolved here. The dict is self-contradictory -- one path silently wins
+          by insertion order.
+        * **A child envoy.** The child stays in the tree, but its own name now
+          reads as the aliased module, so an intervention written against it
+          lands somewhere else and nothing says so.
+        * **An `Envoy` attribute** (``output``, ``trace``, ``source``, ...).
+          Shadowing ``trace`` breaks ``model.trace(...)`` itself, surfacing much
+          later as a ``TypeError`` about context managers.
+
+        Returns a description of the conflict for the caller to raise with.
+        """
+
+        # Already pointing at this very envoy: nothing is displaced. Covers a
+        # key aliased to its own name (``{"attn": "attn"}``, which a cross-
+        # architecture dict pairs with ``{"self_attn": "attn"}``), two keys that
+        # reach one module (tied weights), and the binding being re-applied.
+        if self.__dict__.get(alias) is target:
+            return None
+
+        existing_path = self._aliases.get(alias)
+        if existing_path is not None:
+            return f"the alias already bound here from {existing_path!r}"
+
+        if isinstance(self.__dict__.get(alias), Envoy):
+            return "a child module of that name"
+
+        # Walk the MRO's own namespaces rather than `hasattr`, so an eproperty
+        # is found without its `__get__` running (reading `.output` outside
+        # interleaving raises).
+        if any(alias in vars(klass) for klass in type(self).__mro__):
+            return f"the `{type(self).__name__}.{alias}` attribute"
+
+        return None
+
     def _bind_aliases(self) -> None:
         """Bind each ``rename`` alias as an attribute pointing at the same Envoy.
 
@@ -242,6 +283,14 @@ class Envoy:
         ``"transformer.h.3.mlp"`` binds only on the envoy it resolves from. A
         leading dot is a no-op — path components are matched by name (an empty
         first component is skipped, mirroring `nnsight.util.fetch_attr`).
+
+        A key that does not resolve here is skipped, not an error: one ``rename``
+        is meant to be reusable across architectures that spell the same module
+        differently (``{"attn": "att", "self_attn": "att"}``), and on any given
+        envoy only one of those spellings exists.
+
+        An alias that would *displace* something is an error, because there is no
+        spelling of it that works — see `_alias_conflict`.
 
         Aliases are ordinary attributes referencing the *same* child object (not
         copies, and not added to `_children`), so ``__getattr__`` needs no
@@ -259,6 +308,15 @@ class Envoy:
             if not isinstance(target, Envoy):
                 continue
             for alias in [aliases] if isinstance(aliases, str) else aliases:
+                conflict = self._alias_conflict(alias, path, target)
+                if conflict is not None:
+                    raise ValueError(
+                        f"`rename` alias {alias!r} for {path!r} would shadow "
+                        f"{conflict} on `{self.path}`. Aliases are bound as plain "
+                        f"attributes, so this would make the original unreachable "
+                        f"by name while leaving it in the tree. Pick a different "
+                        f"alias."
+                    )
                 object.__setattr__(self, alias, target)
                 self._aliases[alias] = path
 

--- a/src/nnsight/intervention/envoy.py
+++ b/src/nnsight/intervention/envoy.py
@@ -232,47 +232,6 @@ class Envoy:
         # nothing more to override.
         self.__dict__[name] = envoy
 
-    def _alias_conflict(self, alias: str, path: str, target: Envoy) -> str | None:
-        """What ``alias`` would displace on this envoy, or ``None`` if nothing.
-
-        Aliases are bound with `object.__setattr__`, which overwrites whatever
-        name is already there without a word. Three things can be underneath:
-
-        * **Another alias** from an earlier ``rename`` entry whose key also
-          resolved here. The dict is self-contradictory -- one path silently wins
-          by insertion order.
-        * **A child envoy.** The child stays in the tree, but its own name now
-          reads as the aliased module, so an intervention written against it
-          lands somewhere else and nothing says so.
-        * **An `Envoy` attribute** (``output``, ``trace``, ``source``, ...).
-          Shadowing ``trace`` breaks ``model.trace(...)`` itself, surfacing much
-          later as a ``TypeError`` about context managers.
-
-        Returns a description of the conflict for the caller to raise with.
-        """
-
-        # Already pointing at this very envoy: nothing is displaced. Covers a
-        # key aliased to its own name (``{"attn": "attn"}``, which a cross-
-        # architecture dict pairs with ``{"self_attn": "attn"}``), two keys that
-        # reach one module (tied weights), and the binding being re-applied.
-        if self.__dict__.get(alias) is target:
-            return None
-
-        existing_path = self._aliases.get(alias)
-        if existing_path is not None:
-            return f"the alias already bound here from {existing_path!r}"
-
-        if isinstance(self.__dict__.get(alias), Envoy):
-            return "a child module of that name"
-
-        # Walk the MRO's own namespaces rather than `hasattr`, so an eproperty
-        # is found without its `__get__` running (reading `.output` outside
-        # interleaving raises).
-        if any(alias in vars(klass) for klass in type(self).__mro__):
-            return f"the `{type(self).__name__}.{alias}` attribute"
-
-        return None
-
     def _bind_aliases(self) -> None:
         """Bind each ``rename`` alias as an attribute pointing at the same Envoy.
 
@@ -290,8 +249,13 @@ class Envoy:
         differently (``{"attn": "att", "self_attn": "att"}``), and on any given
         envoy only one of those spellings exists.
 
-        An alias that would *displace* something is an error, because there is no
-        spelling of it that works — see `_alias_conflict`.
+        An alias that would *displace* something is an error, because there is
+        no spelling of it that works. Three things can be underneath: another
+        alias from an earlier key, a name on the envoy (a child, its own state,
+        or an `Envoy` attribute like ``output`` or ``trace``), or a name on the
+        wrapped module — an alias lands in ``__dict__`` and so wins over the
+        ``__getattr__`` fallthrough, silently shadowing the model's own
+        ``config``, ``weight``, ``eval`` and the rest.
 
         Aliases are ordinary attributes referencing the *same* child object (not
         copies, and not added to `_children`), so ``__getattr__`` needs no
@@ -309,15 +273,42 @@ class Envoy:
             if not isinstance(target, Envoy):
                 continue
             for alias in [aliases] if isinstance(aliases, str) else aliases:
-                conflict = self._alias_conflict(alias, path, target)
-                if conflict is not None:
+                # Already pointing at this very envoy: nothing is displaced.
+                # Covers a key aliased to its own name (``{"attn": "attn"}``,
+                # which a cross-architecture dict pairs with
+                # ``{"self_attn": "attn"}``) and two keys reaching one module
+                # through tied weights.
+                if self.__dict__.get(alias) is target:
+                    continue
+
+                # What the name would displace, in the order lookup would find
+                # it. `hasattr` is right for the module and wrong for the envoy:
+                # an eproperty's `__get__` raises outside interleaving, so the
+                # envoy's own classes are scanned by namespace instead.
+                bound = self._aliases.get(alias)
+                if bound is not None:
+                    displaced = f"the alias already bound here from {bound!r}"
+                elif alias in self.__dict__:
+                    displaced = "a child module or attribute of that name"
+                elif any(alias in vars(klass) for klass in type(self).__mro__):
+                    displaced = f"the `{type(self).__name__}.{alias}` attribute"
+                elif hasattr(self._module, alias):
+                    # The same test `__getattr__` gates its fallthrough on, so
+                    # this is the shadowing surface exactly: every name it finds
+                    # is one `envoy.<name>` answers to today.
+                    displaced = "an attribute of the wrapped module"
+                else:
+                    displaced = None
+
+                if displaced is not None:
                     raise ValueError(
                         f"`rename` alias {alias!r} for {path!r} would shadow "
-                        f"{conflict} on `{self.path}`. Aliases are bound as plain "
+                        f"{displaced} on `{self.path}`. Aliases are bound as plain "
                         f"attributes, so this would make the original unreachable "
                         f"by name while leaving it in the tree. Pick a different "
                         f"alias."
                     )
+
                 object.__setattr__(self, alias, target)
                 self._aliases[alias] = path
 

--- a/tests/test_envoy.py
+++ b/tests/test_envoy.py
@@ -330,6 +330,77 @@ class TestRename:
         envoy = Envoy(module, rename={"layers": "blocks"})
         assert envoy.get("blocks.0.mlp") is envoy.layers[0].mlp
 
+    # -- collisions ------------------------------------------------------
+    #
+    # Aliases bind with `object.__setattr__`, so before these checks anything
+    # already under the name was overwritten in silence.
+
+    def test_alias_shadowing_a_sibling_child_raises(self, module):
+        # `head` and `embed` both exist; aliasing one to the other's name would
+        # leave the original in the tree but unreachable by name, so an
+        # intervention written against it would land on the wrong module.
+        with pytest.raises(ValueError) as info:
+            Envoy(module, rename={"head": "embed"})
+
+        message = str(info.value)
+        assert "rename" in message
+        assert "'embed'" in message
+        assert "child module" in message
+
+    def test_alias_shadowing_an_envoy_attribute_raises(self, module):
+        # Shadowing `trace` used to break `model.trace(...)` itself, surfacing
+        # much later as a TypeError about the context manager protocol.
+        with pytest.raises(ValueError) as info:
+            Envoy(module, rename={"head": "trace"})
+
+        assert "Envoy.trace" in str(info.value)
+
+    @pytest.mark.parametrize("alias", ["output", "input", "inputs", "source"])
+    def test_alias_shadowing_an_eproperty_raises(self, module, alias):
+        # These are data descriptors whose __get__ raises outside interleaving,
+        # so the conflict has to be found without reading them. Previously
+        # `output` failed with "Cannot access `model.output` outside of
+        # interleaving", which never mentions `rename`.
+        with pytest.raises(ValueError) as info:
+            Envoy(module, rename={"head": alias})
+
+        assert "rename" in str(info.value)
+
+    def test_two_paths_claiming_one_alias_raises(self, module):
+        # Self-contradictory: one silently won by dict insertion order.
+        with pytest.raises(ValueError) as info:
+            Envoy(module, rename={"embed": "dup", "head": "dup"})
+
+        assert "already bound" in str(info.value)
+
+    # -- collisions that are not collisions ------------------------------
+
+    def test_alias_equal_to_its_own_name_is_a_noop(self, module):
+        # One `rename` is meant to be reusable across architectures that spell
+        # the same module differently. Pairing `{"attn": "attn"}` with an alias
+        # for the other spelling is the normal way to write that, so a key
+        # aliased to its own name must stay harmless.
+        envoy = Envoy(module, rename={"attn": "attn", "self_attn": "attn"})
+
+        assert envoy.layers[0].attn is envoy.layers[0]._module.attn or isinstance(
+            envoy.layers[0].attn, Envoy
+        )
+
+    def test_unresolvable_key_is_still_skipped(self, module):
+        # The cross-architecture case: a key that names nothing here is skipped,
+        # not an error.
+        envoy = Envoy(module, rename={"layers": "blocks", "decoder.layers": "blocks"})
+
+        assert envoy.blocks[0] is envoy.layers[0]
+
+    def test_two_paths_to_the_same_module_share_an_alias(self, module):
+        # Tied weights: two keys reaching one module bind the same object, so
+        # the second is a no-op rather than a conflict.
+        module.tied = module.head
+        envoy = Envoy(module, rename={"head": "out", "tied": "out"})
+
+        assert envoy.out is envoy.head
+
 
 class TestDevice:
     def test_device_of_parameters(self, envoy):

--- a/tests/test_envoy.py
+++ b/tests/test_envoy.py
@@ -337,6 +337,28 @@ class TestRename:
     # Aliases bind with `object.__setattr__`, so before these checks anything
     # already under the name was overwritten in silence.
 
+    def test_alias_shadowing_envoy_state_raises(self, module):
+        # `path`, `interleaver` and the rest are set in `__init__`, so they are
+        # instance attributes rather than class ones — the class-namespace scan
+        # never saw them, and an alias overwrote them in silence.
+        for state in ("path", "interleaver", "_module"):
+            with pytest.raises(ValueError, match="would shadow"):
+                Envoy(module, rename={"head": state})
+
+    def test_alias_shadowing_a_module_attribute_raises(self, module):
+        # An alias lands in the envoy's `__dict__`, which wins over the
+        # `__getattr__` fallthrough — so it hides the wrapped model's own name
+        # with nothing said. `eval` is `nn.Module`'s; `training` is its state.
+        for owned in ("eval", "training", "parameters"):
+            with pytest.raises(ValueError, match="would shadow"):
+                Envoy(module, rename={"head": owned})
+
+    def test_a_name_the_module_does_not_have_is_fine(self, module):
+        # The check is the module's own surface, not a blocklist: a name it
+        # never answered to is still a usable alias.
+        envoy = Envoy(module, rename={"head": "readout"})
+        assert envoy.readout.path == "model.head"
+
     def test_alias_shadowing_a_sibling_child_raises(self, module):
         # `head` and `embed` both exist; aliasing one to the other's name would
         # leave the original in the tree but unreachable by name, so an


### PR DESCRIPTION
Based on `0.8`. Found while checking whether #535 still reproduces there — it mostly doesn't (`cache` navigation resolves against the envoy tree now, so Butanium's minimal repro works), but the `rename` binding underneath it has three silent failure modes.

## Summary

`_bind_aliases` binds each alias with `object.__setattr__`, which overwrites whatever name is already there without a word:

```python
for alias in [aliases] if isinstance(aliases, str) else aliases:
    object.__setattr__(self, alias, target)
    self._aliases[alias] = path
```

Three things can be underneath.

### 1. An `Envoy` attribute — breaks the library's entry point

```python
Envoy(Net(), rename={"b": "trace"})
```

`model.trace` is now an envoy, so opening a trace fails with a message about tensors:

```
TypeError: 'torch.Tensor' object does not support the context manager protocol
(missed __exit__ method)
```

`rename={"b": "output"}` *did* raise, but accidentally and from the wrong place — `ValueError: Cannot access 'model.output' outside of interleaving`, which never mentions `rename`.

### 2. A sibling module — silently wrong activations

```python
e = Envoy(Net(), rename={"head": "b"})
e.b.path   # 'model.head'      <- the real `b` is still in the tree, unreachable by name
```

No error at any point. An intervention written against `b` lands on `head`. This is the one that concerns me most — it produces wrong numbers rather than a traceback.

### 3. An alias an earlier key already claimed

```python
e = Envoy(Net(), rename={"b": "dup", "head": "dup"})
e._aliases     # {'dup': 'head'}   <- 'b' lost, by dict insertion order
```

`docs/usage/rename-modules.md` only advised around case 1 — *"Avoid alias names that collide with Envoy attributes ... They will shadow or be shadowed by those attributes"* — and said nothing about 2 or 3.

## Fix

Raise at construction, naming the alias, the key it came from, and what it would displace:

```
ValueError: `rename` alias 'embed' for 'head' would shadow a child module of that
name on `model`. Aliases are bound as plain attributes, so this would make the
original unreachable by name while leaving it in the tree. Pick a different alias.
```

`_alias_conflict` finds an eproperty by scanning the MRO's own namespaces rather than via `hasattr`, so `output`'s descriptor is detected without its `__get__` running (reading it outside interleaving raises).

## What is deliberately *not* changed

A key that resolves to nothing is **still skipped silently**. One `rename` is meant to be reusable across architectures that spell a module differently — `{"attn": "att", "self_attn": "att"}` binds whichever exists — and that's the nnterp usage behind #535. Breaking it would be worse than the bug.

Two related no-ops, each with a test, so that pattern keeps working:

- **Aliasing a key to its own name** (`{"attn": "attn"}`) — how the cross-architecture form is normally written. Treated as a no-op, not a self-collision.
- **Two keys reaching one module** through tied weights — the second binds the same object, so it's a no-op too.

The rule is identity-based: if the name already points at *this* envoy, nothing is displaced.

## Verification

| | |
|---|---|
| Collection vs `0.8` | **853 = 853** (identical; nothing dropped) |
| Full CPU suite | **856 passed, 7 skipped, 1 xfailed, 0 failed** |
| New tests failing without the fix | **7 of 10** |

The 10 new tests in `TestRename` cover each collision (sibling child, `Envoy.trace`, the four eproperties, duplicate alias) and each non-collision (self-alias, unresolvable key, tied weights).

Checked against every existing `rename=` usage in the suite first — none of the aliases in use (`my_mlp`, `blocks`, `layers`, `first_layer`, `second_layer`, `denoiser`, `e`, `emb`, `zero`, `m`, `first`, `block_mlp`, `first_mlp`, `second`, `model`) collide, so this is not a breaking change for anything in tree. Worth a note in release notes regardless, since it turns a previously-silent case into an error.

<sub>`0.8` @ 8f7546c, Python 3.14.3, `transformers` 5.15.1, `torch` 2.9.1, CPU.</sub>
