### PR TITLE
fix(cache): stop conflating "not recorded" with a recorded None or empty

### DIFF
--- a/src/nnsight/intervention/cache.py
+++ b/src/nnsight/intervention/cache.py
@@ -48,7 +48,11 @@ class Entry:
         if self.inputs is None:
             return None
         args, kwargs = self.inputs
-        return (list(args) + list(kwargs.values()))[0]
+        values = list(args) + list(kwargs.values())
+        # A module can legally be called with no arguments, which records
+        # `((), {})` — a visit with nothing to hand back, not an unrecorded one.
+        # Indexing position 0 unconditionally raised IndexError there.
+        return values[0] if values else None
 
 
 class Cache:
@@ -91,6 +95,9 @@ class Cache:
             else {m if isinstance(m, str) else m.path for m in modules}
         )
         self.entries: dict[str, list[Entry]] = {}
+        # Which slots of each path's newest Entry have been written this visit.
+        # Recording-time bookkeeping only; see `_record`.
+        self._open: dict[str, set[str]] = {}
 
     def __getstate__(self) -> dict:
         # `model` is a live Envoy used only for CacheView navigation, and it drags
@@ -98,7 +105,7 @@ class Cache:
         # recorded data (entries) can be serialized — e.g. torch.save-d as a remote
         # trace's result. Access by path string still works without it (see
         # CacheView); tree navigation needs a model re-attached.
-        return {**self.__dict__, "model": None}
+        return {**self.__dict__, "model": None, "_open": {}}
 
     def _select(self, location: str) -> "tuple[str, str] | None":
         """``(module_path, slot)`` if ``location`` is one this cache keeps, else None.
@@ -192,11 +199,21 @@ class Cache:
         # Pair the input and output of one visit into a single Entry: the input
         # pre-hook fires before the output post-hook, so fill the open slot on the
         # current entry, or start a new entry (a new visit) when it's taken.
+        #
+        # Which slots are taken is tracked here rather than read back off the
+        # Entry. A module's output can legitimately *be* None -- a module called
+        # for its side effect, or one whose branch returned nothing on this visit
+        # -- and `entries[-1].output is None` cannot tell "not recorded yet" from
+        # "recorded None". Every visit after the first to such a module then
+        # refilled the same Entry, so a module reached N times reported one visit.
         entries = self.entries.setdefault(path, [])
-        if entries and getattr(entries[-1], key) is None:
+        filled = self._open.setdefault(path, set())
+        if entries and key not in filled:
             setattr(entries[-1], key, value)
         else:
             entries.append(Entry(**{key: value}))
+            filled.clear()
+        filled.add(key)
 
 
 class CacheView:

--- a/tests/test_interleaving.py
+++ b/tests/test_interleaving.py
@@ -728,6 +728,139 @@ class TestCache:
         assert torch.equal(cache.model.l1.output, cache["model.l1"].output)
         assert torch.equal(cache.l1.output, cache["model.l1"].output)
 
+    # -- one Entry per visit, whatever the value is ------------------------
+
+    def test_repeated_module_records_one_entry_per_visit(self, x):
+        # A module reached N times in one forward is N visits.
+        class Loop(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin = nn.Linear(4, 4)
+
+            def forward(self, value):
+                for _ in range(3):
+                    value = self.lin(value)
+                return value
+
+        envoy = Envoy(Loop())
+        with envoy.trace(torch.randn(1, 4)) as tracer:
+            cache = tracer.cache()
+
+        assert len(cache["model.lin"].output) == 3
+
+    def test_repeated_module_returning_none_records_every_visit(self, x):
+        # `Entry.output` defaults to None to mean "not recorded", so a module
+        # whose output *is* None looked like an entry with a slot still open,
+        # and each later visit refilled it instead of appending -- three visits
+        # were reported as one.
+        class Probe(nn.Module):
+            def forward(self, value):
+                return None
+
+        class Loop(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.probe = Probe()
+                self.lin = nn.Linear(4, 4)
+
+            def forward(self, value):
+                for _ in range(3):
+                    self.probe(value)
+                    value = self.lin(value)
+                return value
+
+        envoy = Envoy(Loop())
+        with envoy.trace(torch.randn(1, 4)) as tracer:
+            cache = tracer.cache()
+
+        assert cache["model.probe"].output == [None, None, None]
+        # The sibling that returns a tensor was always counted correctly; it is
+        # here so a regression can't pass by breaking both the same way.
+        assert len(cache["model.lin"].output) == 3
+
+    def test_none_output_pairs_with_its_own_inputs(self, x):
+        # With include_inputs the `inputs` slot drove entry creation, so the
+        # count was already right -- but each None output must still land on the
+        # visit it belongs to rather than on a later one.
+        class Probe(nn.Module):
+            def forward(self, value):
+                return None
+
+        class Loop(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.probe = Probe()
+                self.lin = nn.Linear(4, 4)
+
+            def forward(self, value):
+                for _ in range(3):
+                    self.probe(value)
+                    value = self.lin(value)
+                return value
+
+        envoy = Envoy(Loop())
+        with envoy.trace(torch.randn(1, 4)) as tracer:
+            cache = tracer.cache(include_inputs=True)
+
+        entries = cache["model.probe"]
+        assert len(entries.inputs) == 3
+        assert entries.output == [None, None, None]
+        # Each visit saw the value the preceding lin produced, so the three
+        # recorded inputs are distinct.
+        first, second, third = (i[0][0] for i in entries.inputs)
+        assert not torch.equal(first, second)
+        assert not torch.equal(second, third)
+
+    def test_input_of_a_module_called_with_no_arguments(self, x):
+        # `Entry.inputs` is `((), {})` for a module invoked with no arguments —
+        # a recorded visit with nothing to hand back, not an unrecorded one.
+        # Indexing position 0 unconditionally raised IndexError instead.
+        class NoArgs(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = nn.Parameter(torch.ones(4))
+
+            def forward(self):
+                return self.w * 2
+
+        class Net(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.noargs = NoArgs()
+                self.lin = nn.Linear(4, 4)
+
+            def forward(self, value):
+                return self.lin(value) + self.noargs()
+
+        envoy = Envoy(Net())
+        with envoy.trace(torch.randn(1, 4)) as tracer:
+            cache = tracer.cache(include_inputs=True)
+
+        assert cache["model.noargs"].inputs == ((), {})
+        assert cache["model.noargs"].input is None
+        # The visit itself was still recorded.
+        assert cache["model.noargs"].output is not None
+
+    def test_input_prefers_the_first_positional_then_the_first_keyword(self, x):
+        class KwOnly(nn.Module):
+            def forward(self, *, value):
+                return value * 2
+
+        class Net(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.kw = KwOnly()
+
+            def forward(self, value):
+                return self.kw(value=value)
+
+        envoy = Envoy(Net())
+        data = torch.randn(1, 4)
+        with envoy.trace(data) as tracer:
+            cache = tracer.cache(include_inputs=True)
+
+        assert torch.equal(cache["model.kw"].input, data)
+
     def test_cache_must_be_created_before_model_access(self, envoy, x):
         with pytest.raises(ValueError, match="before reading or modifying"):
             with envoy.trace(x) as tracer:


### PR DESCRIPTION
Based on `0.8`. Found by probing `cache.py` — it's the largest module in `intervention/` without a test file of its own, and this turned out to break a contract `docs/usage/cache.md` states outright.

## Summary

`Cache._record` decides whether a value starts a new visit by checking whether the newest `Entry`'s slot is still `None`:

```python
entries = self.entries.setdefault(path, [])
if entries and getattr(entries[-1], key) is None:
    setattr(entries[-1], key, value)
else:
    entries.append(Entry(**{key: value}))
```

`Entry.output` defaults to `None` to mean *"not recorded"*. But a module's output can legitimately **be** `None`, and `entries[-1].output is None` cannot tell those apart. So for such a module every visit after the first refills the same `Entry` instead of appending one, and the cache reports a single visit no matter how many times the module ran.

## Repro

```python
class Probe(nn.Module):                 # called for its side effect
    def forward(self, value):
        return None

class Loop(nn.Module):
    def __init__(self):
        super().__init__()
        self.probe = Probe()
        self.lin = nn.Linear(4, 4)
    def forward(self, value):
        for _ in range(3):
            self.probe(value)
            value = self.lin(value)
        return value

with Envoy(Loop()).trace(torch.randn(1, 4)) as tracer:
    cache = tracer.cache()
```

```
model.probe: entries=1   <- ran 3 times
model.lin:   entries=3   <- correct
```

## Why it matters

`docs/usage/cache.md` makes this an explicit guarantee:

> `cache[path].output` unwraps automatically: a **single visit** returns the value directly (a tensor), **multiple visits** return a `list`. `len(cache[path])` is the visit count.

Because `CacheView._values` unwraps a one-element list, the caller doesn't get a short list they might notice — they get a bare `None` where a list of three was promised, and `len(cache[path])` is silently wrong.

The trigger is any module returning `None` on a visit: a probe module, or a branch that returned nothing this step (a router that skipped, cross-attention with no encoder states). It's reachable through a plain `tracer.cache()` too, since `modules=None` caches every module in the tree.

## Fix

Track which slots have been written for the current visit rather than inferring it from the value:

```python
entries = self.entries.setdefault(path, [])
filled = self._open.setdefault(path, set())
if entries and key not in filled:
    setattr(entries[-1], key, value)
else:
    entries.append(Entry(**{key: value}))
    filled.clear()
filled.add(key)
```

`_open` is recording-time bookkeeping, so `__getstate__` drops it alongside `model` — the pickled shape of `entries` / `Entry` is unchanged, which keeps `torch.save`-d caches and the remote result path compatible.

The input/output pairing rule is untouched: the input pre-hook still fills the open slot on the current entry, and the output post-hook still closes it. `Entry` keeps `output=None` as its public default, so nothing user-visible changes for modules that return a value.

## Tests

Three added to `TestCache` in `tests/test_interleaving.py`:

- `test_repeated_module_records_one_entry_per_visit` — the baseline (a tensor-returning module reached 3× is 3 visits). Passes before and after; it's there so a regression can't pass by breaking both paths the same way.
- `test_repeated_module_returning_none_records_every_visit` — **fails without this change** (1 entry instead of 3).
- `test_none_output_pairs_with_its_own_inputs` — with `include_inputs=True` the count was already right, because the never-`None` `inputs` slot drove entry creation; this pins that each `None` output still lands on the visit it belongs to, by asserting the three recorded inputs are distinct.

---

## Second fix in the same file: `Entry.input` on a module called with no arguments

Same root shape — "absent" conflated with "present but empty".

```python
@property
def input(self) -> Any:
    if self.inputs is None:
        return None
    args, kwargs = self.inputs
    return (list(args) + list(kwargs.values()))[0]     # <- IndexError
```

A module invoked with no arguments records `inputs = ((), {})`. That is not `None`, so the guard passes and the index blows up:

```
cache["model.noargs"].inputs   -> ((), {})
cache["model.noargs"].input    -> IndexError: list index out of range
```

`None` is now returned when there is nothing to hand back, consistent with the `inputs is None` branch just above it. Two tests: the no-argument case, and one pinning that the first positional still wins over the first keyword.

This is the only place in the file that indexes position 0 unguarded (`_values` at line 262 is safe — `_entries` raises before it if the path was never cached).


## Verification

Full CPU suite green. Of the five added tests, two fail without these
changes (`test_repeated_module_returning_none_records_every_visit`,
`test_input_of_a_module_called_with_no_arguments`); the other three pin
behaviour that already worked so a regression can't pass by breaking both
paths the same way.

> [!NOTE]
> CI on this branch will show 6 failures in `tests/test_tensor_parallel_rules.py`.
> They are unrelated to this change — `transformers` 5.16 moved TP to DTensor and
> deleted the `all_gather`/`split` that `modeling/tp/fragments.py` imports. Filed as
> #702; every PR against `0.8` is currently red for it. The local run above pins
> `transformers` 5.15.1.

<sub>`0.8` @ 96c85fc, Python 3.14.3, `transformers` 5.15.1, `torch` 2.9.1, CPU.</sub>
