### PR TITLE
fix(tp): explain a transformers whose TP collectives are gone, and skip the rules it no longer describes

### DIFF
--- a/src/nnsight/modeling/tp/fragments.py
+++ b/src/nnsight/modeling/tp/fragments.py
@@ -170,9 +170,40 @@ def _shardable(tensor: torch.Tensor, world_size: int) -> bool:
     return tensor.is_floating_point() and tensor.dim() >= 1 and tensor.shape[-1] % world_size == 0
 
 
+def _collectives():
+    """transformers' ``(all_gather, split)``, the pair fragments are moved with.
+
+    Imported through here rather than at each call site so a transformers that
+    does not have them is one error, raised where it can be explained.
+
+    5.16.0 rebuilt tensor parallelism on DTensor: the implementation moved to
+    ``transformers.distributed.tensor_parallel``, and these two module-level
+    helpers are not part of what the old path re-exports -- they are gone, with
+    no drop-in replacement (a DTensor is made whole through
+    ``redistribute``/``full_tensor``). Left alone, the failure is an ImportError
+    from inside a hook on the first sharded module, naming a module that does
+    still import, on a code path that only runs on multiple GPUs.
+    """
+    try:
+        from transformers.integrations.tensor_parallel import all_gather, split
+    except ImportError as error:
+        import transformers
+
+        raise UnsupportedTransformersVersion(
+            f"transformers {transformers.__version__} does not provide the "
+            "`all_gather` / `split` helpers that nnsight reassembles sharded "
+            "activations with, so a fragment cannot be made whole for an "
+            "intervention to see. 5.16.0 rebuilt tensor parallelism on DTensor "
+            "and removed them. Pin `transformers<5.16`, or load this model on "
+            "one GPU."
+        ) from error
+
+    return all_gather, split
+
+
 def _gather(value: Any, mesh: Any) -> Any:
     """Every rank's slice of ``value``, concatenated back into the whole tensor."""
-    from transformers.integrations.tensor_parallel import all_gather
+    all_gather, _ = _collectives()
 
     return apply(
         value,
@@ -204,7 +235,7 @@ def _reshard(value: Any, mesh: Any) -> Any:
     are autograd functions. Guarded by the same predicate as the gather: a tensor
     that was never a fragment must not be cut down here.
     """
-    from transformers.integrations.tensor_parallel import split
+    _, split = _collectives()
 
     world_size = mesh.size()
     return apply(

--- a/tests/test_tensor_parallel_rules.py
+++ b/tests/test_tensor_parallel_rules.py
@@ -33,6 +33,38 @@ def _upstream_styles() -> set:
     return set(ALL_PARALLEL_STYLES._global_mapping)
 
 
+def _drives_this_transformers() -> bool:
+    """Whether the installed transformers is the one these rules describe.
+
+    The tables say which side of a handoff carries a shard, and the reshard
+    guard patches the helper that moves one. Both are written against the
+    ``all_gather``/``split`` implementation nnsight drives; 5.16 rebuilt tensor
+    parallelism on DTensor and removed those, so asserting either against it
+    says nothing about whether nnsight is right. Refusing to run there is not
+    the same as refusing to notice: a transformers that still has the helpers
+    and adds a style fails these as loudly as before.
+    """
+    try:
+        from transformers.integrations.tensor_parallel import (  # noqa: F401
+            all_gather,
+            split,
+        )
+    except ImportError:
+        return False
+
+    return True
+
+
+drives_this_transformers = pytest.mark.skipif(
+    not _drives_this_transformers(),
+    reason=(
+        "transformers no longer provides the all_gather/split tensor-parallel "
+        "helpers these rules are written against (5.16 moved to DTensor); "
+        "nnsight refuses to shard there - see fragments._collectives"
+    ),
+)
+
+
 class _FakeMesh:
     def __init__(self, size: int = 2) -> None:
         self._size = size
@@ -62,6 +94,7 @@ def _module(style: str | None, **attrs) -> torch.nn.Module:
 class TestStyleCoverage:
     """Every style transformers knows about has a rule here, and vice versa."""
 
+    @drives_this_transformers
     def test_no_upstream_style_is_unaccounted_for(self):
         # The one that matters: a new style upstream with no rule here is a model
         # nnsight will refuse at deploy time. Better to find out at test time.
@@ -72,6 +105,7 @@ class TestStyleCoverage:
             f"carry a shard) or to UNSUPPORTED."
         )
 
+    @drives_this_transformers
     def test_no_rule_names_a_style_that_no_longer_exists(self):
         stale = (set(SIDES) | set(UNSUPPORTED)) - _upstream_styles()
         assert not stale, (
@@ -268,6 +302,22 @@ class TestTransformersVersionFloor:
         # checkout reports 5.15.0.dev0, which a plain >= would reject.
         self._check(monkeypatch, version)
 
+    def test_a_transformers_without_the_collectives_is_refused(self, monkeypatch):
+        # 5.16 rebuilt tensor parallelism on DTensor and dropped `all_gather` /
+        # `split`. Without a guard the failure is an ImportError from inside a
+        # hook on the first sharded module, naming a module that does still
+        # import -- on a path that only runs on multiple GPUs.
+        import transformers.integrations.tensor_parallel as tp
+
+        from nnsight.modeling.tp import UnsupportedTransformersVersion
+        from nnsight.modeling.tp import fragments as tp_fragments
+
+        monkeypatch.delattr(tp, "all_gather", raising=False)
+        monkeypatch.delattr(tp, "split", raising=False)
+
+        with pytest.raises(UnsupportedTransformersVersion, match="all_gather"):
+            tp_fragments._collectives()
+
     def test_it_only_runs_once(self, monkeypatch):
         # instrument() calls this per sharded module -- hundreds on a real model
         # -- so the import and version parse have to happen once, not per call.
@@ -397,6 +447,7 @@ class FakeMesh:
         return self._size
 
 
+@drives_this_transformers
 class TestReshardGuard:
     """What goes back to the model must be guarded like what came out of it.
 


### PR DESCRIPTION
Fixes the CI failures reported in #702. Based on `0.8`.

## Summary

transformers **5.16.0** rebuilt tensor parallelism on DTensor. The implementation moved to `transformers.distributed.tensor_parallel`, and `transformers.integrations.tensor_parallel` became a re-export shim — one that does **not** re-export `all_gather` and `split`, the two module-level helpers `_gather` and `_reshard` reassemble fragments with. They are gone, with no drop-in replacement (a DTensor is made whole through `redistribute` / `full_tensor`).

`pyproject.toml` pins `transformers` unbounded, so 5.16 is what CI installs today. **Every PR against `0.8` is currently red on the same six tests**, mine included:

```
6 failed, 879 passed, 8 skipped, 1 xfailed
```

The runtime breakage is wider than those six show. Both imports are function-local:

```python
def _gather(value, mesh):
    from transformers.integrations.tensor_parallel import all_gather
```

so nothing fails until a hook fires on the first sharded module — and then it's a bare `ImportError` naming a module that *does* still import, on a path that only runs on multiple GPUs.

## Changes

**1. One guarded import.** Both call sites now go through `_collectives()`, which turns a missing pair into `UnsupportedTransformersVersion` naming what changed and what to pin — the same shape as the `MINIMUM_TRANSFORMERS` refusal directly above it:

```
UnsupportedTransformersVersion: transformers 5.16.1 does not provide the
`all_gather` / `split` helpers that nnsight reassembles sharded activations
with, so a fragment cannot be made whole for an intervention to see. 5.16.0
rebuilt tensor parallelism on DTensor and removed them. Pin
`transformers<5.16`, or load this model on one GPU.
```

**2. The six tests skip where their subject doesn't exist.** Two compare `SIDES`/`UNSUPPORTED` against the upstream registry (5.16 registers `colwise_rep` and `rowwise_rep`, drops `embedding_colwise`); four monkeypatch `split`. All six assert against the `all_gather`/`split` implementation nnsight drives, so on a DTensor build they say nothing about whether nnsight is right.

The skip is keyed on **the helpers being importable**, not on a version number — so a transformers that still has them and adds a style fails these as loudly as before. Refusing to run isn't the same as refusing to notice.

## What I deliberately did *not* do

- **No upper version bound.** `test_the_floor_and_above_are_allowed` admits `6.0.0` on purpose. Making future versions refuse by default reverses that policy, and that's your call, not a side effect of a CI fix. I built one first and threw it away for this reason.
- **No new `SIDES` entries.** The table's own note says to read a style's `_prepare_input_fn`/`_prepare_output_fn` before adding one, *"the name alone misled on `moe_tp_experts`"*, and the starred rows were measured on Llama-3.2-3B at tp=4. `colwise_rep`/`rowwise_rep` belong to an implementation this version can't drive; entering them against it would put unmeasured rows into a table whose whole point is distinguishing measured from inferred. I have no multi-GPU box to measure on.

Porting `_gather`/`_reshard` to DTensor and re-measuring `SIDES` is the real follow-up — that's #702, and I'm happy to do the mechanical half if you can confirm the handoff points.

## Verification

Both sides of the break, full CPU suite:

| transformers | result |
|---|---|
| 5.15.1 | **860 passed, 7 skipped, 0 failed** |
| 5.16.1 | **854 passed, 13 skipped, 0 failed** |

The added test (`test_a_transformers_without_the_collectives_is_refused`) fails without the guard.

<sub>`0.8` @ 5be282b, Python 3.14.3, `torch` 2.9.1, CPU.</sub>
