### PR TITLE
ci: run on pushes to 0.8, and test both ends of the advertised Python range

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -18,13 +18,25 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      # Both ends of the advertised range. `pyproject.toml` claims 3.10 through
+      # 3.14, and a single 3.12 job cannot see a break that only the newest one
+      # has: #698 was exactly that -- PEP 649 gives every `def` an extra
+      # `__annotate__` symtable child on 3.14, which silently disabled the
+      # payload scope filter, and the two tests that covered it were failing on
+      # 3.14 while CI stayed green. 3.11 and 3.13 are left out rather than
+      # guessed at; add them once someone has run the suite there.
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.14"]
+
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       # Many tests pull small models from the HuggingFace Hub on first run; cache
       # them so reruns don't re-download. Keyed by the test files so it refreshes
@@ -33,8 +45,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/huggingface
-          key: hf-${{ runner.os }}-${{ hashFiles('tests/**/*.py') }}
-          restore-keys: hf-${{ runner.os }}-
+          key: hf-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('tests/**/*.py') }}
+          restore-keys: hf-${{ runner.os }}-py${{ matrix.python-version }}-
 
       - name: Install
         run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,7 +5,10 @@ name: Tests
 
 on:
   push:
-    branches: ["main"]
+    # Development happens on the release branch, so it has to be listed here or
+    # nothing tests it: a `pull_request` run only ever tests the PR head, never
+    # the merge that lands it, and never a commit pushed straight to the branch.
+    branches: ["main", "0.8"]
   pull_request:
 
 permissions:


### PR DESCRIPTION
Two independent CI gaps, one commit each, so you can take just the first if you prefer. Based on `0.8`.

## 1. Nothing tests `0.8` (`7676b6b`)

`on.push.branches` lists only `main`. A `pull_request` run tests the **PR head** — never the merge that lands it, and never a commit pushed straight to the branch. So the branch all development happens on has no push CI at all.

Every 0.8 commit I checked has zero check-runs, including the merge of my own #698:

```console
$ gh api repos/ndif-team/nnsight/commits/<sha>/check-runs -q .total_count
8f7546c7  Merge pull request #698 from Hotragn/...    0
dc5829d3  vllm: install source taps from ...          0
5bc45e02  remote: take a result off the response ...  0
96c85fc7  vllm: named edits, and edits=[...] ...      0
```

Push runs exist for `main` and `dev` only, from when those were the branch in hand.

**This is how #702 stayed hidden.** transformers 5.16 removed the tensor-parallel collectives `modeling/tp/fragments.py` imports; because `pyproject.toml` pins transformers unbounded, the break arrived with a *release*, not a commit — and nothing was watching the branch. It surfaced only when a PR happened to run afterwards, by which point every open PR was red for a reason none of them had introduced. A push run on 0.8 would have caught it on the first commit after the release.

## 2. Only one Python version is tested (`14607cb`)

`pyproject.toml` claims 3.10–3.14; CI runs 3.12 alone, so a break only the newest version has is invisible.

**#698 was exactly that.** PEP 649 gives every `def` an extra `__annotate__` symtable child on 3.14, so `_function_referenced_names` — which located the function's own child by *counting* children — fell through to the block rule for every `def`, silently disabling the payload scope filter. The two tests that already covered it were failing on 3.14 the whole time while CI stayed green on 3.12.

Adds 3.14 as a second job, `fail-fast: false` so one version failing still reports the other, and the HF cache key gains the version so the two jobs don't race on one entry.

**3.11 and 3.13 deliberately left out.** 3.13 would exercise the same symtable path via PEP 695 generics, so it's the next one worth having — but I haven't run the suite on either, and an unverified matrix entry turns CI red for a reason unrelated to whatever change trips it. Worth adding once someone has.

3.14 **is** verified — I've been running the full CPU suite there all along: `860 passed, 7 skipped` on transformers 5.15.1.

## Note on the checks for this PR

The 3.12 job will show the six `test_tensor_parallel_rules.py` failures from #702 until #706 lands; the 3.14 job will show them too. Neither comes from this change — this PR only touches the workflow file. #706 fixes them and its own run is green.

<sub>`0.8` @ dc5829d. YAML validated; `strategy.matrix` and `on.push.branches` parse as intended.</sub>
