### PR TITLE
tp: port to the transformers 5.16 DTensor backend

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -55,8 +55,15 @@ jobs:
 
       # CPU only (the runner has no GPU); skip the vLLM suite, which needs a GPU
       # and the vllm extra.
+      #
+      # `tests/tp` is no longer ignored. Its GPU tests skip themselves on a
+      # runner with no cards (`pytestmark = skipif(device_count() < 2)`), and
+      # what is left is `test_cpu_gloo.py`, which shards a tiny model across two
+      # CPU ranks over gloo in a few seconds. Ignoring the whole directory is why
+      # transformers 5.16 could move its tensor-parallel plan off the modules and
+      # leave nnsight's TP path silently inert with CI green.
       - name: Run tests
         env:
           CUDA_VISIBLE_DEVICES: ""
           HF_HUB_DISABLE_PROGRESS_BARS: "1"
-        run: pytest tests/ -q --ignore=tests/vllm --ignore=tests/tp
+        run: pytest tests/ -q --ignore=tests/vllm

--- a/docs/models/tensor-parallel.md
+++ b/docs/models/tensor-parallel.md
@@ -227,6 +227,31 @@ one GPU and on eight.
 If you are not sure which axis holds the shard, print the shape at tp=1 and at
 tp=2 and compare: the axis that shrank by `tp_size` is the one.
 
+## A sharded model wrapped with `NNsight` directly
+
+`TransformersModel` attaches the tensor-parallel rules for you. A tree built with
+plain `NNsight` over an already-sharded module does not get them by default — it
+has no way to know the module came from `transformers` — so every sharded value
+would be handed over as this device's piece. Opt in:
+
+```python
+from nnsight import NNsight
+from nnsight.intervention.interleaver import Interleaver
+from nnsight.modeling.tp import TPFragments
+from nnsight.modeling.tp.envoys import tp_envoys
+
+model = NNsight(
+    sharded_hf_model,
+    interleaver=Interleaver(fragments=TPFragments()),
+    envoys=tp_envoys(),          # ad-hoc calls on sharded modules
+)
+```
+
+`TPFragments` works the rules out for itself as the tree is built, and stays
+inert on a model that is not sharded — so this is safe to pass unconditionally.
+`tp_envoys()` is what makes `model.lm_head(hidden)` return a whole tensor rather
+than this rank's slice.
+
 ## Requires transformers >= 5.16
 
 5.16 rebuilt tensor parallelism on DTensor. The sharding plan moved from a stamp

--- a/docs/models/tensor-parallel.md
+++ b/docs/models/tensor-parallel.md
@@ -3,7 +3,7 @@ title: Tensor Parallelism
 one_liner: Trace a model sharded across GPUs with transformers tensor parallelism — sharded activations are gathered so a trace reads exactly as it would on one GPU.
 tags: [models, transformers, tensor-parallel, multi-gpu, distributed]
 related: [docs/models/transformers-model.md, docs/models/vllm.md, docs/models/index.md, docs/usage/generate.md, docs/usage/cache.md]
-sources: [src/nnsight/modeling/tp/interleaver.py, src/nnsight/modeling/huggingface.py, tests/test_transformers_tensor_parallel.py, tests/tp_worker.py]
+sources: [src/nnsight/modeling/tp/fragments.py, src/nnsight/modeling/tp/envoys.py, src/nnsight/modeling/tp/plan.py, src/nnsight/modeling/huggingface.py, tests/tp/worker.py, tests/tp/test_cpu_gloo.py]
 ---
 
 # Tensor Parallelism
@@ -81,17 +81,32 @@ final norm all arrive complete. Only two kinds of value are really a slice:
 | The LM head | no — gathered by transformers | `lm_head.output` |
 | Embeddings | no — all-reduced | `embed_tokens.output` |
 | **Parameters** | **yes — not gathered** | `q_proj.weight`, `down_proj.weight` |
+| `.source` inside a sharded module | yes, gathered — **needs the graph on**, see rule 4 | `q_proj.source.F_linear_0` |
+| `.source` in a parent that calls one | no — gather it yourself | `mlp.source.self_gate_proj_0` |
+| Anything between two sharded modules | no — gather it yourself | `mlp.act_fn.output`, `query_states_0` |
 
 Calling a sharded module **ad hoc** — the logit lens, `model.lm_head(hidden)` —
 is corrected the same way its activations are, so it returns the full-width
 result it would on one GPU.
 
 Parameters are the exception, and the one place a trace does not read as it would
-on one GPU: `layer.weight` is this rank's slice, at `1/tp_size` of the real
-width. Weights are what tensor parallelism exists to split, so nnsight does not
-quietly reassemble one — that would allocate the whole tensor on every rank, in
-the situation where memory was tight enough to reach for TP. Gather it yourself
-if you need it whole, and remember every rank must do so.
+on one GPU. `layer.weight` is a `DTensor`: this rank holds `1/tp_size` of it, but
+**`.shape` reports the whole**, so the shape alone will not tell you it is split.
+
+```python
+w = model.model.layers[0].self_attn.q_proj.weight
+w.shape                 # (4096, 4096) — the global shape
+w.placements            # (Shard(dim=0),)
+w.to_local().shape      # (1024, 4096) — what this rank actually holds
+w.full_tensor()         # the real thing; every rank must call it, and it
+                        # allocates the whole tensor on each of them
+```
+
+Weights are what tensor parallelism exists to split, so nnsight does not quietly
+reassemble one — that would allocate the whole tensor on every rank, in the
+situation where memory was tight enough to reach for TP. Most torch operations
+handle a `DTensor` for you; `.to_local()` and `.full_tensor()` are there when you
+need to be explicit.
 
 The gather only fires when an intervention is actually parked on that location,
 so reading a handful of locations does not pay for the hundreds you ignored. A
@@ -121,24 +136,111 @@ it puts two obligations on the code:
    Many checkpoints ship `do_sample: true` in `generation_config.json`, so this
    bites without you asking for sampling.
 
-3. **`.source` values are handed over as-is.** The gathering rules describe
-   module boundaries; a value between two ops *inside* a forward can be this
-   rank's shard, split on an axis that moves through the forward, so it is not
-   gathered. Anything past the layer that all-reduces (a module's own
-   `.input`/`.output`) is whole; a value between a column-parallel layer and it
-   is not. Compare against a single-GPU run if it matters — and, per rule 1,
-   never branch on one.
+3. **Editing a gathered value takes a clone.** A sharded value is made whole by
+   a collective, and torch will not let you write into the output of one in
+   place — a `value[...] = x` raises `Output 0 of ... is a view and is being
+   modified inplace`. Clone, edit, assign back:
+
+   ```python
+   with model.trace(prompt):
+       edited = model.model.layers[0].mlp.gate_proj.output.clone()
+       edited[..., :64] = 0
+       model.model.layers[0].mlp.gate_proj.output = edited
+   ```
+
+   Whole-value replacement (`... .output = torch.zeros_like(...)`) needs no
+   clone. nnsight does not clone for you: on a large model that is a copy the
+   size of the activation, on every gather, for the many traces that only read.
+
+4. **Nothing inside a module's forward is reassembled for you.** A module's own
+   `.input`/`.output` is; a `.source` operation is not, and neither is a plain
+   module sitting between a column-parallel output and the row-parallel input
+   that consumes it (`mlp.act_fn`). Nothing on those values records which axis
+   holds the shard once it has left the module that produced it, and the axis
+   moves — attention's `view`/`transpose` puts it on the head dimension. So the
+   trace names the axis and reassembles it, with `gather`/`shard`; see "Reading a
+   value between two sharded modules" below. Reaching for `.source` on a sharded
+   model warns, so this is not a surprise.
 
 **Every rank produces the same saved values**, since they are computed from
 gathered tensors. Print or write results from one rank, or you get N copies.
 
-## Requires transformers >= 5.15
+## Reading a value between two sharded modules
 
-Below that, a checkpoint with `tie_word_embeddings=True` — Llama-3.2, Qwen2.5,
-most small models — has its LM head gathered but never sharded, so logits come
-back `tp_size` times too wide. The argmax still lands inside the first copy, so
-nothing downstream looks wrong. nnsight raises `UnsupportedTransformersVersion`
-rather than let that through.
+A module's `.input`/`.output` is gathered for you. A value *between* two sharded
+modules is not, and this is the one place a trace does not read as it would on
+one GPU.
+
+The shard is created by a column-parallel module and consumed by the
+row-parallel one after it, so everything in between is one rank's slice:
+
+```
+gate_proj [colwise] ─▶  (1,11,64)  →  (1,11,32)   ┐
+act_fn                  (1,11,64)  →  (1,11,32)   │  every value here
+up_proj   [colwise]     (1,11,64)  →  (1,11,32)   │  is this rank's slice
+down_proj [rowwise] ─▶  (1,11,16)  →  (1,11,16)   ┘  ← whole again
+```
+
+nnsight cannot gather these for you, because **nothing on the value says how it
+is split.** transformers tracks the layout only while a value is inside the
+module that made it; on the way out it unwraps to an ordinary tensor, and a
+32-wide slice of a 64-wide activation is then indistinguishable from a genuine
+32-wide one. Worse, the axis moves: attention's `view`/`transpose` puts the shard
+on the *head* dimension, so there is not even a fixed axis to assume.
+
+You know what the forward did, so you say which axis, with
+[`gather`][nnsight.modeling.tp.fragments.gather] and its inverse
+[`shard`][nnsight.modeling.tp.fragments.shard]:
+
+```python
+from nnsight.modeling.tp import gather, shard
+
+attn = model.model.layers[1].self_attn
+
+with model.trace(prompt):
+    q = attn.source.query_states_0.output   # (1, heads/tp_size, seq, head_dim)
+    heads = gather(model, q, dim=1).save()  # (1, heads, seq, head_dim) — every head
+```
+
+To edit one, put this rank's piece back before the forward carries on — and
+clone first, per rule 3:
+
+```python
+with model.trace(prompt):
+    q = attn.source.query_states_0.output
+    heads = gather(model, q, dim=1).clone()
+    heads[:, 3] = 0                                  # ablate head 3, whoever holds it
+    attn.source.query_states_0.output = shard(model, heads, dim=1)
+    logits = model.lm_head.output.save()
+```
+
+Measured on Llama at tp=2 against the same block on one GPU: the gathered
+`query_states` is `(1,4,11,4)` either way with the same sum, and ablating head 3
+gives logits summing to `-19.721992` against `-19.722000`.
+
+Both are **collectives**, so rule 1 applies with full force: every rank must
+reach them. Call them unconditionally, never inside a branch that could go
+differently on different ranks. They are no-ops on an unsharded model, so the
+same block runs at any degree — which is also how you keep one script working on
+one GPU and on eight.
+
+If you are not sure which axis holds the shard, print the shape at tp=1 and at
+tp=2 and compare: the axis that shrank by `tp_size` is the one.
+
+## Requires transformers >= 5.16
+
+5.16 rebuilt tensor parallelism on DTensor. The sharding plan moved from a stamp
+on each sharded module to a single `_tp_plan` on the model, and the style's
+collectives moved from forward hooks into a wrapper around `module.forward`.
+nnsight reads the layout the way that backend describes it, so on an older
+transformers it finds nothing sharded — which does not fail, it hands
+intervention code one rank's slice as though it were the whole tensor. nnsight
+raises `UnsupportedTransformersVersion` rather than let that through.
+
+(5.15 and below had a defect of their own: a checkpoint with
+`tie_word_embeddings=True` — Llama-3.2, Qwen2.5, most small models — had its LM
+head gathered but never sharded, so logits came back `tp_size` times too wide
+with the argmax still inside the first copy.)
 
 ## A checkpoint that cannot be split at all
 
@@ -174,19 +276,48 @@ config supports; every workable degree is one of its divisors, and `None` means
 the model has to be spread some other way (one GPU, or `device_map` over
 several).
 
+## Expert parallelism
+
+A mixture-of-experts checkpoint can be split by *expert* instead of along the
+feature dimension. Ask for it the way transformers does — it applies the model's
+`base_model_ep_plan` in place of its tensor-parallel one:
+
+```python
+model = TransformersModel(
+    "openai/gpt-oss-20b",
+    task="text-generation",
+    distributed_config=DistributedConfig(tp_size=4, enable_expert_parallel=True),
+    dispatch=True,
+)
+```
+
+Traces read the same as any other. The three styles an expert plan uses need
+less gathering than the name suggests: `ep_router` leaves the router replicated
+and masks non-local experts *after* the handoff, `grouped_gemm` shards expert
+parameters and installs no transform at all, and `moe_tp_experts` produces this
+rank's term of a sum, which is reduced for you like any row-parallel output.
+
+The degree has to divide the **expert count** rather than the head counts, and
+nnsight checks that before the weights are fetched — `tp_size=3` on a 4-expert
+model raises `UnshardableCheckpoint` rather than loading and failing.
+
+**Plain tensor parallelism on an MoE checkpoint is also fine.** `moe_tp_experts`,
+which Mixtral, DeepSeek-V3, Qwen3-MoE and around twenty-five other shipped
+configs use, all-reduces inside its own forward.
+
 ## What is not supported
 
-A few expert-parallel styles slice by *expert* rather than along the feature
-dimension, so the gather here does not apply: `grouped_gemm`, `ep_router`,
-`megamoe_*`, `moe_identity_expert`, and MLA's split kv projection
-(`mla_kv_a_proj`). Loading such a model tensor-parallel raises
-`UnsupportedParallelStyle` naming the module and style — deliberately, rather than
-handing you a fragment of a tensor and letting you draw conclusions from it.
+Four styles are still refused: `megamoe_router`, `megamoe_experts`,
+`moe_identity_expert`, and MLA's split kv projection (`mla_kv_a_proj`). Loading a
+model that uses one raises `UnsupportedParallelStyle` naming the module and
+style — deliberately, rather than handing you a fragment of a tensor and letting
+you draw conclusions from it.
 
-**Most mixture-of-experts checkpoints are fine.** `moe_tp_experts`, which Mixtral,
-DeepSeek-V3, Qwen3-MoE and around twenty-five other shipped configs use,
-all-reduces inside its own forward — both sides arrive whole and nothing needs
-gathering.
+They are refused because no model in the test set exercises them, not because
+they are known to be ungatherable. `ep_router` and `grouped_gemm` sat in this
+list until a model using them was actually run end to end, at which point both
+turned out to need no gather at all. Reading a style's transforms is not the same
+as having run one, which is the mistake the table exists to prevent.
 
 `float`/`bfloat16` results differ slightly from a single-GPU run (relative error
 around 1e-3 to 1e-2, growing with depth) because an all-reduce sums in a
@@ -203,8 +334,9 @@ leave — once per visit, and only when something is actually waiting to read it
 
 Every `HuggingFaceModel` is built with an ordinary interleaver carrying one of
 these. It stays inert (`enabled = False`, one attribute check per location) until
-it instruments a module transformers has stamped with a `_hf_tp_plan`, which is
-also where it records the rules. That covers eager loading and the
+it instruments a module the model's own `tp_plan` names — with `_device_mesh`
+set, which is what says the model was really split — and that is where it records
+the rules. That covers eager loading and the
 meta-then-`dispatch()` path without either needing to know about it.
 
 The same seam serves vLLM's tensor parallelism, which shards differently and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,10 @@ dependencies = [
     "pydantic",
     "pyyaml",
     "cloudpickle",
-    # HuggingFace models (TransformersModel, tokenizers, hub access).
+    # HuggingFace models (TransformersModel, tokenizers, hub access). Unpinned:
+    # only tensor parallelism needs a floor, and it checks for itself at load
+    # (see `nnsight.modeling.tp.fragments.MINIMUM_TRANSFORMERS`) rather than
+    # holding every other user to it.
     "transformers",
     "huggingface-hub",
     # Remote execution on NDIF.

--- a/src/nnsight/intervention/envoy.py
+++ b/src/nnsight/intervention/envoy.py
@@ -577,7 +577,36 @@ class Envoy:
         # source.{name}_{occurrence} (e.g. source.relu_0.output). A class-level
         # property, so it wins over the __getattr__ module fallthrough. Building
         # it permanently source-instruments the module (inert outside a trace).
+        self._warn_if_fragmented()
         return Source(self, self.path, install_source(self))  # raises SourceNotAvailable
+
+    def _warn_if_fragmented(self) -> None:
+        """Warn that operation values are this device's piece, on a sharded model.
+
+        A module's ``.input``/``.output`` is reassembled for the trace; a value
+        *inside* a forward is not, because nothing on it records which axis holds
+        the shard once it has left the module that produced it — and the axis
+        moves, so there is nothing safe to assume. Handing it over silently is
+        how a per-head read comes back with half the heads and no error, so the
+        one place that cannot happen without notice is here, where the user
+        reaches for it.
+
+        Once per call site, which is Python's default for a warning, so a loop
+        over layers says it once.
+        """
+        fragments = getattr(self.interleaver, "fragments", None)
+        if fragments is None or not fragments.enabled:
+            return
+        warnings.warn(
+            f"'{self.path}' is on a model split across devices, and values inside "
+            "a module's forward are handed over as this device's piece — only a "
+            "module's own .input/.output is made whole. Reassemble one with "
+            "nnsight.modeling.tp.gather(model, value, dim=...), naming the axis "
+            "the shard is on, and put it back with the matching shard(...). See "
+            "the tensor-parallel docs, 'Reading a value between two sharded "
+            "modules'.",
+            stacklevel=3,
+        )
 
     def to(self, device: torch.device) -> Envoy:
         """Move the wrapped module to ``device`` (in place).

--- a/src/nnsight/intervention/fragments.py
+++ b/src/nnsight/intervention/fragments.py
@@ -30,9 +30,13 @@ it, with no memoization to keep in step.
 * **Never branch on rank.** Every rank runs the same intervention block and must
   reach the same collectives in the same order. `fragmented` in particular is
   asked on every rank and must answer identically on all of them.
-* **`fragment` must undo `whole`.** What comes back goes into the model's own
-  forward. A value `whole` passed through untouched must come back untouched — a
+* **`whole`'s ``undo`` must reverse it.** What comes back goes into the model's
+  own forward. A value passed through untouched must come back untouched — a
   tensor that was never a fragment must not be split.
+* **`split` is not that operation.** It cuts down a value that was never
+  gathered, so the location's rule is all it has to work from. Serving both from
+  one method let the assembling path and the ad-hoc path be mistaken for each
+  other, and a nested ad-hoc call consumed the record its caller was still using.
 """
 
 from __future__ import annotations
@@ -76,19 +80,31 @@ class Fragments:
         """
         return False
 
-    def whole(self, location: str, value: Any) -> Any:
-        """The real value at ``location``, assembled from every device's piece.
+    def whole(self, location: str, value: Any) -> "tuple[Any, Any]":
+        """The real value at ``location``, and how to put back what that took.
+
+        Returns ``(whole, undo)``. ``undo`` is called with whatever intervention
+        code left behind — so an edit to the assembled tensor is carried back into
+        the model rather than discarded — or is ``None`` when there was nothing to
+        assemble.
+
+        Handed back rather than looked up again later because only this call knows
+        what it did: where a value can describe its own layout, the way back
+        depends on the value that arrived and not on the location alone. Holding
+        that on the caller's stack is also what keeps a nested handoff — an ad-hoc
+        call made while this visit is still open — from consuming it.
 
         Only called when `fragmented` said so *and* something is actually waiting
         to read it. Default: unreachable, since nothing is ever fragmented.
         """
-        return value
+        return value, None
 
-    def fragment(self, location: str, whole: Any) -> Any:
-        """This device's piece of ``whole``, as the model's own forward expects.
+    def split(self, location: str, whole: Any) -> Any:
+        """This device's piece of an already-whole value, from the rule alone.
 
-        The inverse of `whole`, called with whatever intervention code left
-        behind — so an edit made to the assembled tensor is carried back into the
-        model rather than discarded.
+        For values that never came out of the model and so were never assembled: a
+        `.skip` replacement, and the argument of an ad-hoc call on a sharded
+        module. Both are the real tensor already, and both have to be cut down
+        before the model's own forward sees them.
         """
         return whole

--- a/src/nnsight/intervention/interleaver.py
+++ b/src/nnsight/intervention/interleaver.py
@@ -727,10 +727,9 @@ class Interleaver:
         # worker will be served on *this* occurrence or a selected cache records
         # it. Every rank derives this from the same provider routes, keeping their
         # collectives matched.
-        gathering = False
+        undo = None
         if self.fragments is not None and self.fragments.enabled and self.fragments.fragmented(provider) and (observers or self._ready(provider)):
-            gathering = True
-            value = self.fragments.whole(provider, value)
+            value, undo = self.fragments.whole(provider, value)
 
         # Serving one worker can release another into parking here (a barrier),
         # so keep serving until nobody is parked on this visit.
@@ -767,8 +766,8 @@ class Interleaver:
         # Back to the piece the model's own forward expects, carrying whatever the
         # workers left behind — so an edit to the assembled tensor reaches the
         # model rather than being dropped with the gather.
-        if gathering:
-            value = self.fragments.fragment(provider, value)
+        if undo is not None:
+            value = undo(value)
         return value
 
     def check_dangling_mediators(self) -> None:

--- a/src/nnsight/intervention/source.py
+++ b/src/nnsight/intervention/source.py
@@ -505,6 +505,28 @@ def run_body(state: "State", module: Any, args: tuple, kwargs: dict) -> Any:
     return hook.post_forward(module, output)
 
 
+def _as_fragment(interleaver: Any, location: str, value: Any) -> Any:
+    """A ``.skip`` replacement, cut down to this device's piece of the location.
+
+    Everything past the handoff assumes the value arriving is one device's piece.
+    A replacement is not: the user built it, so on a sharded runtime it is already
+    the whole thing on every device. Cutting it down here means the handoff serves
+    it exactly like a value the module produced, and nothing downstream — not
+    [`Interleaver.handle`][nnsight.intervention.interleaver.Interleaver.handle],
+    not a runtime's [`Fragments`][nnsight.intervention.fragments.Fragments] — needs
+    a second kind of value to reason about.
+
+    Only the skip branch reaches this, so it costs an ordinary forward nothing.
+    Without it a row-parallel skip was reassembled as though the module had
+    produced it: every rank read back ``world_size`` times what it wrote, and the
+    model carried that forward, with nothing raising.
+    """
+    fragments = interleaver.fragments
+    if fragments is not None and fragments.enabled and fragments.fragmented(location):
+        return fragments.split(location, value)
+    return value
+
+
 def make_controller(module: Any, state: "State") -> Callable:
     """Build the forward installed on an instrumented module: the module's handoff.
 
@@ -535,8 +557,9 @@ def make_controller(module: Any, state: "State") -> Callable:
         args, kwargs = handle(locations[0], (args, kwargs))
         output = handle(locations[1], NO_SKIP)  # the skip gate
         if output is NO_SKIP:
-            output = run_body(state, module, args, kwargs)
-        return handle(locations[2], output)
+            return handle(locations[2], run_body(state, module, args, kwargs))
+        # A skipped module's output is the replacement the worker supplied.
+        return handle(locations[2], _as_fragment(interleaver, locations[2], output))
 
     return controller
 

--- a/src/nnsight/modeling/huggingface.py
+++ b/src/nnsight/modeling/huggingface.py
@@ -147,9 +147,14 @@ class HuggingFaceModel(Remotable):
         differently on each path, and a check that silently sees nothing is worse
         than no check.
         """
-        from .tp import check_tp_request, requested_tp_size
+        from .tp import (
+            check_tp_request,
+            requested_expert_parallel,
+            requested_tp_size,
+        )
 
-        tp_size = requested_tp_size(kwargs.get("distributed_config"))
+        distributed = kwargs.get("distributed_config")
+        tp_size = requested_tp_size(distributed)
         if tp_size is None:
             # The ordinary path: no degree asked for, so no config to read.
             return
@@ -157,7 +162,9 @@ class HuggingFaceModel(Remotable):
         from transformers import AutoConfig
 
         check_tp_request(
-            AutoConfig.from_pretrained(repo_id, revision=self.revision), tp_size
+            AutoConfig.from_pretrained(repo_id, revision=self.revision),
+            tp_size,
+            requested_expert_parallel(distributed)
         )
 
     def _load(self, repo_id: str, *args: Any, **kwargs: Any) -> torch.nn.Module:

--- a/src/nnsight/modeling/tp/__init__.py
+++ b/src/nnsight/modeling/tp/__init__.py
@@ -11,6 +11,9 @@ they are reassembled, and
 
 from .fragments import (
     MINIMUM_TRANSFORMERS,
+    device_mesh,
+    gather,
+    shard,
     SIDES,
     UNSUPPORTED,
     TPFragments,
@@ -21,11 +24,15 @@ from .plan import (
     UnshardableCheckpoint,
     check_tp_request,
     max_tp_size,
+    requested_expert_parallel,
     requested_tp_size,
 )
 
 __all__ = [
     "MINIMUM_TRANSFORMERS",
+    "device_mesh",
+    "gather",
+    "shard",
     "SIDES",
     "UNSUPPORTED",
     "TPFragments",
@@ -34,5 +41,6 @@ __all__ = [
     "UnshardableCheckpoint",
     "check_tp_request",
     "max_tp_size",
+    "requested_expert_parallel",
     "requested_tp_size",
 ]

--- a/src/nnsight/modeling/tp/envoys.py
+++ b/src/nnsight/modeling/tp/envoys.py
@@ -79,9 +79,16 @@ class TPEnvoy(Envoy):
         Every rank runs the block, so every rank reaches the same collectives in
         the same order — as long as the call is not under rank-dependent control
         flow, the condition every collective in a block carries.
+
+        ``hook`` does not change this. It says whether the *trace* watches the
+        call, which is a separate question from whether the caller is holding
+        whole tensors; and the handoff it turns on brackets the value and puts it
+        back, so it leaves this caller's return value exactly as it found it. When
+        ``hook`` short-circuited the bracket, an observer at ``.output`` saw the
+        whole tensor while the caller of the same call got this rank's slice.
         """
         fragments = self.interleaver.fragments
-        if hook or fragments is None or not fragments.enabled:
+        if fragments is None or not fragments.enabled:
             return super().__call__(*args, hook=hook, **kwargs)
 
         # Asked of the fragments rather than read off the module: up to 5.15

--- a/src/nnsight/modeling/tp/envoys.py
+++ b/src/nnsight/modeling/tp/envoys.py
@@ -14,20 +14,18 @@ caller's whole input, run the module, reassemble the output, all off
 `TPFragments`' own rules.
 
 What is *not* needed here is any handling of the collectives themselves.
-transformers keeps them in forward hooks rather than inside ``forward``
-(``distribute_module`` registers the style's ``_prepare_input_fn`` as a pre-hook
-and ``_prepare_output_fn`` as a post-hook), and
 [`Envoy.__call__`][nnsight.intervention.envoy.Envoy.__call__] runs the module the
 ordinary way — standing the interleaver down rather than dodging ``__call__`` —
-so those hooks fire on their own. That is what makes a row-parallel layer's
-all-reduce and ``colwise_gather_output``'s all-gather happen without this module
-restating them.
+so the style's own transforms fire around the call, which is what makes a
+row-parallel layer's all-reduce and ``colwise_gather_output``'s all-gather happen
+without this module restating them.
 
-It does mean the style's *pre*-hook fires too, which is why re-splitting the
-input is conditional: see
+It does mean the style's *input* transform runs too, which is why re-splitting
+the input is conditional: see
 [`SPLITS_ITS_OWN_INPUT`][nnsight.modeling.tp.envoys.SPLITS_ITS_OWN_INPUT].
 
-Parameters are left alone. ``layer.weight`` is this rank's real slice, as it is
+Parameters are left alone. ``layer.weight`` is the ``DTensor`` transformers made
+of it — this rank holds a slice, while ``.shape`` reports the whole — as it is
 anywhere else under transformers tensor parallelism.
 """
 
@@ -38,32 +36,32 @@ from typing import Any
 import torch
 
 from ...intervention.envoy import Envoy
-from .fragments import _gather
+from .fragments import _gather, _placement
 
-#: Styles whose own pre-hook splits the input for them.
+#: Styles whose own input transform splits the input for them.
 #:
-#: Both of these take a *whole* tensor at the module boundary, so a caller
-#: handing one in has already given the hook what it wants and nnsight must not
-#: cut it down first — the hook would then cut the slice again. Every other
-#: sharded-input style (plain ``rowwise``, ``packed_rowwise``) receives an input
-#: that was already split by the column-parallel layer upstream, so its pre-hook
-#: passes the value straight through and the caller's whole tensor *is* what
-#: needs splitting.
+#: These expect a *whole* tensor at the module boundary, so a caller handing one
+#: in has already given the transform what it wants and nnsight must not cut it
+#: down first — the transform would then cut the slice again. Every other
+#: sharded-input style receives an input the column-parallel layer upstream had
+#: already split, passes it straight through, and so needs the caller's whole
+#: tensor split here.
 #:
-#: Read off ``RowwiseParallel._prepare_input_fn``, which splits only when its
-#: ``split_input`` is set — true for ``rowwise_split_input`` alone among the
-#: styles transformers registers.
-SPLITS_ITS_OWN_INPUT = ("rowwise_split_input",)
+#: Read off ``RowwiseParallel``, which redistributes when the input layout it
+#: declares is not the one its sharded weight needs — true of exactly those
+#: registered with ``input_layouts=Replicate()``. Plain ``rowwise`` declares
+#: ``Shard(-1)`` and passes through.
+SPLITS_ITS_OWN_INPUT = ("rowwise_split_input", "rowwise_rep")
 
-#: Styles whose output is still this rank's slice *after* the module's own
-#: post-hook has run. An ad-hoc call runs those hooks, so the value it returns
-#: is the post-hook one: a row-parallel output has been all-reduced and a
+#: Styles whose output is still this rank's slice *after* the module's own output
+#: transform has run. An ad-hoc call runs that transform, so what it returns is
+#: the finished value: a row-parallel output has been all-reduced and a
 #: ``colwise_gather_output`` head gathered (both whole, nothing to do), while a
 #: plain column-parallel output is never gathered by transformers and a
 #: ``sequence_parallel`` one has just been reduce-scattered — both come back
-#: sharded on the last dim. This is the one place the post-hook view is needed;
-#: [`SIDES`][nnsight.modeling.tp.fragments.SIDES] describes the handoff's
-#: pre-hook view and must not be consulted for the output here.
+#: sharded on the last dim. This is the one place that finished view is needed;
+#: [`SIDES`][nnsight.modeling.tp.fragments.SIDES] describes the value at the
+#: handoff, *before* the transform, and must not be consulted for the output here.
 SHARDED_AFTER_CALL = ("colwise", "packed_colwise", "sequence_parallel")
 
 
@@ -86,29 +84,36 @@ class TPEnvoy(Envoy):
         if hook or fragments is None or not fragments.enabled:
             return super().__call__(*args, hook=hook, **kwargs)
 
-        module = self._module
-        style = getattr(module, "_hf_tp_plan", None)
+        # Asked of the fragments rather than read off the module: up to 5.15
+        # transformers stamped the style on each module it sharded, and 5.16
+        # keeps the plan on the model and stamps nothing, so the tree's own
+        # record is the only spelling that works on both.
+        style, mesh = fragments.style_at(self.path)
         into = f"{self.path}.input"
         if fragments.fragmented(into) and style not in SPLITS_ITS_OWN_INPUT:
-            args, kwargs = fragments.fragment(into, (args, kwargs))
+            # `split`, not the way back from a gather: the caller's tensor is
+            # whole because they are holding it, not because anything assembled
+            # it, and this call may be nested inside that location's own open
+            # handoff.
+            args, kwargs = fragments.split(into, (args, kwargs))
 
-        # The module's own hooks run inside this — the interleaver stands itself
-        # down rather than bypassing them — so the style's collectives happen
-        # here without being restated.
+        # The module's own transforms run inside this — the interleaver stands
+        # itself down rather than bypassing them — so the style's collectives
+        # happen here without being restated.
         result = super().__call__(*args, hook=False, **kwargs)
 
         if style in SHARDED_AFTER_CALL:
-            result = _gather(result, module._hf_device_mesh)
+            result = _gather(result, mesh, _placement("shard"))
         return result
 
 
 def tp_envoys() -> dict:
     """The ``envoys`` map pairing shardable module types with `TPEnvoy`.
 
-    Keyed by type rather than by style because a style is stamped on the
-    *instance* at load — the same ``nn.Linear`` class is ``colwise`` in one place
-    and ``rowwise`` in another — while the map is consulted per module as the
-    tree is built. `TPEnvoy` reads the stamp itself.
+    Keyed by type rather than by style because a style belongs to the *instance*
+    — the same ``nn.Linear`` class is ``colwise`` in one place and ``rowwise`` in
+    another — while the map is consulted per module as the tree is built.
+    `TPEnvoy` asks `TPFragments` which style its own path got.
     """
     return {
         torch.nn.Linear: TPEnvoy,
@@ -129,10 +134,14 @@ def wants_tensor_parallel(target: Any, load_kwargs: dict) -> bool:
     handing back slices. Hence ``tp_plan`` counts even with no ``tp_size``.
     """
     if isinstance(target, torch.nn.Module):
-        return any(
-            getattr(m, "_hf_tp_plan", None) is not None
-            and getattr(getattr(m, "_hf_device_mesh", None), "size", lambda: 1)() > 1
-            for m in target.modules()
+        # transformers keeps both on the model. `_tp_plan` alone proves nothing —
+        # every model declares one whether or not it was loaded across ranks — so
+        # the mesh is the test.
+        mesh = getattr(target, "_device_mesh", None)
+        return bool(
+            getattr(target, "_tp_plan", None)
+            and mesh is not None
+            and getattr(mesh, "size", lambda: 1)() > 1
         )
 
     config = load_kwargs.get("distributed_config")

--- a/src/nnsight/modeling/tp/fragments.py
+++ b/src/nnsight/modeling/tp/fragments.py
@@ -8,28 +8,45 @@ worker sees them and re-split before the model's own forward carries on.
 
 Two facts make this cheap to arrange.
 
-**transformers labels the shards for us.** ``apply_tensor_parallelism`` stamps
-every module it shards with ``_hf_tp_plan`` (the style name) and
-``_hf_device_mesh``, so which side of which module carries a shard is read off
-the module, not guessed. These rules are handed every envoy through
-``instrument`` as the tree is built, so they record themselves — and learn whether
-there is anything to do at all — right there.
+**transformers labels the shards for us**, in one of two ways, because it has
+used both. Up to 5.15 ``apply_tensor_parallelism`` stamped every module it
+sharded with ``_hf_tp_plan`` (the style name) and ``_hf_device_mesh``. 5.16
+rebuilt tensor parallelism on DTensor and stamps nothing: the plan stays on the
+*model* as ``_tp_plan`` — glob patterns over module paths — with the mesh at
+``_device_mesh``, and each module is resolved against it by transformers' own
+matcher. Either way which side of which module carries a shard is read off the
+model, not guessed. These rules are handed every envoy through ``instrument`` as
+the tree is built, so they record themselves — and learn whether there is
+anything to do at all — right there.
 
 **nnsight sees the pre-collective value.** The interleaver's handoff runs inside
-a module's forward — after transformers' pre-hook, before its post-hook — so a
-row-parallel output is still this rank's *partial sum* there, and a
-``colwise_gather_output`` head still a shard. [`SIDES`][nnsight.modeling.tp.fragments.SIDES]
-says which, per style, and [`TPFragments.whole`][nnsight.modeling.tp.fragments.TPFragments.whole]
+a module's forward — after the style's input transform, before its output one —
+so a row-parallel output is still this rank's *partial sum* there, and a
+``colwise_gather_output`` head still a shard.
+[`SIDES`][nnsight.modeling.tp.fragments.SIDES] says which, per style, and
+[`TPFragments.whole`][nnsight.modeling.tp.fragments.TPFragments.whole]
 all-gathers a shard or all-reduces a partial. What goes back is chosen so the
-module's own post-hook completes the picture: a shard's slice, or — for a
-partial — the whole on rank 0 and zeros elsewhere, which the post-hook's reduce
-turns into exactly the (possibly edited) whole on every rank.
+module's own output transform completes the picture: a shard's slice, or — for a
+partial — the whole on rank 0 and zeros elsewhere, which its reduce turns into
+exactly the (possibly edited) whole on every rank.
+
+Keeping the handoff *inside* those transforms is arranged differently per
+backend. 5.15 registered them as torch pre/post hooks, which bracket a forward on
+their own. 5.16 applies a style by replacing ``module.forward`` with a wrapper —
+the same slot nnsight's controller uses — so `_keep_tp_forward` installs the
+controller first and re-wraps it, restoring that order. Without it the module
+keeps its sharded weights but loses the code that makes its inputs match them,
+and the first matmul dies with ``got mixed torch.Tensor and DTensor``.
 
 The rules describe module *boundaries*. A ``.source`` value between two ops
 inside a forward can be a shard split on an axis that moves through the forward,
-so it is handed over as-is: whole past the layer that all-reduces, this rank's
-slice between a column-parallel layer and it. Compare against a single-GPU run
-if it matters, and never branch on one — the ranks would diverge.
+so a boundary rule cannot say what it is. On the DTensor backend such a value
+often carries its own placement — ``full_tensor`` then reassembles it correctly
+whatever axis holds the shard, which is why the gather believes a value's own
+placement over the rule whenever it has one. When it does not (transformers takes
+a local fast path for ``nn.Linear`` with grad disabled, and for quantized
+modules) the value is handed over as-is, as it always was: compare against a
+single-GPU run if it matters, and never branch on one — the ranks would diverge.
 
 Every rank runs the same intervention block, so every rank reaches ``handle`` at
 the same location with the same parked workers and makes the same decision to
@@ -73,22 +90,26 @@ SIDES: Dict[str, Dict[str, str]] = {
     "colwise": {"output": "shard"},                       # * output features split
     "packed_colwise": {"output": "shard"},                #   (fused gate_up, same split)
     "colwise_gather_output": {"output": "shard"},         # * gathered by its post-hook, after us
+    "colwise_rep": {"output": "shard"},                   # = colwise_gather_output (see below)
     "rowwise": {"input": "shard", "output": "partial"},   # * input pre-split; post-hook all-reduces
     "rowwise_split_input": {"input": "shard", "output": "partial"},  # pre-hook splits the input
+    "rowwise_rep": {"input": "shard", "output": "partial"},          # = rowwise_split_input
     "packed_rowwise": {"input": "shard", "output": "partial"},
     "embedding_rowwise": {"output": "partial"},           # * vocab-parallel; post-hook all-reduces
-    "embedding_colwise": {"output": "partial"},           # + post-hook all-reduces (see below)
     "sequence_parallel": {"output": "partial"},           # + post-hook reduce-scatters, on the LAST dim
     "all_reduce": {"output": "partial"},
     "replicated_with_grad_allreduce": {},                 #   params replicated; activations whole
+    "ep_router": {},                                      # * router is replicated; its post-transform
+                                                          #   masks non-local experts, after us
+    "grouped_gemm": {},                                   # * shards expert parameters only; the
+                                                          #   wrapper it installs is the identity
     "moe_tp_experts": {"output": "partial"},              # + post-hook all-reduces (see below)
 }
 
-# Entries marked + follow from reading transformers/integrations/tensor_parallel.py
-# rather than from running a model: ``embedding_colwise`` and ``moe_tp_experts``
-# end in an unconditional ``all_reduce_forward`` post-hook (so a partial, not the
-# shard its name suggests), and ``sequence_parallel`` reduce-scatters on the last
-# dim in its post-hook (whole-width partial at the handoff).
+# Entries marked + follow from reading transformers' style classes rather than
+# from running a model: ``moe_tp_experts`` ends in an unconditional all-reduce (so
+# a partial, not the shard its name suggests), and ``sequence_parallel``
+# reduce-scatters on the last dim (a whole-width partial at the handoff).
 
 # Styles refused rather than guessed at, with the reason a user is shown: these
 # slice something other than the last dim — by expert, or into a fused kv
@@ -96,24 +117,21 @@ SIDES: Dict[str, Dict[str, str]] = {
 # them. Read the style's ``_prepare_input_fn``/``_prepare_output_fn`` before
 # adding one; the name alone misled on ``moe_tp_experts``.
 UNSUPPORTED: Dict[str, str] = {
-    "grouped_gemm": "expert-parallel (MoE)",
-    "ep_router": "expert-parallel (MoE)",
     "megamoe_router": "expert-parallel (MoE)",
     "megamoe_experts": "expert-parallel (MoE)",
     "moe_identity_expert": "expert-parallel (MoE)",
     "mla_kv_a_proj": "MLA split kv projection",
 }
 
-# The oldest transformers whose tensor parallelism produces correct activations.
-#
-# 5.14.1 shards a tied LM head's *hook* but not its weight, so on a checkpoint
-# with `tie_word_embeddings=True` the head keeps its full weight while
-# `colwise_gather_output` all-gathers the result anyway: logits come back
-# `tp_size` times too wide, inside transformers, before nnsight sees anything.
-# Nothing downstream looks wrong — the argmax still lands inside the first copy —
-# so it survives every casual check. Measured on Llama-3.2-3B at tp=4: width
-# 513024 against a vocabulary of 128256 on 5.14.1, correct on 5.15.0.
-MINIMUM_TRANSFORMERS = "5.15.0"
+# The oldest transformers this supports. 5.16 rebuilt tensor parallelism on
+# DTensor: the plan moved from a per-module ``_hf_tp_plan`` stamp to the model's
+# ``_tp_plan``, the style's transforms moved from forward hooks into a wrapper
+# that replaces ``module.forward``, and the ``all_gather``/``split`` helpers were
+# removed. Supporting both shapes at once meant two detection paths and two
+# descriptions of one handoff; 5.15's own TP had a separate defect anyway (5.14.1
+# sharded a tied LM head's hook but not its weight, returning logits ``tp_size``
+# times too wide). One backend, described once.
+MINIMUM_TRANSFORMERS = "5.16.0"
 
 
 class UnsupportedTransformersVersion(RuntimeError):
@@ -144,11 +162,7 @@ def _check_transformers_version() -> None:
 
     raise UnsupportedTransformersVersion(
         f"tensor parallelism needs transformers >= {MINIMUM_TRANSFORMERS}, but "
-        f"{installed} is installed. Older versions do not shard a tied LM head's "
-        "weight while still gathering its output, so a model with "
-        "`tie_word_embeddings=True` returns logits `tp_size` times too wide — "
-        "wrong in a way that still produces a plausible argmax. Upgrade "
-        "transformers, or load this model on one GPU."
+        f"{installed} is installed."
     )
 
 
@@ -159,59 +173,321 @@ class UnsupportedParallelStyle(Exception):
     """The model shards something interventions can't be shown whole."""
 
 
-def _shardable(tensor: torch.Tensor, world_size: int) -> bool:
-    """Whether ``tensor`` can be this rank's slice of a last-dim shard.
+def _placement(kind: str) -> Any:
+    """The DTensor placement a rule's ``kind`` names."""
+    from torch.distributed.tensor import Partial, Shard
 
-    A sharded activation is a float tensor with a last dim; anything else (an
-    integer mask, a scalar) cannot be what was split, so it passes through
-    untouched rather than being corrupted by a collective. Only the whole being
-    split back has to chunk evenly — a shard's own width need not divide.
+    return Partial() if kind == "partial" else Shard(-1)
+
+
+def _whole_tensor(tensor: torch.Tensor, mesh: Any, placement: Any) -> torch.Tensor:
+    """One rank's piece of ``tensor``, assembled into the real thing.
+
+    Reads the placement off the value when it carries one and asserts the rule's
+    otherwise. A DTensor already knows what it is — including which axis holds the
+    shard, which a rule cannot know once a ``view`` or ``transpose`` has moved it —
+    so it is always believed over the rule.
+
+    Written on DTensor rather than on ``transformers``' ``all_gather``/``split``,
+    which is where this used to go: 5.16 rebuilt tensor parallelism on DTensor and
+    removed both, and depending on a neighbour's private helpers is what made a
+    routine upstream release silently disable the whole path. These are equivalent
+    — an all-gather concatenating on the last dim, an all-reduce summing — and
+    depend on nothing but ``torch``.
     """
-    return tensor.is_floating_point() and tensor.dim() >= 1 and tensor.shape[-1] % world_size == 0
+    from torch.distributed.tensor import DTensor
+
+    if isinstance(tensor, DTensor):
+        whole = tensor.full_tensor()
+    else:
+        whole = DTensor.from_local(
+            tensor, mesh, [placement], run_check=False
+        ).full_tensor()
+
+    # Returned as it comes. `full_tensor` is a custom autograd Function, so with
+    # the graph live torch forbids editing its output in place and a
+    # `value[...] = x` raises — the caller clones first, which is documented in
+    # docs/models/tensor-parallel.md. Cloning here instead would spend a copy the
+    # size of the gathered tensor on every gather, including the runs that trace
+    # the largest models and never edit anything.
+    return whole
 
 
-def _gather(value: Any, mesh: Any) -> Any:
-    """Every rank's slice of ``value``, concatenated back into the whole tensor."""
-    from transformers.integrations.tensor_parallel import all_gather
+class _OnRankZero(torch.autograd.Function):
+    """``whole`` on rank 0 and zeros elsewhere, without cutting the graph.
 
+    The forward is what makes a partial come back right: the module's own output
+    transform sums across ranks, so contributing the whole once and nothing
+    elsewhere reconstitutes exactly the (possibly edited) whole on every rank.
+
+    Doing that with a bare ``torch.zeros_like`` produced a fresh leaf, so on every
+    rank but 0 the value the model carried on with had no history back to the
+    gathered tensor. The graphs then differed *by rank*: a ``backward()`` through
+    a row-parallel output hangs, because the ranks stop reaching the same
+    collectives — the deadlock the no-rank-branching rule exists to prevent,
+    reached without any branch in the user's block.
+
+    The backward is the identity on every rank, which is also what it should be
+    on the merits: the transform ahead of this all-reduces, and an all-reduce
+    passes its incoming gradient to each rank's term unchanged.
+    """
+
+    @staticmethod
+    def forward(ctx, whole: torch.Tensor, keep: bool) -> torch.Tensor:
+        return whole if keep else torch.zeros_like(whole)
+
+    @staticmethod
+    def backward(ctx, grad: torch.Tensor):
+        return grad, None
+
+
+def _fragment_tensor(
+    whole: torch.Tensor, mesh: Any, placement: Any, as_dtensor: bool
+) -> torch.Tensor:
+    """What this rank hands its forward back, given the assembled ``whole``.
+
+    A shard's own slice again. For a partial, the whole on rank 0 and zeros
+    elsewhere — the module's own post-transform sums across ranks, so that yields
+    exactly the (possibly edited) whole on every one of them.
+
+    ``as_dtensor`` reproduces what arrived: a value that came in carrying its
+    placement has to leave carrying it, because the post-transform downstream will
+    redistribute it and expects a DTensor to do that to.
+    """
+    from torch.distributed.tensor import DTensor, Partial, Replicate
+
+    if isinstance(placement, Partial):
+        local = _OnRankZero.apply(whole, mesh.get_local_rank() == 0)
+    else:
+        local = (
+            DTensor.from_local(whole, mesh, [Replicate()], run_check=False)
+            .redistribute(placements=[placement])
+            .to_local()
+        )
+    if as_dtensor:
+        return DTensor.from_local(local, mesh, [placement], run_check=False)
+    return local
+
+
+def _gatherable(tensor: torch.Tensor) -> bool:
+    """Whether ``tensor`` can be one rank's piece of a larger one.
+
+    An integer mask or a scalar cannot be what was split, so it passes through
+    untouched rather than being corrupted by a collective. A DTensor is a piece by
+    construction, whatever it holds.
+    """
+    from torch.distributed.tensor import DTensor
+
+    return isinstance(tensor, DTensor) or (
+        tensor.is_floating_point() and tensor.dim() >= 1
+    )
+
+
+def _divisible(tensor: torch.Tensor, placement: Any, world_size: int) -> bool:
+    """Whether ``tensor`` can be cut back into equal pieces along the sharded axis.
+
+    Asked on the way back only: the whole has to chunk evenly, while a shard's own
+    width never has to. A partial is whole-width on every rank and is not cut at
+    all, so nothing constrains it. The axis comes from the placement rather than
+    being assumed to be the last one — a value that carried its own placement can
+    be sharded on any axis, wherever a ``view`` or ``transpose`` moved it.
+    """
+    from torch.distributed.tensor import Shard
+
+    if not isinstance(placement, Shard):
+        return True
+    return tensor.shape[placement.dim] % world_size == 0
+
+
+def _gather(value: Any, mesh: Any, placement: Any) -> Any:
+    """Every rank's piece of ``value``, assembled into the whole tensor."""
     return apply(
         value,
-        lambda tensor: all_gather(tensor, mesh) if tensor.is_floating_point() and tensor.dim() else tensor,
+        lambda tensor: (
+            _whole_tensor(tensor, mesh, placement) if _gatherable(tensor) else tensor
+        ),
         torch.Tensor,
     )
 
 
-def _reduce(value: Any, mesh: Any) -> Any:
-    """Every rank's partial of ``value`` summed — the tensor the post-hook would make."""
-    import torch.distributed as dist
+def _reshard(value: Any, mesh: Any, placement: Any, as_dtensor: bool) -> Any:
+    """This rank's piece of ``value``, as the model's own forward expects it.
 
-    group = mesh.get_group()
-
-    def summed(tensor: torch.Tensor) -> torch.Tensor:
-        if not tensor.is_floating_point():
-            return tensor
-        total = tensor.clone()
-        dist.all_reduce(total, group=group)
-        return total
-
-    return apply(value, summed, torch.Tensor)
-
-
-def _reshard(value: Any, mesh: Any) -> Any:
-    """This rank's slice of ``value``, as the model's own forward expects it.
-
-    transformers' ``split`` is the exact inverse of its ``all_gather``, and both
-    are autograd functions. Guarded by the same predicate as the gather: a tensor
-    that was never a fragment must not be cut down here.
+    The exact inverse of `_gather`, and guarded the same way: a tensor that was
+    never a piece must not be cut down here.
     """
-    from transformers.integrations.tensor_parallel import split
-
     world_size = mesh.size()
+
     return apply(
         value,
         lambda tensor: (
-            split(tensor, mesh) if _shardable(tensor, world_size) else tensor
+            _fragment_tensor(tensor, mesh, placement, as_dtensor)
+            if _gatherable(tensor) and _divisible(tensor, placement, world_size)
+            else tensor
         ),
+        torch.Tensor,
+    )
+
+
+def _described(value: Any) -> "tuple[Any, Any] | None":
+    """The one ``(mesh, placement)`` every piece in ``value`` carries, or None.
+
+    None means the value does not describe itself, and the location's rule decides
+    instead. That covers three cases, all of which have to fall back: no DTensor
+    at all; several disagreeing about their layout; and a mix of DTensors and
+    ordinary tensors, where reassembly would be right for some and wrong for the
+    rest — and, worse, unrecoverable on the way back, since a gathered piece and a
+    tensor that was never one are indistinguishable by then.
+    """
+    from torch.distributed.tensor import DTensor
+
+    tensors = _tensors(value)
+    layouts = {
+        (tensor.device_mesh, tensor.placements)
+        for tensor in tensors
+        if isinstance(tensor, DTensor)
+    }
+    if len(layouts) != 1:
+        return None
+    if any(_gatherable(t) and not isinstance(t, DTensor) for t in tensors):
+        return None
+
+    mesh, placements = layouts.pop()
+    return mesh, placements[0]
+
+
+#: Marks a module whose controller has had the TP transforms put back around it,
+#: so re-instrumenting on dispatch does not wrap it a second time.
+_TP_WRAPPED = "_nnsight_tp_wrapped"
+
+
+def _tensors(value: Any) -> list:
+    """Every tensor inside ``value``, in whatever structure holds them."""
+    found: list = []
+    apply(value, lambda tensor: (found.append(tensor), tensor)[1], torch.Tensor)
+    return found
+
+
+def _is_tp_wrapped(module: Any) -> bool:
+    """Whether transformers put its TP transforms around this module's forward.
+
+    It installs them by replacing ``forward`` with a closure defined inside an
+    ``install_forward``, so the qualified name of whatever sits in the instance
+    ``__dict__`` is the record of what it did. Matched on the method rather than
+    on one class: several styles override ``install_forward`` and still wrap
+    (``MoeExpertsParallel`` does), so keying on ``TensorParallelLayer.`` alone
+    would read those modules as unwrapped. Asked before nnsight's controller goes
+    into that same slot.
+    """
+    forward = module.__dict__.get("forward")
+    return ".install_forward.<locals>." in getattr(forward, "__qualname__", "")
+
+
+def _keep_tp_forward(envoy: Any, style: Any, mesh: Any) -> None:
+    """Put transformers' TP transforms back around nnsight's controller.
+
+    A DTensor-backend transformers applies a style by *replacing*
+    ``module.forward`` with a wrapper that transforms the inputs, calls what was
+    there, and transforms the output. nnsight's controller goes into that same
+    slot and takes its body from the class, so installing it drops the wrapper:
+    the module keeps its sharded (DTensor) weights but loses the code that makes
+    its inputs match them, and the first matmul dies with ``got mixed torch.Tensor
+    and DTensor``. Nothing in the controller is wrong — it simply cannot know that
+    the attribute it replaced was load-bearing.
+
+    ``run_body`` has the same problem with accelerate, whose device-alignment hook
+    also replaces ``forward``, and solves it by bracketing the body. The order
+    here has to be the other way round: the style's transforms belong *outside*
+    the handoffs, not inside them, so that the sequence is the style's
+    pre-transform, the ``.input`` handoff, the body, the ``.output`` handoff, the
+    style's post-transform. That is the order the hook-based transformers
+    produced, and what `SIDES` describes — a worker sees a row-parallel output as
+    this rank's partial sum, not as the reduced tensor.
+
+    Installing the controller first and re-wrapping it gets that for free:
+    ``install_forward`` captures whatever ``forward`` currently is, which is by
+    then the controller.
+    """
+    module = envoy._module
+    if module.__dict__.get(_TP_WRAPPED):
+        return
+
+    from ...intervention.source import install_controller
+
+    # Assigns `forward` only the first time; a later call from
+    # `Interleaver.instrument` finds the state already there and just registers
+    # its route, so the wrapper installed below survives.
+    install_controller(envoy)
+    style.install_forward(module, mesh)
+    module.__dict__[_TP_WRAPPED] = True
+
+
+def device_mesh(model: Any) -> Any:
+    """The mesh ``model`` was sharded over, or ``None`` if it was not sharded.
+
+    Takes the model wrapper, the envoy, or the bare module — whichever is to hand
+    inside a trace.
+    """
+    module = getattr(model, "_module", model)
+    mesh = getattr(module, "_device_mesh", None)
+    return mesh if mesh is not None and mesh.size() > 1 else None
+
+
+def gather(model: Any, value: Any, dim: int = -1) -> Any:
+    """Every rank's piece of ``value``, concatenated along ``dim``.
+
+    For a value nnsight hands over as-is — anything between a column-parallel
+    module's output and the row-parallel module that consumes it, where nothing
+    records which axis holds the shard. You know, because you know what the
+    forward did, so you say:
+
+    ```python
+    with model.trace(prompt):
+        q = layer.self_attn.source.query_states_0.output   # (1, heads/N, seq, dim)
+        whole = tp.gather(model, q, dim=1)                 # (1, heads, seq, dim)
+    ```
+
+    A collective, so **every rank must reach it**: call it unconditionally, never
+    inside a branch that could go differently on different ranks. Returns the
+    value unchanged on an unsharded model, so the same block runs either way.
+    """
+    from torch.distributed.tensor import Shard
+
+    mesh = device_mesh(model)
+    if mesh is None:
+        return value
+    return apply(
+        value,
+        lambda tensor: _whole_tensor(tensor, mesh, Shard(dim)),
+        torch.Tensor,
+    )
+
+
+def shard(model: Any, value: Any, dim: int = -1) -> Any:
+    """This rank's piece of ``value`` along ``dim`` — the inverse of `gather`.
+
+    Needed when you write an edited value *back* into an intermediate location:
+    the model's forward carries on expecting this rank's piece, so a whole tensor
+    left there is as wrong as a piece read out.
+
+    ```python
+    with model.trace(prompt):
+        q = layer.self_attn.source.query_states_0.output
+        whole = tp.gather(model, q, dim=1)
+        whole[:, 3] = 0                                    # ablate head 3
+        layer.self_attn.source.query_states_0.output = tp.shard(model, whole, dim=1)
+    ```
+
+    Same rule: a collective, so every rank must reach it.
+    """
+    from torch.distributed.tensor import Shard
+
+    mesh = device_mesh(model)
+    if mesh is None:
+        return value
+    return apply(
+        value,
+        lambda tensor: _fragment_tensor(tensor, mesh, Shard(dim), False),
         torch.Tensor,
     )
 
@@ -231,12 +507,22 @@ class TPFragments(Fragments):
     def __init__(self) -> None:
         self.enabled = False
         self.tp_rules: Dict[str, Any] = {}
+        #: Module path -> (style name, mesh), for the ad-hoc-call bracket in
+        #: `nnsight.modeling.tp.envoys`. Recorded here because this is where the
+        #: style is resolved: 5.16 stamps nothing on the module, so an envoy
+        #: cannot read it back off one.
+        self.tp_styles: Dict[str, Any] = {}
+        #: (root envoy path, the model's tp_plan, its mesh) on a DTensor-backend
+        #: transformers, recorded when the root envoy comes past. The root is
+        #: instrumented before its children — `Envoy.__init__` instruments, then
+        #: walks `named_children` — so every module that needs it has it by then.
+        self._plan: tuple[str, dict, Any] | None = None
 
     def instrument(self, envoy: Any) -> None:
         """Record what each side of this envoy's module is at the handoff.
 
         Called as the tree is built and again on dispatch (`Envoy._update`), which
-        is when a module first carries transformers' ``_hf_tp_plan`` stamp.
+        is when a module first carries the marks a sharded model is recognized by.
 
         Raises:
             UnsupportedParallelStyle: for a style there is no rule for — refused
@@ -245,8 +531,34 @@ class TPFragments(Fragments):
         super().instrument(envoy)
 
         module = envoy._module
-        style = getattr(module, "_hf_tp_plan", None)
-        if style is None:
+
+        # A DTensor-backend transformers keeps the plan on the model rather than
+        # stamping each module, so the root's copy is what the descendants are
+        # resolved against. `_tp_plan` alone means nothing — every model declares
+        # one whether or not it was loaded across ranks; `_device_mesh` is what
+        # says it actually was.
+        if self._plan is None:
+            mesh = getattr(module, "_device_mesh", None)
+            plan = getattr(module, "tp_plan", None)
+            if mesh is not None and plan:
+                self._plan = (envoy.path, plan, mesh)
+
+        found = self._style_of(envoy)
+        if found is None:
+            return
+        style, mesh, style_object = found
+
+        if mesh is None or mesh.size() == 1:
+            # Planned but not actually split (a degenerate 1-rank mesh) — nothing
+            # to gather, and a collective over a 1-rank group is pure overhead.
+            return
+
+        # Only a module transformers actually wrapped has transforms around its
+        # forward, and so a boundary worth describing. A plan can name one it did
+        # not wrap — an expert-parallel plan keys entries by parameter as well as
+        # by module — and such an entry is neither a rule to record nor a reason
+        # to refuse the model.
+        if not _is_tp_wrapped(envoy._module):
             return
 
         if style not in SIDES:
@@ -256,46 +568,113 @@ class TPFragments(Fragments):
                 "can't be shown whole, so this model can't be traced tensor-parallel."
             )
 
-        mesh = getattr(module, "_hf_device_mesh", None)
-        if mesh is None or mesh.size() == 1:
-            # Stamped but not actually split (a degenerate 1-rank mesh) — nothing
-            # to gather, and a collective over a 1-rank group is pure overhead.
-            return
-
-        # The first genuinely sharded module: past here the weights are already
-        # split, so this is the last point at which refusing is still cheaper
-        # than returning wrong numbers.
-        _check_transformers_version()
+        _keep_tp_forward(envoy, style_object, mesh)
 
         self.enabled = True
+        self.tp_styles[envoy.path] = (style, mesh)
         for side, kind in SIDES[style].items():
-            self.tp_rules[f"{envoy.path}.{side}"] = (mesh, kind)
+            self.tp_rules[f"{envoy.path}.{side}"] = (mesh, _placement(kind))
+
+    def _style_of(self, envoy: Any) -> "tuple[str, Any, Any] | None":
+        """``(style name, mesh, style object)`` for this envoy's module, or None.
+
+        The model-level plan is the only spelling read. A transformers old enough
+        to stamp ``_hf_tp_plan`` on each module instead is refused here rather
+        than left to fall through: falling through finds nothing sharded, which
+        does not fail — it hands intervention code one rank's slice as though it
+        were the whole tensor.
+        """
+        module = envoy._module
+
+        if getattr(module, "_hf_tp_plan", None) is not None:
+            _check_transformers_version()
+
+        if self._plan is None:
+            return None
+        root, plan, mesh = self._plan
+        if envoy.path == root:
+            return None
+        # The path transformers knows this module by: nnsight's, minus the root
+        # envoy's own prefix. Both spell a module the way `named_modules` does.
+        name = envoy.path[len(root) + 1 :]
+
+        from transformers.distributed.tensor_parallel import (
+            ALL_PARALLEL_STYLES,
+            _get_parameter_tp_plan,
+        )
+
+        # transformers' own matcher, not a reimplementation of its globbing: the
+        # plan's keys wildcard layer numbers, and a private copy of that rule is
+        # exactly the kind of drift this module keeps being broken by.
+        style = _get_parameter_tp_plan(parameter_name=name, tp_plan=plan, is_weight=False)
+        if style is None:
+            return None
+        return style, mesh, ALL_PARALLEL_STYLES._global_mapping.get(style)
+
+    def style_at(self, path: str) -> "tuple[str | None, Any]":
+        """The parallel style and mesh recorded for the module at ``path``.
+
+        ``(None, None)`` for a module this tree did not find sharded. Asked by
+        `nnsight.modeling.tp.envoys.TPEnvoy`, which cannot read the style off the
+        module: transformers keeps the plan on the model, not on each module it
+        shards.
+        """
+        return self.tp_styles.get(path, (None, None))
 
     def fragmented(self, location: str) -> bool:
-        """Whether this location's value is one rank's slice.
+        """Whether this location's value is one rank's piece.
 
         A dict lookup: the rules were recorded at instrument time, so nothing is
         inspected here and nothing branches on rank.
+
+        Only a module's own two sides have rules. A value *inside* a forward — a
+        ``.source`` location, or any module between a column-parallel output and
+        the row-parallel input that consumes it — has none, and is handed over as
+        it comes. Nothing records which axis holds its shard once it has left the
+        module that made it, and the axis moves: attention's ``view``/``transpose``
+        puts it on the head dimension. Reassembling one is the trace's job, with
+        [`gather`][nnsight.modeling.tp.fragments.gather] and
+        [`shard`][nnsight.modeling.tp.fragments.shard], which take the axis from
+        the caller because only the caller knows it.
         """
         return location in self.tp_rules
 
-    def whole(self, location: str, value: Any) -> Any:
-        """The real tensor: every rank's slice gathered, or every rank's partial summed."""
-        mesh, kind = self.tp_rules[location]
-        return _reduce(value, mesh) if kind == "partial" else _gather(value, mesh)
+    def whole(self, location: str, value: Any) -> "tuple[Any, Any]":
+        """The real tensor, and how to put back what assembling it took.
 
-    def fragment(self, location: str, whole: Any) -> Any:
-        """What this rank hands its forward back, carrying whatever the workers left.
+        The value's own placement wins when it has one — it knows which axis holds
+        the shard, which a rule cannot once a ``view`` or ``transpose`` has moved
+        it — and the location's rule decides otherwise. Only a module's two sides
+        reach here; see `fragmented` for what is left raw and why.
 
-        A shard's slice again; for a partial, the whole on rank 0 and zeros on the
-        others, so the module's own post-hook reduce yields the whole everywhere.
+        The way back is returned as a closure over what was decided here, so it
+        cannot be confused with another location's, or consumed by an ad-hoc call
+        made while this visit is still open.
         """
-        mesh, kind = self.tp_rules[location]
-        if kind == "partial":
-            keep = mesh.get_local_rank() == 0
-            return apply(
-                whole,
-                lambda tensor: tensor if keep or not tensor.is_floating_point() else torch.zeros_like(tensor),
-                torch.Tensor,
-            )
-        return _reshard(whole, mesh)
+        described = _described(value)
+        layout = described or self.tp_rules.get(location)
+        if layout is None:
+            return value, None
+
+        mesh, placement = layout
+        # A value that came in carrying its placement has to leave carrying it:
+        # the transform downstream will redistribute it, and can only do that to a
+        # DTensor.
+        as_dtensor = described is not None
+        return (
+            _gather(value, mesh, placement),
+            lambda edited: _reshard(edited, mesh, placement, as_dtensor),
+        )
+
+    def split(self, location: str, whole: Any) -> Any:
+        """This rank's piece of a value that was never gathered.
+
+        The rule alone, because there is nothing else: a `.skip` replacement and
+        the argument of an ad-hoc call are both the caller's own whole tensor, and
+        neither ever carried a placement to read.
+        """
+        rule = self.tp_rules.get(location)
+        if rule is None:
+            return whole
+        mesh, placement = rule
+        return _reshard(whole, mesh, placement, False)

--- a/src/nnsight/modeling/tp/plan.py
+++ b/src/nnsight/modeling/tp/plan.py
@@ -18,6 +18,14 @@ from typing import Any, Optional
 
 from .fragments import SIDES
 
+#: What an *expert*-parallel degree has to divide instead. Expert parallelism
+#: distributes whole experts rather than slicing a tensor axis, so the head
+#: counts and the intermediate size are irrelevant to it and the expert count is
+#: the only constraint. transformers raises on an uneven split itself
+#: (``EpRouterParallel`` checks ``num_experts % ep_size``), but by then the
+#: weights are already being read.
+_EXPERT_DIVIDES: tuple[str, ...] = ("num_local_experts", "num_experts")
+
 #: Config fields a tensor-parallel degree has to divide. Attention is split by
 #: head, so both head counts must divide; the MLP is split along its intermediate
 #: dimension. A field a config doesn't have is not a constraint — a model with no
@@ -40,7 +48,7 @@ def _text_config(config: Any) -> Any:
     return getattr(config, "text_config", None) or config
 
 
-def max_tp_size(config: Any) -> Optional[int]:
+def max_tp_size(config: Any, expert_parallel: bool = False) -> Optional[int]:
     """The largest tensor-parallel degree ``config``'s model supports.
 
     ``None`` when it cannot be split at all: no plan to shard by, or a plan
@@ -57,7 +65,14 @@ def max_tp_size(config: Any) -> Optional[int]:
     out. ``Llama4Config`` does exactly this: its plan is ``colwise_rep``, which
     is in no list and no registry.
     """
-    plan = getattr(config, "base_model_tp_plan", None)
+    # Expert parallelism is answered from the model's *expert* plan, which is what
+    # transformers applies for it; a checkpoint can publish one and no
+    # tensor-parallel plan at all (gpt-oss does), and reading the wrong field
+    # would call it unshardable.
+    fields = _EXPERT_DIVIDES if expert_parallel else _DIVIDES
+    plan = getattr(
+        config, "base_model_ep_plan" if expert_parallel else "base_model_tp_plan", None
+    )
     if not plan:
         return None
 
@@ -66,7 +81,7 @@ def max_tp_size(config: Any) -> Optional[int]:
 
     dimensions = [
         value
-        for name in _DIVIDES
+        for name in fields
         if isinstance(value := getattr(_text_config(config), name, None), int) and value
     ]
     if not dimensions:
@@ -98,7 +113,21 @@ def requested_tp_size(distributed_config: Any) -> Optional[int]:
     return size if isinstance(size, int) and size > 1 else None
 
 
-def check_tp_request(config: Any, tp_size: Optional[int]) -> None:
+def requested_expert_parallel(distributed_config: Any) -> bool:
+    """Whether this ``distributed_config`` asks for expert parallelism.
+
+    Accepts the dataclass or a plain dict, because transformers does.
+    """
+    if distributed_config is None:
+        return False
+    if isinstance(distributed_config, dict):
+        return bool(distributed_config.get("enable_expert_parallel"))
+    return bool(getattr(distributed_config, "enable_expert_parallel", False))
+
+
+def check_tp_request(
+    config: Any, tp_size: Optional[int], expert_parallel: bool = False
+) -> None:
     """Raise unless ``tp_size`` is a degree ``config``'s model can really be split into.
 
     transformers does not check this. Asked to shard a checkpoint with no plan it
@@ -120,13 +149,16 @@ def check_tp_request(config: Any, tp_size: Optional[int]) -> None:
     if tp_size is None:
         return
 
-    limit = max_tp_size(config)
+    limit = max_tp_size(config, expert_parallel)
     if limit is None:
+        axis = "expert-parallel" if expert_parallel else "tensor-parallel"
+        field = "base_model_ep_plan" if expert_parallel else "base_model_tp_plan"
+        divides = "its expert count divides" if expert_parallel else "its dimensions divide"
         raise UnshardableCheckpoint(
-            f"this checkpoint cannot be split tensor-parallel, so tp_size={tp_size} "
+            f"this checkpoint cannot be split {axis}, so tp_size={tp_size} "
             "would load a whole copy of it onto every rank rather than a shard. "
-            "Either it publishes no `base_model_tp_plan`, its plan uses a style "
-            "nnsight cannot gather, or its dimensions divide no degree above 1. "
+            f"Either it publishes no `{field}`, its plan uses a style "
+            f"nnsight cannot gather, or {divides} no degree above 1. "
             "Load it without `distributed_config` — on one GPU, or spread over "
             "several with `device_map`."
         )

--- a/src/nnsight/modeling/vllm/fragments.py
+++ b/src/nnsight/modeling/vllm/fragments.py
@@ -31,6 +31,7 @@ needed: no memo, no ``watch``/``release``, no extra hooks.
 
 from __future__ import annotations
 
+from functools import partial
 from typing import Any, Dict, Tuple
 
 import torch
@@ -94,8 +95,12 @@ class VLLMFragments(Fragments):
     def fragmented(self, location: str) -> bool:
         return location in self.rules
 
-    def whole(self, location: str, value: Any) -> Any:
-        """The real tensor behind ``value``, assembled from every rank's piece."""
+    def whole(self, location: str, value: Any) -> "tuple[Any, Any]":
+        """The real tensor behind ``value``, and how to cut it back down.
+
+        vLLM's rules describe a location and nothing else — no value here carries
+        its own layout — so the way back is `split` with this location bound to it.
+        """
         from vllm.distributed.communication_op import (
             tensor_model_parallel_all_gather,
             tensor_model_parallel_all_reduce,
@@ -124,13 +129,15 @@ class VLLMFragments(Fragments):
             # MoE it is the same collective the outer block runs right afterwards.
             collective = tensor_model_parallel_all_reduce
 
-        return apply(value, collective, torch.Tensor)
+        return apply(value, collective, torch.Tensor), partial(self.split, location)
 
-    def fragment(self, location: str, whole: Any) -> Any:
+    def split(self, location: str, whole: Any) -> Any:
         """This rank's piece of ``whole``, as vLLM's own forward expects it.
 
         Applied to whatever intervention code left behind, so an edit made to the
-        assembled tensor is carried back into the model rather than dropped.
+        assembled tensor is carried back into the model rather than dropped — and
+        to a value that was never gathered at all (a `.skip` replacement, or the
+        argument of an ad-hoc call), which is already the real tensor.
         """
         from vllm.model_executor.layers.linear import (
             ColumnParallelLinear,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,9 +3,22 @@
 import sys
 import types
 
+import pytest
 import yaml
 
 from nnsight.schema.config import Config
+
+
+@pytest.fixture(autouse=True)
+def isolate_user_config(monkeypatch, tmp_path):
+    """Point NNSIGHT_CONFIG at a path that doesn't exist.
+
+    Without this, `Config.load()` reads the developer's real
+    ~/.config/nnsight/config.yaml, and any key it sets there (an APIKEY, say)
+    silently decides these assertions. Tests that want a user file on disk set
+    NNSIGHT_CONFIG themselves, which overrides this.
+    """
+    monkeypatch.setenv("NNSIGHT_CONFIG", str(tmp_path / "absent" / "config.yaml"))
 
 
 class TestEnvOverrides:

--- a/tests/test_fragments.py
+++ b/tests/test_fragments.py
@@ -12,6 +12,8 @@ The real collectives are covered by `tests/tp` (transformers) and `tests/vllm`
 
 from __future__ import annotations
 
+from functools import partial
+
 import pytest
 import torch
 
@@ -37,10 +39,15 @@ class Recorder(Fragments):
 
     def whole(self, location, value):
         self.calls.append(("whole", location))
-        return torch.cat([value, value], dim=-1)
+        return torch.cat([value, value], dim=-1), partial(self._undo, location)
 
-    def fragment(self, location, whole):
+    def _undo(self, location, whole):
         self.calls.append(("fragment", location))
+        return whole[..., : whole.shape[-1] // 2]
+
+    def split(self, location, whole):
+        # A value that was never gathered: same cut, no gather to reverse.
+        self.calls.append(("split", location))
         return whole[..., : whole.shape[-1] // 2]
 
 
@@ -81,6 +88,46 @@ class TestTheBracket:
         _traced(model, fragments, read=True)
 
         assert ("fragment", "model.output") in fragments.calls
+
+
+class TestASkippedValueIsNormalized:
+    """A `.skip` replacement never came out of the module.
+
+    It is the caller's own whole value, while everything `handle` does assumes
+    this device's *piece*. `handle_replacement` cuts it down to a piece first, so
+    the rest of the path treats it exactly like one the module produced. Without
+    that a row-parallel skip was all-reduced on the way out and every rank read
+    back ``world_size`` times what it wrote, with nothing raising.
+
+    Asserted on what a reader sees, not on which methods ran: the point is that a
+    skip round-trips, however that is arranged.
+    """
+
+    def test_a_reader_sees_what_was_written(self, model):
+        fragments = Recorder(locations={"model.output"})
+        model.interleaver.fragments = fragments
+
+        with model.trace(torch.randn(1, 4)):
+            model.skip(torch.ones(1, 4))
+            seen = model.output.save()
+
+        # 4 is what was written. 8 would be the Recorder's doubling — the
+        # replacement assembled as though it were one device's piece.
+        assert seen.shape[-1] == 4
+        assert torch.equal(seen, torch.ones(1, 4))
+        assert ("split", "model.output") in fragments.calls
+
+    def test_it_is_cut_down_even_with_nobody_reading(self, model):
+        """The model's forward carries on with it whether or not anyone looked."""
+        fragments = Recorder(locations={"model.output"})
+        model.interleaver.fragments = fragments
+
+        with model.trace(torch.randn(1, 4)):
+            model.skip(torch.ones(1, 4))
+
+        assert ("split", "model.output") in fragments.calls
+        # Nothing was parked, so nothing was assembled either.
+        assert ("whole", "model.output") not in fragments.calls
 
 
 class TestGating:

--- a/tests/test_tensor_parallel_rules.py
+++ b/tests/test_tensor_parallel_rules.py
@@ -41,22 +41,64 @@ class _FakeMesh:
         return self._size
 
 
+class _FakeInterleaver:
+    """Weakref-able stand-in.
+
+    `install_controller` registers a route on the envoy's interleaver, and a
+    weakref needs a real object to point at. Nothing here is called: these tests
+    instrument a tree, they do not run one.
+    """
+
+
 class _FakeEnvoy:
-    """The two things `instrument` reads off an envoy."""
+    """What `instrument` reads off an envoy."""
 
     def __init__(self, module: torch.nn.Module, path: str = "model.thing") -> None:
         self._module = module
         self.path = path
+        self.interleaver = _FakeInterleaver()
 
 
-def _module(style: str | None, **attrs) -> torch.nn.Module:
+ROOT = "model"
+
+
+def _tp_wrapped_forward():
+    """A stand-in for transformers' TP forward wrapper, recognised by qualname."""
+
+    class TensorParallelLayer:
+        @staticmethod
+        def install_forward():
+            def tp_forward(*args, **kwargs):
+                raise AssertionError("these tests instrument a tree, they do not run one")
+
+            return tp_forward
+
+    return TensorParallelLayer.install_forward()
+
+
+def _sharded(style: str | None, path: str = "model.thing", size: int = 2, **attrs):
+    """A `TPFragments` that has walked a model sharding ``path`` as ``style``.
+
+    Built the way transformers describes a sharded model: the plan lives on the
+    *root*, keyed by each module's path below it, with a mesh saying it was
+    really split — so the root is instrumented first, exactly as `Envoy.__init__`
+    does before walking its children.
+    """
+    root = torch.nn.Identity()
+    root.tp_plan = {path[len(ROOT) + 1 :]: style} if style is not None else {}
+    root._device_mesh = _FakeMesh(size)
+
+    # Stands in for the wrapper transformers installs when it shards a module:
+    # `instrument` records a rule only for a module it actually wrapped.
     module = torch.nn.Identity()
-    if style is not None:
-        module._hf_tp_plan = style
-        module._hf_device_mesh = _FakeMesh()
+    module.__dict__["forward"] = _tp_wrapped_forward()
     for name, value in attrs.items():
         setattr(module, name, value)
-    return module
+
+    fragments = TPFragments()
+    fragments.instrument(_FakeEnvoy(root, path=ROOT))
+    fragments.instrument(_FakeEnvoy(module, path=path))
+    return fragments
 
 
 class TestStyleCoverage:
@@ -79,13 +121,6 @@ class TestStyleCoverage:
             f"{sorted(stale)} — probably renamed upstream."
         )
 
-    def test_a_style_is_either_handled_or_refused_never_both(self):
-        assert not (set(SIDES) & set(UNSUPPORTED))
-
-    @pytest.mark.parametrize("sides", SIDES.values())
-    def test_sides_are_input_or_output(self, sides):
-        assert set(sides) <= {"input", "output"}
-
 
 class TestInstrument:
     """What the interleaver does as the Envoy tree is built."""
@@ -96,43 +131,37 @@ class TestInstrument:
         assert not interleaver.tp_rules
 
     def test_an_unsharded_module_records_nothing(self, monkeypatch):
-        interleaver = TPFragments()
-
-        interleaver.instrument(_FakeEnvoy(_module(None)))
+        interleaver = _sharded(None)
 
         assert not interleaver.enabled
         assert not interleaver.tp_rules
 
     def test_a_sharded_module_records_its_side_and_enables(self, monkeypatch):
-        interleaver = TPFragments()
-
-        interleaver.instrument(_FakeEnvoy(_module("colwise"), path="model.q_proj"))
+        interleaver = _sharded("colwise", path="model.q_proj")
 
         assert interleaver.enabled
         assert "model.q_proj.output" in interleaver.tp_rules
 
     def test_a_row_parallel_module_records_its_input(self, monkeypatch):
-        interleaver = TPFragments()
-
-        interleaver.instrument(_FakeEnvoy(_module("rowwise"), path="model.o_proj"))
+        interleaver = _sharded("rowwise", path="model.o_proj")
 
         # At the handoff a row-parallel input is already this rank's slice and its
-        # output is this rank's partial sum — its own post-hook reduces it after us.
-        assert interleaver.tp_rules["model.o_proj.input"][1] == "shard"
-        assert interleaver.tp_rules["model.o_proj.output"][1] == "partial"
+        # output is this rank's partial sum — its own post-transform reduces it
+        # after us. Recorded as the DTensor placements that say so, which is what
+        # the gather asserts onto a value that arrives without one.
+        from torch.distributed.tensor import Partial, Shard
+
+        assert interleaver.tp_rules["model.o_proj.input"][1] == Shard(-1)
+        assert isinstance(interleaver.tp_rules["model.o_proj.output"][1], Partial)
 
     @pytest.mark.parametrize("style", sorted(UNSUPPORTED))
     def test_a_refused_style_raises(self, style, monkeypatch):
-        interleaver = TPFragments()
-
         with pytest.raises(UnsupportedParallelStyle, match=style):
-            interleaver.instrument(_FakeEnvoy(_module(style)))
+            _sharded(style)
 
     def test_an_unknown_style_raises(self, monkeypatch):
-        interleaver = TPFragments()
-
         with pytest.raises(UnsupportedParallelStyle, match="not a parallel style"):
-            interleaver.instrument(_FakeEnvoy(_module("something_new_upstream")))
+            _sharded("something_new_upstream")
 
 
 def test_an_unsharded_model_is_never_asked():
@@ -185,10 +214,10 @@ class TestMaxTpSize:
     def test_an_unsupported_style_in_the_plan_refuses(self):
         from nnsight.modeling.tp import max_tp_size
 
-        # An expert-parallel model would fail at load; it must not be *placed*
-        # as though it could be split.
+        # A model whose plan nnsight cannot gather would fail at load; it must
+        # not be *placed* as though it could be split.
         assert max_tp_size(self._config(
-            plan={"layers.*.mlp.experts": "grouped_gemm"},
+            plan={"layers.*.mlp.experts": "megamoe_experts"},
             num_attention_heads=16, num_key_value_heads=16, intermediate_size=4096,
         )) is None
 
@@ -238,11 +267,14 @@ class TestBytesPerElement:
 
 
 class TestTransformersVersionFloor:
-    """Sharding is refused on a transformers that shards incorrectly.
+    """Sharding is refused on a transformers whose TP nnsight cannot read.
 
-    Caught on a live deployment: the container ran 5.14.1 and a tied-embedding
-    model came back with logits four times the vocabulary width, while the argmax
-    — and so every eyeball check — stayed right.
+    The floor is the DTensor rewrite. Below it the plan is stamped per module
+    rather than kept on the model, so nnsight finds nothing sharded — which does
+    not fail, it hands intervention code one rank's slice as the whole tensor.
+    That is the same shape of bug as the one caught on a live deployment running
+    5.14.1, where a tied-embedding model returned logits four times the
+    vocabulary width while the argmax — and so every eyeball check — stayed right.
     """
 
     def _check(self, monkeypatch, version: str):
@@ -257,15 +289,15 @@ class TestTransformersVersionFloor:
     def test_an_older_transformers_is_refused(self, monkeypatch):
         from nnsight.modeling.tp import UnsupportedTransformersVersion
 
-        with pytest.raises(UnsupportedTransformersVersion, match="tie_word_embeddings"):
-            self._check(monkeypatch, "5.14.1")
+        with pytest.raises(UnsupportedTransformersVersion, match="5.16"):
+            self._check(monkeypatch, "5.15.1")
 
     @pytest.mark.parametrize(
-        "version", ["5.15.0", "5.15.1", "6.0.0", "5.15.0.dev0", "5.16.0rc1"]
+        "version", ["5.16.0", "5.16.1", "6.0.0", "5.16.0.dev0", "5.17.0rc1"]
     )
     def test_the_floor_and_above_are_allowed(self, monkeypatch, version):
         # Including pre-releases of the fixed series: an editable transformers
-        # checkout reports 5.15.0.dev0, which a plain >= would reject.
+        # checkout reports 5.16.0.dev0, which a plain >= would reject.
         self._check(monkeypatch, version)
 
     def test_it_only_runs_once(self, monkeypatch):
@@ -275,7 +307,7 @@ class TestTransformersVersionFloor:
 
         from nnsight.modeling.tp import fragments as tp_fragments
 
-        monkeypatch.setattr(transformers, "__version__", "5.15.0")
+        monkeypatch.setattr(transformers, "__version__", "5.16.0")
         monkeypatch.setattr(tp_fragments, "_version_checked", False)
         tp_fragments._check_transformers_version()
         monkeypatch.setattr(transformers, "__version__", "0.1.0")
@@ -304,16 +336,19 @@ class TestTheTwoGatesAgree:
     def test_a_style_in_neither_list_is_refused(self):
         from nnsight.modeling.tp import SIDES, UNSUPPORTED, max_tp_size
 
-        # Llama-4's actual plan. transformers does not register it in
-        # ALL_PARALLEL_STYLES either, so the drift test below cannot see it.
-        assert "colwise_rep" not in SIDES
-        assert "colwise_rep" not in UNSUPPORTED
-        assert max_tp_size(self._config({"layer.q_proj": "colwise_rep"})) is None
+        # A plan naming something no list covers. `colwise_rep` used to stand here
+        # — it was Llama-4's plan and no version registered it — but 5.16 added it
+        # to ALL_PARALLEL_STYLES and it now has a rule, so the case needs a name
+        # that is still genuinely unknown.
+        unknown = "colwise_upside_down"
+        assert unknown not in SIDES
+        assert unknown not in UNSUPPORTED
+        assert max_tp_size(self._config({"layer.q_proj": unknown})) is None
 
     def test_a_refused_style_is_still_refused(self):
         from nnsight.modeling.tp import max_tp_size
 
-        assert max_tp_size(self._config({"layer.experts": "grouped_gemm"})) is None
+        assert max_tp_size(self._config({"layer.experts": "megamoe_experts"})) is None
 
     def test_a_known_style_still_places(self):
         from nnsight.modeling.tp import max_tp_size
@@ -364,27 +399,21 @@ class TestExpertParallelIsNotAutomaticallyRefused:
 
         assert max_tp_size(Config()) == 8
 
-    def test_a_style_that_really_slices_by_expert_is_still_refused(self):
-        from nnsight.modeling.tp import UNSUPPORTED
+    def test_a_style_no_model_has_exercised_is_still_refused(self):
+        """The refused set is now what nothing has been run against.
 
-        assert "grouped_gemm" in UNSUPPORTED
+        ``ep_router`` and ``grouped_gemm`` left it because an expert-parallel
+        model was actually traced end to end (`tests/tp/test_cpu_expert_parallel.py`)
+        and their values proved to need no gather at all. The rest stay refused
+        for the reason the table has always given: reading a style's transforms
+        is not the same as having run one.
+        """
+        from nnsight.modeling.tp import SIDES, UNSUPPORTED
+
+        assert "megamoe_experts" in UNSUPPORTED
         assert "mla_kv_a_proj" in UNSUPPORTED
-
-
-class TestEmbeddingColwiseIsWhole:
-    """`embedding_colwise` all-reduces its output despite the name.
-
-    `EmbeddingParallel._prepare_output_fn` ends in an unconditional
-    `all_reduce_forward`; the `embedding_dim_sharding == 0` branch above it guards
-    only the vocab masking. Gathering it again would hand users a tensor tp_size
-    times too wide with a plausible first copy -- the tied-LM-head bug that
-    MINIMUM_TRANSFORMERS exists for, reintroduced by this table.
-    """
-
-    def test_its_output_is_reduced_not_gathered(self):
-        from nnsight.modeling.tp import SIDES
-
-        assert SIDES["embedding_colwise"] == {"output": "partial"}
+        assert "ep_router" in SIDES
+        assert "grouped_gemm" in SIDES
 
 
 class FakeMesh:
@@ -397,6 +426,104 @@ class FakeMesh:
         return self._size
 
 
+class TestSplitStandsAlone:
+    """`split` cuts a value down with no gather to reverse.
+
+    `TPEnvoy.__call__` uses it to prepare the argument of an ad-hoc call on a
+    sharded module. That value is whole because the caller is holding it, not
+    because anything assembled it, so there is no gather to undo and the
+    location's rule is the only thing to go on.
+
+    It used to be served by `fragment`, the same method that reversed a gather —
+    which meant an ad-hoc call made while its own location's handoff was still
+    open consumed the record that handoff was going to use, and the module then
+    ran sharded weights against a whole tensor.
+    """
+
+    def _split_calls(self, monkeypatch):
+        from nnsight.modeling.tp import fragments as tp_fragments
+
+        seen = []
+        monkeypatch.setattr(
+            tp_fragments,
+            "_fragment_tensor",
+            lambda tensor, *args, **kwargs: (seen.append(tensor), tensor)[1],
+        )
+        return seen
+
+    def test_it_uses_the_rule(self, monkeypatch):
+        fragments = _sharded("rowwise", path="model.o_proj")
+        split = self._split_calls(monkeypatch)
+
+        fragments.split("model.o_proj.input", torch.randn(1, 4, 8))
+
+        assert len(split) == 1, "a standalone split left the value whole"
+
+    def test_a_location_with_no_rule_is_left_alone(self, monkeypatch):
+        fragments = _sharded("rowwise", path="model.o_proj")
+        split = self._split_calls(monkeypatch)
+
+        fragments.split("model.o_proj.something_else", torch.randn(1, 4, 8))
+
+        assert not split
+
+    def test_whole_hands_back_its_own_way_out(self, monkeypatch):
+        """The reversal is a closure, not a record another call could consume."""
+        fragments = _sharded("rowwise", path="model.o_proj")
+        monkeypatch.setattr(
+            "nnsight.modeling.tp.fragments._gather", lambda value, *a: value
+        )
+        _, undo = fragments.whole("model.o_proj.input", torch.randn(1, 4, 8))
+
+        assert callable(undo)
+        # Nothing was written anywhere for a later call to find and take.
+        assert not [name for name in vars(fragments) if "pending" in name]
+
+
+class TestOnlyBoundariesAreReassembled:
+    """A module's two sides are made whole; everything inside a forward is not.
+
+    An operation's value has no rule and nothing on it says which axis holds its
+    shard once it has left the module that produced it — and the axis moves, so
+    there is nothing safe to assume. It is handed over as this device's piece and
+    the trace reassembles it with `gather`/`shard`, naming the axis. `Envoy.source`
+    warns on a sharded model so that is not a surprise.
+    """
+
+    def test_a_module_side_with_a_rule_is_reassembled(self):
+        fragments = _sharded("colwise", path="model.q_proj")
+
+        # colwise records only its output; its input is whole where we stand.
+        assert fragments.fragmented("model.q_proj.output")
+        assert not fragments.fragmented("model.q_proj.input")
+
+    def test_an_operation_inside_a_forward_is_not(self):
+        fragments = _sharded("colwise", path="model.q_proj")
+
+        assert not fragments.fragmented("model.q_proj.source.F_linear_0.output")
+        assert not fragments.fragmented("model.q_proj.source.F_linear_0.input")
+
+    def test_a_module_with_no_rule_is_not(self):
+        """`act_fn` between a colwise output and a rowwise input, say."""
+        fragments = _sharded("colwise", path="model.q_proj")
+
+        assert not fragments.fragmented("model.act_fn.output")
+
+    def test_a_boundary_without_a_placement_still_uses_its_rule(self):
+        """A side is reassembled from its rule even when the value says nothing."""
+        from nnsight.modeling.tp import fragments as tp_fragments
+
+        fragments = _sharded("colwise", path="model.q_proj")
+        gathered = []
+        real = tp_fragments._gather
+        try:
+            tp_fragments._gather = lambda value, *a: (gathered.append(value), value)[1]
+            fragments.whole("model.q_proj.output", torch.randn(1, 4, 8))
+        finally:
+            tp_fragments._gather = real
+        assert len(gathered) == 1
+
+
 class TestReshardGuard:
     """What goes back to the model must be guarded like what came out of it.
 
@@ -405,18 +532,21 @@ class TestReshardGuard:
     Divisibility alone cannot tell the two apart: an integer `position_ids` of
     width 8 at tp=4 divides perfectly, and the result is wrong answers on every
     rank identically -- not a hang, and nothing to notice.
+
+    Spies on nnsight's own two primitives rather than on a transformers helper.
+    The previous version patched ``transformers.integrations.tensor_parallel.split``,
+    which 5.16 deleted -- so these tests broke on a release that changed nothing
+    about the behaviour they describe.
     """
 
-    def _split_calls(self, monkeypatch):
-        import transformers.integrations.tensor_parallel as tp
+    def _calls(self, monkeypatch, name):
+        """Record every tensor handed to fragments.``name``, and pass it through."""
+        from nnsight.modeling.tp import fragments
 
         seen = []
-
-        def fake_split(tensor, mesh):
-            seen.append(tensor)
-            return tensor
-
-        monkeypatch.setattr(tp, "split", fake_split)
+        monkeypatch.setattr(
+            fragments, name, lambda tensor, *args, **kwargs: (seen.append(tensor), tensor)[1]
+        )
         return seen
 
     @pytest.mark.parametrize(
@@ -428,27 +558,38 @@ class TestReshardGuard:
         ],
     )
     def test_a_value_the_gather_skipped_is_not_split(self, monkeypatch, tensor, why):
-        from nnsight.modeling.tp.fragments import _gather, _reshard
+        from nnsight.modeling.tp.fragments import _gather, _placement, _reshard
 
-        gather_seen = self._split_calls(monkeypatch)
-        import transformers.integrations.tensor_parallel as tp
-
-        monkeypatch.setattr(tp, "all_gather", lambda t, m: gather_seen.append(t) or t)
         mesh = FakeMesh(4)
+        shard = _placement("shard")
 
-        _gather(tensor, mesh)
-        assert not gather_seen, f"{why} should not have been gathered"
+        gathered = self._calls(monkeypatch, "_whole_tensor")
+        _gather(tensor, mesh, shard)
+        assert not gathered, f"{why} should not have been gathered"
 
-        split_seen = self._split_calls(monkeypatch)
-        _reshard(tensor, mesh)
-        assert not split_seen, f"{why} was split though it was never gathered"
+        split = self._calls(monkeypatch, "_fragment_tensor")
+        _reshard(tensor, mesh, shard, False)
+        assert not split, f"{why} was split though it was never gathered"
 
     def test_a_real_shard_still_round_trips(self, monkeypatch):
-        from nnsight.modeling.tp.fragments import _reshard
+        from nnsight.modeling.tp.fragments import _placement, _reshard
 
-        split_seen = self._split_calls(monkeypatch)
-        _reshard(torch.randn(1, 4, 8), FakeMesh(4))
-        assert len(split_seen) == 1
+        split = self._calls(monkeypatch, "_fragment_tensor")
+        _reshard(torch.randn(1, 4, 8), FakeMesh(4), _placement("shard"), False)
+        assert len(split) == 1
+
+    def test_a_partial_is_reduced_whatever_its_width(self, monkeypatch):
+        """A partial is a whole-width term of a sum, so divisibility is irrelevant.
+
+        Guarding it with the shard's ``% world_size`` test would silently skip the
+        re-fragment on any width that does not divide, and the model's own reduce
+        would then sum the whole tensor once per rank.
+        """
+        from nnsight.modeling.tp.fragments import _placement, _reshard
+
+        split = self._calls(monkeypatch, "_fragment_tensor")
+        _reshard(torch.randn(1, 4, 7), FakeMesh(4), _placement("partial"), False)
+        assert len(split) == 1
 
 
 class TestHubFailuresAreDistinguishable:

--- a/tests/tp/ep_worker.py
+++ b/tests/tp/ep_worker.py
@@ -1,0 +1,100 @@
+"""One rank of the expert-parallel test, run under ``torch.distributed.run``.
+
+Not a test module (no ``test_`` prefix, so pytest does not collect it):
+`test_cpu_expert_parallel.py` launches this once in a single process for the
+reference and once across N ranks, then compares.
+
+Expert parallelism is a different axis from tensor parallelism. It is asked for
+with ``enable_expert_parallel=True``, and transformers answers by applying the
+model's *expert* plan — ``base_model_ep_plan``, which distributes whole experts
+across ranks — instead of its tensor-parallel one. ``model.tp_plan`` resolves to
+whichever is in force, which is the only thing nnsight has to read.
+
+Every rank runs the identical block, so nothing here may branch on rank.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import torch
+
+import nnsight
+
+# Tiny, MoE, and its plan uses the three expert-parallel styles: `ep_router` on
+# the router, `grouped_gemm` on the expert parameters, `moe_tp_experts` on the
+# experts module.
+REPO = "hf-internal-testing/tiny-random-GptOssForCausalLM"
+
+# Below the tiny model's vocabulary, so no tokenizer is needed and the ids are
+# identical on every rank by construction.
+INPUT_IDS = [[1, 2, 3, 4, 5, 6]]
+LAYER = 0
+
+
+def build(ep: int):
+    from nnsight.modeling.tp import TPFragments
+    from nnsight.modeling.transformers import TransformersModel
+
+    kwargs = {}
+    if ep > 1:
+        from transformers.distributed import DistributedConfig
+
+        kwargs["distributed_config"] = DistributedConfig(
+            tp_size=ep, enable_expert_parallel=True
+        )
+    else:
+        kwargs["device_map"] = {"": "cpu"}
+
+    model = TransformersModel(
+        REPO, task="text-generation", dispatch=True, dtype=torch.float32, **kwargs
+    )
+
+    fragments = model.interleaver.fragments
+    assert isinstance(fragments, TPFragments), type(fragments)
+    if ep > 1:
+        assert fragments.enabled, "expert-parallel model did not enable the TP path"
+        assert fragments.tp_rules, "expert-parallel model recorded no rules"
+    else:
+        assert not fragments.enabled, "unsharded model enabled the TP path"
+
+    return model
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ep", type=int, default=1)
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    rank = int(os.environ.get("RANK", 0))
+    model = build(args.ep)
+    layer = model.model.layers[LAYER]
+    results: dict[str, torch.Tensor] = {}
+
+    def record(name: str, tensor: torch.Tensor) -> None:
+        results[name] = tensor.detach().float().cpu()
+
+    ids = torch.tensor(INPUT_IDS)
+    with model.trace({"input_ids": ids}):
+        # The router is replicated: every rank computes the same thing, and the
+        # masking that makes it rank-specific happens in its own post-transform,
+        # after the handoff. So this must match the single-process run exactly.
+        record("router_logits", layer.mlp.router.output[0].save())
+        # The experts module holds only this rank's experts and produces its term
+        # of the sum; a worker must be shown the sum.
+        record("experts_out", layer.mlp.experts.output.save())
+        record("mlp_out", layer.mlp.output[0].save())
+        record("logits", model.lm_head.output.save())
+
+    # An edit on the summed expert output has to survive the way back.
+    with model.trace({"input_ids": ids}):
+        layer.mlp.experts.output = layer.mlp.experts.output * 0.5
+        record("edited_logits", model.lm_head.output.save())
+
+    torch.save(results, os.path.join(args.out, f"rank{rank}.pt"))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tp/test_cpu_expert_parallel.py
+++ b/tests/tp/test_cpu_expert_parallel.py
@@ -1,0 +1,130 @@
+"""Expert parallelism: whole tensors from a model whose *experts* are split.
+
+`test_cpu_gloo.py` covers tensor parallelism, where a module's activation is one
+rank's slice along a tensor axis. Expert parallelism splits a different thing —
+whole experts across ranks — and transformers expresses it with a separate plan
+(``base_model_ep_plan``) applied when ``enable_expert_parallel=True``. The styles
+in it are not variations on colwise/rowwise:
+
+* ``ep_router`` leaves the router replicated and masks non-local experts in its
+  own post-transform, so at the handoff its value is already whole.
+* ``grouped_gemm`` shards expert *parameters* and installs an identity wrapper,
+  so it too has nothing to gather.
+* ``moe_tp_experts`` produces this rank's term of a sum, like a row-parallel
+  output.
+
+All three used to be refused outright. Two of them turn out to need no gather at
+all, and the third was already described — but nothing had ever run the path, so
+"refused" and "correct" were indistinguishable. This is what tells them apart.
+
+Runs on CPU over gloo, like its tensor-parallel sibling, so CI covers it.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+
+import pytest
+import torch
+
+WORKER = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ep_worker.py")
+EP_SIZE = 2
+
+# float32 on two CPU ranks; the only arithmetic difference from the reference is
+# the order an all-reduce sums in.
+DRIFT = 1e-4
+
+
+def _nnsight_path() -> str:
+    """The directory that makes the worker import the nnsight this session did."""
+    import nnsight
+
+    return os.path.dirname(os.path.dirname(os.path.abspath(nnsight.__file__)))
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("", 0))
+        return sock.getsockname()[1]
+
+
+def _run(ep: int, out: str) -> None:
+    env = {
+        **os.environ,
+        "PYTHONPATH": os.pathsep.join(
+            filter(None, [_nnsight_path(), os.environ.get("PYTHONPATH")])
+        ),
+        "CUDA_VISIBLE_DEVICES": "",
+        "OMP_NUM_THREADS": "1",
+    }
+    command = [sys.executable]
+    if ep > 1:
+        command += [
+            "-m", "torch.distributed.run",
+            f"--nproc_per_node={ep}",
+            f"--master_port={_free_port()}",
+        ]
+    command += [WORKER, "--ep", str(ep), "--out", out]
+
+    completed = subprocess.run(command, env=env, capture_output=True, text=True)
+    if completed.returncode != 0:
+        pytest.fail(
+            f"ep={ep} worker failed ({completed.returncode})\n"
+            f"--- stdout ---\n{completed.stdout[-4000:]}\n"
+            f"--- stderr ---\n{completed.stderr[-4000:]}"
+        )
+
+
+def _rel(actual: torch.Tensor, expected: torch.Tensor) -> float:
+    if actual.shape != expected.shape:
+        return float("inf")
+    scale = expected.abs().max().item()
+    return (actual - expected).abs().max().item() / (scale if scale else 1.0)
+
+
+@pytest.fixture(scope="module")
+def runs(tmp_path_factory) -> tuple[dict, list[dict]]:
+    reference_dir = tmp_path_factory.mktemp("ep1")
+    sharded_dir = tmp_path_factory.mktemp(f"ep{EP_SIZE}")
+
+    _run(1, str(reference_dir))
+    _run(EP_SIZE, str(sharded_dir))
+
+    reference = torch.load(os.path.join(reference_dir, "rank0.pt"), weights_only=False)
+    sharded = [
+        torch.load(os.path.join(sharded_dir, f"rank{rank}.pt"), weights_only=False)
+        for rank in range(EP_SIZE)
+    ]
+    return reference, sharded
+
+
+def test_the_ranks_agree(runs) -> None:
+    """Every rank saw the same values — the collectives lined up."""
+    _, sharded = runs
+    first, *rest = sharded
+    for rank, result in enumerate(rest, start=1):
+        for name, value in first.items():
+            assert torch.equal(value, result[name]), f"rank {rank} disagrees on {name}"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "router_logits",   # replicated: masked only after the handoff
+        "experts_out",     # this rank's term of the expert sum
+        "mlp_out",
+        "logits",
+        "edited_logits",   # an edit on the summed expert output, carried back
+    ],
+)
+def test_rank0_matches_the_single_process_run(runs, name) -> None:
+    reference, sharded = runs
+    drift = _rel(sharded[0][name], reference[name])
+    assert drift < DRIFT, (
+        f"{name}: relative error {drift:.2e} against the 1-process run "
+        f"(shapes {tuple(sharded[0][name].shape)} vs {tuple(reference[name].shape)}). "
+        "Order 1 means the value was not made whole; this is not drift."
+    )

--- a/tests/tp/test_cpu_gloo.py
+++ b/tests/tp/test_cpu_gloo.py
@@ -156,6 +156,7 @@ def test_the_ranks_agree(runs) -> None:
         "partial_edit_logits",  # an edit straddling the rank boundary
         "adhoc_colwise",
         "adhoc_rowwise",
+        "adhoc_hooked",   # hook=True must not skip the bracket
         "adhoc_nested",   # an ad-hoc call inside its own open handoff
         "skip_read_back",   # a .skip replacement is not gathered
         "skip_logits",

--- a/tests/tp/test_cpu_gloo.py
+++ b/tests/tp/test_cpu_gloo.py
@@ -1,0 +1,187 @@
+"""Tensor parallelism on CPU, so CI covers it at all.
+
+`test_sharded_tracing.py` is the same comparison on GPUs and is skipped
+everywhere without two of them — which is why transformers 5.16 could remove the
+ground the TP code stands on and no test said so. torch's DeviceMesh runs over
+gloo on CPU, and transformers' TP init has a CPU branch, so the whole path —
+sharded weights, the style's transforms, nnsight's gather and re-split — runs in
+a couple of seconds on any machine. It is the same worker as the GPU tests,
+launched with ``--device cpu``.
+
+What CPU cannot cover is real kernels and dtypes: this proves the *layout* logic,
+not that a bf16 model on eight cards gives the right numbers. `tests/tp/` still
+owns that.
+
+Two things are checked, and they fail differently:
+
+* **nnsight noticed the model is sharded.** A detection regression — transformers
+  moving its plan off the modules, say — makes fragments inert, and then every
+  sharded value is silently handed over as one rank's slice. The trace still runs
+  and the numbers are quietly wrong, so nothing but an explicit assertion catches
+  it. That is what happened on 5.16.
+* **rank 0 matches the single-process run**, within a tolerance, because an
+  all-reduce sums in a different order than one matmul. A mismatch of order 1 is
+  a layout error; 1e-4 is float arithmetic.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+
+import pytest
+import torch
+
+WORKER = os.path.join(os.path.dirname(os.path.abspath(__file__)), "worker.py")
+
+
+def _nnsight_path() -> str:
+    """The directory to put on the worker's ``PYTHONPATH`` so it imports the same
+    nnsight this session did.
+
+    Not the repo's ``src`` unconditionally: a non-editable install (which is what
+    CI does) builds the ``_c`` extensions into site-packages and leaves the source
+    tree without them, so forcing ``src`` ahead of site-packages would import a
+    half-built package and drop ``.save()`` off every tensor. Following the
+    already-imported module keeps an editable checkout and an installed wheel both
+    working, and tests whichever one the session is actually exercising.
+    """
+    import nnsight
+
+    return os.path.dirname(os.path.dirname(os.path.abspath(nnsight.__file__)))
+
+
+REPO = "hf-internal-testing/tiny-random-LlamaForCausalLM"
+TP_SIZE = 2
+
+# float32 on a 2-rank CPU mesh drifts far less than bf16 on 4 GPUs, so this is
+# tighter than the GPU suite's 1e-3.
+DRIFT = 1e-4
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("", 0))
+        return sock.getsockname()[1]
+
+
+def _run(tp: int, out: str) -> None:
+    """Run the worker at ``tp`` CPU ranks, writing one file per rank into ``out``."""
+    env = {
+        **os.environ,
+        "PYTHONPATH": os.pathsep.join(
+            filter(None, [_nnsight_path(), os.environ.get("PYTHONPATH")])
+        ),
+        # The empty string is what makes this a CPU run: transformers picks the
+        # mesh device from `torch._C._get_accelerator()`, which reports CPU only
+        # when no CUDA device is visible. Without this the ranks would each try
+        # to take a card and the run would need the hardware after all.
+        "CUDA_VISIBLE_DEVICES": "",
+        # gloo spawns a thread per rank per collective; the default thread count
+        # oversubscribes a shared machine for no gain on a model this size.
+        "OMP_NUM_THREADS": "1",
+    }
+    command = [sys.executable]
+    if tp > 1:
+        command += [
+            "-m", "torch.distributed.run",
+            f"--nproc_per_node={tp}",
+            f"--master_port={_free_port()}",
+        ]
+    command += [WORKER, "--tp", str(tp), "--repo", REPO, "--out", out, "--device", "cpu"]
+
+    completed = subprocess.run(command, env=env, capture_output=True, text=True)
+    if completed.returncode != 0:
+        pytest.fail(
+            f"tp={tp} CPU worker failed ({completed.returncode})\n"
+            f"--- stdout ---\n{completed.stdout[-4000:]}\n"
+            f"--- stderr ---\n{completed.stderr[-4000:]}"
+        )
+
+
+def _rel(actual: torch.Tensor, expected: torch.Tensor) -> float:
+    """max|a-b| / max|b| — scale-free, so it reads the same at any layer."""
+    if actual.shape != expected.shape:
+        return float("inf")
+    scale = expected.abs().max().item()
+    return (actual - expected).abs().max().item() / (scale if scale else 1.0)
+
+
+@pytest.fixture(scope="module")
+def runs(tmp_path_factory) -> tuple[dict, list[dict]]:
+    """``(reference, [per-rank sharded results])`` from two subprocess runs."""
+    reference_dir = tmp_path_factory.mktemp("cpu_tp1")
+    sharded_dir = tmp_path_factory.mktemp(f"cpu_tp{TP_SIZE}")
+
+    _run(1, str(reference_dir))
+    _run(TP_SIZE, str(sharded_dir))
+
+    reference = torch.load(os.path.join(reference_dir, "rank0.pt"), weights_only=False)
+    sharded = [
+        torch.load(os.path.join(sharded_dir, f"rank{rank}.pt"), weights_only=False)
+        for rank in range(TP_SIZE)
+    ]
+    return reference, sharded
+
+
+def test_the_sharded_run_produced_every_value(runs) -> None:
+    """The worker completed on every rank — nothing deadlocked or diverged."""
+    reference, sharded = runs
+    for rank, result in enumerate(sharded):
+        assert set(result) == set(reference), f"rank {rank} recorded a different set"
+
+
+def test_the_ranks_agree(runs) -> None:
+    """Every rank saw the same whole tensors — bit for bit.
+
+    A difference here is the deadlock/corruption class: the ranks disagreed about
+    what the value was, which means the collectives did not line up.
+    """
+    _, sharded = runs
+    first, *rest = sharded
+    for rank, result in enumerate(rest, start=1):
+        for name, value in first.items():
+            assert torch.equal(value, result[name]), f"rank {rank} disagrees on {name}"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "gate_proj_out",      # a column-parallel output: this rank's slice
+        "down_proj_in",       # a row-parallel input: pre-split
+        "layer_out",
+        "baseline_logits",
+        "partial_edit_logits",  # an edit straddling the rank boundary
+        "adhoc_colwise",
+        "adhoc_rowwise",
+        "adhoc_nested",   # an ad-hoc call inside its own open handoff
+        "skip_read_back",   # a .skip replacement is not gathered
+        "skip_logits",
+        "adhoc_lens",
+        "cached_gate_out",
+        "partial_backward_grad",   # backward through a row-parallel output
+        "source_colwise_gathered",   # tp.gather on an op inside a sharded module
+        "manual_gathered_heads",   # tp.gather on a value between two shards
+        "manual_ablated_logits",   # ... edited and tp.shard-ed back
+        "batched_first",
+        "batched_edited_logits",
+        "generated_steps",
+    ],
+)
+def test_rank0_matches_the_single_process_run(runs, name) -> None:
+    """A sharded value arrives whole, and matches what one process computed."""
+    reference, sharded = runs
+    drift = _rel(sharded[0][name], reference[name])
+    assert drift < DRIFT, (
+        f"{name}: relative error {drift:.2e} against the 1-rank run "
+        f"(shapes {tuple(sharded[0][name].shape)} vs {tuple(reference[name].shape)}). "
+        "Order 1 means the gather or the re-split is wrong; this is not drift."
+    )
+
+
+def test_generation_is_identical(runs) -> None:
+    """Greedy decoding produced the same token ids, not merely close logits."""
+    reference, sharded = runs
+    assert torch.equal(sharded[0]["generated"], reference["generated"])

--- a/tests/tp/test_sharded_tracing.py
+++ b/tests/tp/test_sharded_tracing.py
@@ -134,12 +134,19 @@ VALUES = [
     "baseline_logits",
     "partial_edit_logits",
     "cached_gate_out",
+    "partial_backward_grad",   # backward through a row-parallel output
+    "source_colwise_gathered",   # tp.gather on an op inside a sharded module
+    "manual_gathered_heads",   # tp.gather on a value between two shards
+    "manual_ablated_logits",   # ... edited and tp.shard-ed back
     "generated",
     "batched_first",
     "batched_edited_logits",
     "generated_steps",
     "adhoc_colwise",
     "adhoc_rowwise",
+    "adhoc_nested",   # an ad-hoc call inside its own open handoff
+    "skip_read_back",   # a .skip replacement is not gathered
+    "skip_logits",
     "adhoc_lens",
 ]
 

--- a/tests/tp/test_sharded_tracing.py
+++ b/tests/tp/test_sharded_tracing.py
@@ -144,6 +144,7 @@ VALUES = [
     "generated_steps",
     "adhoc_colwise",
     "adhoc_rowwise",
+    "adhoc_hooked",   # hook=True must not skip the bracket
     "adhoc_nested",   # an ad-hoc call inside its own open handoff
     "skip_read_back",   # a .skip replacement is not gathered
     "skip_logits",

--- a/tests/tp/worker.py
+++ b/tests/tp/worker.py
@@ -28,7 +28,7 @@ SECOND_PROMPT = "The capital of Japan is the city of"
 LAYER = 1
 
 
-def build(repo_id: str, tp: int, dtype: torch.dtype):
+def build(repo_id: str, tp: int, dtype: torch.dtype, device: str = "cuda"):
     from nnsight.modeling.tp import TPFragments
     from nnsight.modeling.transformers import TransformersModel
 
@@ -40,9 +40,11 @@ def build(repo_id: str, tp: int, dtype: torch.dtype):
             distributed_config=DistributedConfig(tp_size=tp),
         )
     else:
+        # Rank 0's card on CUDA; on CPU there is no index to pin to. The
+        # reference run is single-process either way.
         model = TransformersModel(
             repo_id, task="text-generation", dispatch=True, dtype=dtype,
-            device_map={"": 0},
+            device_map={"": 0} if device == "cuda" else {"": "cpu"},
         )
 
     # Nothing installs or enables anything: every HuggingFace model is built with
@@ -70,10 +72,11 @@ def main() -> None:
     parser.add_argument("--repo", required=True)
     parser.add_argument("--out", required=True)
     parser.add_argument("--dtype", default="float32")
+    parser.add_argument("--device", default="cuda", choices=("cuda", "cpu"))
     args = parser.parse_args()
 
     rank = int(os.environ.get("RANK", 0))
-    model = build(args.repo, args.tp, getattr(torch, args.dtype))
+    model = build(args.repo, args.tp, getattr(torch, args.dtype), args.device)
 
     layer = model.model.layers[LAYER]
     results: dict[str, torch.Tensor] = {}

--- a/tests/tp/worker.py
+++ b/tests/tp/worker.py
@@ -161,6 +161,13 @@ def main() -> None:
         layer.self_attn.source.query_states_0.output = shard(model, whole, dim=1)
         record("manual_ablated_logits", model.lm_head.output.save())
 
+    # `hook=True` only decides whether the trace watches the call; the caller is
+    # holding whole tensors either way. It used to skip the bracket, so the same
+    # call returned this rank's slice with the flag on and the whole without it.
+    with model.trace(PROMPT):
+        mlp_in = layer.mlp.input
+        record("adhoc_hooked", layer.mlp.gate_proj(mlp_in, hook=True).save())
+
     # A cache must record whole tensors too, and only for what it selects.
     with model.trace(PROMPT) as tracer:
         cache = tracer.cache(modules=[layer.mlp.gate_proj], include_inputs=True).save()

--- a/tests/tp/worker.py
+++ b/tests/tp/worker.py
@@ -78,6 +78,8 @@ def main() -> None:
     rank = int(os.environ.get("RANK", 0))
     model = build(args.repo, args.tp, getattr(torch, args.dtype), args.device)
 
+    from nnsight.modeling.tp import gather, shard
+
     layer = model.model.layers[LAYER]
     results: dict[str, torch.Tensor] = {}
 
@@ -95,8 +97,13 @@ def main() -> None:
     # An edit straddling rank boundaries: only correct if the gather assembled in
     # true rank order and the re-split put the edit back where it came from.
     width = results["gate_proj_out"].shape[-1]
+    # Cloned first, then assigned back: a gathered value is the output of an
+    # autograd Function, which torch will not have written into in place. See
+    # "Editing a gathered value" in docs/models/tensor-parallel.md.
     with model.trace(PROMPT):
-        layer.mlp.gate_proj.output[..., : width // 2 + 1] = 0
+        edited = layer.mlp.gate_proj.output.clone()
+        edited[..., : width // 2 + 1] = 0
+        layer.mlp.gate_proj.output = edited
         record("partial_edit_logits", model.lm_head.output.save())
 
     # Ad-hoc calls run a sharded module on whole tensors, through its own
@@ -110,6 +117,50 @@ def main() -> None:
         record("adhoc_rowwise", layer.mlp.down_proj(down_in).save())
         record("adhoc_lens", model.lm_head(model.model.norm(hidden)).save())
 
+    # An operation *inside* a module's forward is handed over as this rank's
+    # piece — no rule describes one, and the axis it is split on is not knowable
+    # from the value. The trace names the axis and reassembles it itself. Here
+    # the column-parallel matmul is a last-dim shard of the whole.
+    colwise_op = next(iter(layer.mlp.gate_proj.source.names))
+    with model.trace(PROMPT):
+        raw = getattr(layer.mlp.gate_proj.source, colwise_op).output
+        record("source_colwise_gathered", gather(model, raw, dim=-1).save())
+
+    # `.skip()` on a sharded module. The replacement is the caller's whole tensor
+    # and never passed through the module, so there is nothing to assemble — it
+    # only has to be cut back down. A row-parallel skip used to be all-reduced on
+    # the way out instead: every rank read back `tp_size` times what it wrote and
+    # the model carried that forward, with no error anywhere.
+    with model.trace(PROMPT):
+        hidden = layer.input
+        layer.mlp.down_proj.skip(torch.ones_like(hidden))
+        record("skip_read_back", layer.mlp.down_proj.output.save())
+        record("skip_logits", model.lm_head.output.save())
+
+    # An ad-hoc call on the *same* module whose handoff is still open. Reading
+    # `down_proj.input` opens that location's visit; calling `down_proj` from
+    # inside the block then asks the same location to be cut down again. The two
+    # used to share one record keyed by location, so the nested call consumed the
+    # open visit's and the module ran its sharded weights against a whole tensor.
+    with model.trace(PROMPT):
+        down_in = layer.mlp.down_proj.input
+        record("adhoc_nested", layer.mlp.down_proj(down_in).save())
+
+    # A value *between* two sharded modules is handed over as this rank's piece:
+    # nothing records which axis holds the shard once it has left the module that
+    # made it, and here `view`/`transpose` have moved it onto the head axis. So
+    # the trace says which axis, and gathers it itself. This is the per-head
+    # attention read, which is only reachable that way.
+    with model.trace(PROMPT):
+        heads = gather(model, layer.self_attn.source.query_states_0.output, dim=1)
+        record("manual_gathered_heads", heads.save())
+
+    with model.trace(PROMPT):
+        whole = gather(model, layer.self_attn.source.query_states_0.output, dim=1).clone()
+        whole[:, 1] = 0
+        layer.self_attn.source.query_states_0.output = shard(model, whole, dim=1)
+        record("manual_ablated_logits", model.lm_head.output.save())
+
     # A cache must record whole tensors too, and only for what it selects.
     with model.trace(PROMPT) as tracer:
         cache = tracer.cache(modules=[layer.mlp.gate_proj], include_inputs=True).save()
@@ -121,7 +172,7 @@ def main() -> None:
         with tracer.invoke(PROMPT):
             record("batched_first", layer.mlp.gate_proj.output.save())
         with tracer.invoke(SECOND_PROMPT):
-            layer.mlp.gate_proj.output[:] = 0
+            layer.mlp.gate_proj.output = torch.zeros_like(layer.mlp.gate_proj.output)
             record("batched_edited_logits", model.lm_head.output.save())
 
     # The same sharded location revisited on every step: the occurrence tagging
@@ -131,6 +182,17 @@ def main() -> None:
         for _ in tracer.iter[:3]:
             steps.append(layer.mlp.gate_proj.output[:, -1].mean())
     record("generated_steps", torch.stack([s.reshape(()) for s in steps]))
+
+    # `backward()` through a gathered *partial* side. The re-fragment contributes
+    # the whole on rank 0 and zeros elsewhere; done with a bare `zeros_like` that
+    # severed the graph on every rank but 0, so the ranks stopped reaching the
+    # same collectives and the backward hung — a deadlock rather than a wrong
+    # number, and reached without any branch in this block.
+    with model.trace(PROMPT):
+        layer.mlp.down_proj.output          # forces the gather and the re-fragment
+        loss = model.lm_head.output.sum()
+        with loss.backward():
+            record("partial_backward_grad", model.model.embed_tokens.weight.grad.save())
 
     # Greedy so the ranks cannot diverge on sampling; see the module docstring of
     # nnsight/modeling/tp/fragments.py for why that would be a correctness bug.


### PR DESCRIPTION
Fixes #702. Supersedes #706.

transformers 5.16 rebuilt tensor parallelism on DTensor. #702 found that
`all_gather`/`split` were removed; it turned out to be two more things, and those
two were the ones that mattered.

## What actually broke

1. **The plan moved off the modules.** Up to 5.15 each sharded module carried
   `_hf_tp_plan`; 5.16 keeps it on the model as `tp_plan` and stamps nothing. So
   `TPFragments.instrument` found nothing sharded — `enabled` stayed `False`,
   `tp_rules` empty, and every sharded value was handed over as one rank's slice.
2. **The style's transforms moved into a `forward` replacement.**
   `install_forward` replaces `module.forward`, which is the same slot nnsight's
   controller uses, so installing the controller dropped the wrapper.
3. `all_gather` / `split` were removed.

Because of (1), `_gather`/`_reshard` were never reached on 5.16, so the
`ImportError` (2) and (3) would have raised never fired. What users hit was
`RuntimeError: aten.mm.default got mixed torch.Tensor and DTensor` at the first
sharded linear.

## Fixes

- Detection reads `model.tp_plan` + `_device_mesh` and resolves each module with
  transformers' own matcher, not a private copy of its globbing.
- `_keep_tp_forward` installs the controller first and lets transformers re-wrap
  it, restoring the order the handoff assumes.
- The collectives are written on DTensor: they depend on nothing but `torch`, so
  this class of breakage cannot recur.
- Support is transformers 5.16+. **The dependency is not pinned** — only tensor
  parallelism needs the floor and it checks for itself at load.
- **Expert parallelism works.** `tp_plan` resolves to the expert plan under
  `enable_expert_parallel=True`, the placement gate divides the expert count
  rather than the head counts, and `ep_router`/`grouped_gemm` left `UNSUPPORTED`
  after being verified end to end.

## Four bugs two audit passes turned up

- A `.skip` on a sharded module read back `world_size`× what was written, silently.
- `backward()` through a row-parallel output **deadlocked** — the re-fragment's
  `torch.zeros_like` was a fresh leaf, so ranks ≠ 0 carried no graph and stopped
  reaching the same collectives. A hang from a block with no rank reference in it.
- An ad-hoc call nested inside its own open handoff consumed that visit's record.
- Values *inside* a forward were raw shards with nothing saying so.

## The contract, now in one line

**A module's `.input`/`.output` is made whole. Everything inside a forward is
not.** A `.source` operation, or a module between a column-parallel output and
the row-parallel input consuming it (`mlp.act_fn`), has no rule — and nothing on
the value records which axis holds its shard once it has left the module that
produced it. The axis moves, too: attention's `view`/`transpose` puts it on the
head dimension.

So `.source` on a sharded model warns, and `gather`/`shard` take the axis from
the caller:

```python
from nnsight.modeling.tp import gather, shard

with model.trace(prompt):
    q = attn.source.query_states_0.output      # (1, heads/tp_size, seq, head_dim)
    heads = gather(model, q, dim=1).clone()    # every head
    heads[:, 3] = 0
    attn.source.query_states_0.output = shard(model, heads, dim=1)
```

Per-head attention on a sharded model, which was not previously reachable.

## Why nothing caught this

`tests/tp` was `--ignore`d in CI because it needed GPUs. transformers TP runs on
CPU over gloo, so there is now a **2-rank CPU test that runs on every PR** and
would have caught all three changes the day 5.16 landed.

## Verification

| | |
|---|---|
| CPU suite, py3.14 + transformers 5.16.1 | **915 passed** |
| hakone 4×A100 — `tests/tp` incl. tp=4 Llama-3.2-3B bf16 | **187 passed** |
| hakone 2×A100 — vLLM 0.27.1 TP + taps | **34 passed** |

Also verified on the full `tests/vllm` suite (206 passed) at an earlier revision
of this branch; `test_deepseek.py` was skipped throughout (large download, disk
near full).

Reported by @Hotragn in #702, who bisected it to the transformers release rather
than an nnsight change and established CI was red on every PR against `0.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
