### PR TITLE
diffusion: automodel= chooses the class the weights load through

### DIFF
--- a/docs/models/diffusion-model.md
+++ b/docs/models/diffusion-model.md
@@ -9,6 +9,41 @@ sources: [src/nnsight/modeling/diffusion.py, src/nnsight/modeling/huggingface.py
 # DiffusionModel
 
 
+## Asking the same weights for a different task
+
+`DiffusionModel(repo_id)` builds whatever class the repo's `model_index.json`
+declares. For every Stable Diffusion repo that is the text-to-image pipeline, so
+`image=` has nowhere to go even though the weights serve image-to-image perfectly
+well.
+
+`automodel=` names the class to load through instead:
+
+```python
+from diffusers import AutoPipelineForImage2Image
+from nnsight.modeling.diffusion import DiffusionModel
+
+model = DiffusionModel("stable-diffusion-v1-5/stable-diffusion-v1-5",
+                       automodel=AutoPipelineForImage2Image)
+
+with model.trace("a photo of a cat", image=source, strength=0.5,
+                 num_inference_steps=20):
+    latents = model.unet.output[0].save()
+    result = model.output.save()
+```
+
+`AutoPipelineForImage2Image` picks the right class for the architecture, so the
+same line works for Flux, Kandinsky, SD3 and the rest. Its siblings are
+`AutoPipelineForText2Image`, `AutoPipelineForInpainting` and
+`AutoPipelineForText2Audio`. A concrete class works too, either as the class or
+as a name in `diffusers`:
+
+```python
+DiffusionModel(repo, automodel="StableDiffusionImg2ImgPipeline")
+```
+
+Everything else is unchanged: components are envoys, interventions fire per
+denoising step, and `model.output` is the pipeline's output object.
+
 ## What this is for
 
 `nnsight.DiffusionModel` wraps any `diffusers.DiffusionPipeline` so you can trace and intervene on its sub-modules — UNet (Stable Diffusion), transformer (Flux, DiT, SD3), VAE, text encoder — with the same NNsight API as other models. It supports:

--- a/src/nnsight/modeling/diffusion.py
+++ b/src/nnsight/modeling/diffusion.py
@@ -252,11 +252,18 @@ class DiffusionModel(HuggingFaceModel):
         requested = automodel if automodel is not None else self.automodel
         if requested is not None:
             chosen = self._pipeline_class(requested)
-            # `DiffusionPipeline` itself is a subclass of `DiffusionPipeline`, so
-            # this has to test what was *asked for* rather than what
-            # `_pipeline_class` defaulted to, or the declared class is replaced by
-            # the abstract base and the pipeline comes out with no components.
-            if isinstance(chosen, type) and issubclass(chosen, diffusers.DiffusionPipeline):
+            # Only a *concrete* pipeline can assemble anything here. Two things
+            # cannot: an `AutoPipelineFor*`, which picks its class at load and
+            # refuses direct construction, and `DiffusionPipeline` itself, which
+            # is a subclass of itself but has no components of its own — building
+            # from it filters every component out and yields a pipeline with no
+            # `.components` at all. Both fall back to the declared class, which is
+            # what the caller would have got anyway.
+            if (
+                isinstance(chosen, type)
+                and issubclass(chosen, diffusers.DiffusionPipeline)
+                and chosen is not diffusers.DiffusionPipeline
+            ):
                 pipeline_cls = chosen
 
         expected = set(inspect.signature(pipeline_cls.__init__).parameters) - {"self"}

--- a/src/nnsight/modeling/diffusion.py
+++ b/src/nnsight/modeling/diffusion.py
@@ -209,13 +209,30 @@ class DiffusionModel(HuggingFaceModel):
 
     pipeline: Optional["DiffusionPipeline"]
 
-    def __init__(self, repo_id: Any, *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self, repo_id: Any, *args: Any, automodel: Any = None, **kwargs: Any
+    ) -> None:
         self.pipeline = None
+        #: The diffusers class to load with, as a class or a name in ``diffusers``.
+        #: ``DiffusionPipeline`` (the default) builds whatever class the repo's
+        #: ``model_index.json`` declares, which is the text-to-image one for every
+        #: Stable Diffusion repo whatever you meant to do with the weights. Naming
+        #: another asks the same weights for a different task.
+        self.automodel = automodel
         super().__init__(repo_id, *args, **kwargs)
+
+    def _pipeline_class(self, automodel: Any = None) -> Any:
+        """The diffusers class to load with, defaulting to ``DiffusionPipeline``."""
+        import diffusers
+
+        chosen = automodel if automodel is not None else self.automodel
+        if chosen is None:
+            return diffusers.DiffusionPipeline
+        return getattr(diffusers, chosen) if isinstance(chosen, str) else chosen
 
     # -- loading -------------------------------------------------------------
 
-    def _meta_pipeline(self, repo_id: str) -> "DiffusionPipeline":
+    def _meta_pipeline(self, repo_id: str, automodel: Any = None) -> "DiffusionPipeline":
         # Build the pipeline component-by-component so no weights are loaded:
         # module components come from their config on meta (see MetaDevice),
         # everything else (schedulers, tokenizers, processors) loads normally.
@@ -225,6 +242,23 @@ class DiffusionModel(HuggingFaceModel):
             repo_id, revision=self.revision
         )
         pipeline_cls = getattr(diffusers, config["_class_name"])
+
+        # An `AutoPipelineFor*` picks its class per architecture at load and
+        # refuses to be constructed directly, so it cannot assemble anything
+        # here; a concrete class can. Either way the meta pipeline only has to
+        # hold the same *components* as the real one, since that is what the
+        # envoy tree is built from — the task variants of one architecture share
+        # them, so falling back to the declared class stays correct.
+        requested = automodel if automodel is not None else self.automodel
+        if requested is not None:
+            chosen = self._pipeline_class(requested)
+            # `DiffusionPipeline` itself is a subclass of `DiffusionPipeline`, so
+            # this has to test what was *asked for* rather than what
+            # `_pipeline_class` defaulted to, or the declared class is replaced by
+            # the abstract base and the pipeline comes out with no components.
+            if isinstance(chosen, type) and issubclass(chosen, diffusers.DiffusionPipeline):
+                pipeline_cls = chosen
+
         expected = set(inspect.signature(pipeline_cls.__init__).parameters) - {"self"}
 
         components: dict[str, Any] = {}
@@ -267,14 +301,21 @@ class DiffusionModel(HuggingFaceModel):
         with MetaDevice.real():
             return klass.from_pretrained(repo_id, subfolder=name, revision=self.revision)
 
-    def _load_meta(self, repo_id: str, *args: Any, **kwargs: Any) -> torch.nn.Module:
-        self.pipeline = self._meta_pipeline(repo_id)
+    def _load_meta(
+        self, repo_id: str, *args: Any, automodel: Any = None, **kwargs: Any
+    ) -> torch.nn.Module:
+        self.pipeline = self._meta_pipeline(repo_id, automodel)
         return _PipelineModule(self.pipeline)
 
-    def _load(self, repo_id: str, *args: Any, **kwargs: Any) -> torch.nn.Module:
-        from diffusers import DiffusionPipeline
-
-        self.pipeline = DiffusionPipeline.from_pretrained(
+    def _load(
+        self, repo_id: str, *args: Any, automodel: Any = None, **kwargs: Any
+    ) -> torch.nn.Module:
+        # `from_pretrained` is one classmethod shared by every pipeline class: on
+        # the base it reads the repo's declared class, on a concrete one it builds
+        # that class, and on an `AutoPipelineFor*` it picks the right class for
+        # the architecture. Loading through whichever was asked for is the whole
+        # of task selection.
+        self.pipeline = self._pipeline_class(automodel).from_pretrained(
             repo_id, revision=self.revision, **kwargs
         )
         return _PipelineModule(self.pipeline)

--- a/tests/test_diffusion.py
+++ b/tests/test_diffusion.py
@@ -47,19 +47,19 @@ def arch(request):
     return DiffusionModel(repo), denoiser
 
 
-def _grey():
+def _grey(colour=(127, 127, 127)):
     """A plain input image, for the image-to-image pipelines."""
     from PIL import Image
 
-    return Image.new("RGB", (64, 64), (127, 127, 127))
+    return Image.new("RGB", (64, 64), colour)
 
 
-def _mask():
+def _mask(box=(16, 16, 48, 48)):
     """A mask for the inpainting pipelines: a white square marks what to repaint."""
     from PIL import Image
 
     mask = Image.new("L", (64, 64), 0)
-    mask.paste(255, (16, 16, 48, 48))
+    mask.paste(255, box)
     return mask
 
 
@@ -330,6 +330,54 @@ class TestAutoPipelines:
         assert type(model.pipeline).__name__.endswith("Img2ImgPipeline")
         assert set(model.pipeline.components) == components
         assert isinstance(denoised, torch.Tensor)
+
+
+class TestTheTaskInputsReachTheModel:
+    """The image and the mask change the result.
+
+    Everything else about these pipelines can pass while the task input is
+    ignored: the class name is right, the denoiser carries both guidance rows, the
+    components match, and an intervention still changes the output, because the
+    intervention is what changed it. These are the assertions that fail if
+    `image=` or `mask_image=` never reaches the model.
+
+    The seed is pinned around each run so the input is the only thing that
+    differs. The margins are small because the checkpoint is tiny and randomly
+    initialised, and two denoising steps is not much; the point is that they are
+    not zero.
+    """
+
+    @torch.no_grad()
+    def test_image_to_image_depends_on_the_image(self):
+        from diffusers import AutoPipelineForImage2Image
+
+        model = DiffusionModel(REPO, automodel=AutoPipelineForImage2Image,
+                               dispatch=True, safety_checker=None)
+
+        results = []
+        for colour in ((0, 0, 0), (255, 255, 255)):
+            torch.manual_seed(0)
+            with model.trace(PROMPT, image=_grey(colour), strength=0.6, **KWARGS):
+                out = model.output.save()
+            results.append(numpy.asarray(out.images[0]))
+
+        assert not numpy.allclose(*results)
+
+    @torch.no_grad()
+    def test_inpainting_depends_on_the_mask(self):
+        from diffusers import AutoPipelineForInpainting
+
+        model = DiffusionModel(REPO, automodel=AutoPipelineForInpainting,
+                               dispatch=True, safety_checker=None)
+
+        results = []
+        for box in ((0, 0, 32, 32), (32, 32, 64, 64)):
+            torch.manual_seed(0)
+            with model.trace(PROMPT, image=_grey(), mask_image=_mask(box), **KWARGS):
+                out = model.output.save()
+            results.append(numpy.asarray(out.images[0]))
+
+        assert not numpy.allclose(*results)
 
 
 class TestText2Audio:

--- a/tests/test_diffusion.py
+++ b/tests/test_diffusion.py
@@ -4,10 +4,14 @@ Covers the lazy meta build, the envoy tree over the pipeline's module components
 the two run modes (both run the whole pipeline; ``trace`` defaults to one denoising
 step, ``generate`` to the pipeline's default), running a single component directly
 (``model.unet.trace(...)``), reading and modifying activations, ``seed=``
-reproducibility, and multi-prompt batching via ``DiffusionBatcher``
-(classifier-free-guidance doubling and ``num_images_per_prompt``).
+reproducibility, multi-prompt batching via ``DiffusionBatcher``
+(classifier-free-guidance doubling and ``num_images_per_prompt``), and
+``automodel=`` — the diffusers class the weights load through, which is what
+reaches a task other than the one the repo declares.
 """
 
+
+from types import SimpleNamespace
 
 import nnsight
 import pytest
@@ -48,6 +52,57 @@ def _grey():
     from PIL import Image
 
     return Image.new("RGB", (64, 64), (127, 127, 127))
+
+
+def _mask():
+    """A mask for the inpainting pipelines: a white square marks what to repaint."""
+    from PIL import Image
+
+    mask = Image.new("L", (64, 64), 0)
+    mask.paste(255, (16, 16, 48, 48))
+    return mask
+
+
+# Each `AutoPipelineFor*` that reaches a task on this repo's architecture
+# (stable-diffusion), the concrete class it picks, and the extra inputs that task
+# takes — built per call, since the pipelines consume the image. The fourth Auto
+# class, `AutoPipelineForText2Audio`, has no entry for this architecture and is
+# covered by `TestText2Audio`.
+AUTO_TASKS = [
+    ("AutoPipelineForText2Image", "StableDiffusionPipeline", dict),
+    (
+        "AutoPipelineForImage2Image",
+        "StableDiffusionImg2ImgPipeline",
+        lambda: dict(image=_grey(), strength=0.6),
+    ),
+    (
+        "AutoPipelineForInpainting",
+        "StableDiffusionInpaintPipeline",
+        lambda: dict(image=_grey(), mask_image=_mask()),
+    ),
+]
+AUTO_IDS = ["text2image", "image2image", "inpainting"]
+
+
+@pytest.fixture(scope="module", params=AUTO_TASKS, ids=AUTO_IDS)
+def auto(request):
+    """A lazily-built model loaded through one `AutoPipelineFor*`.
+
+    What the meta build produced is captured here, before any test dispatches it,
+    so the assertions about it don't depend on which test runs first.
+    """
+    import diffusers
+
+    name, concrete, inputs = request.param
+    model = DiffusionModel(REPO, automodel=getattr(diffusers, name), safety_checker=None)
+    return SimpleNamespace(
+        model=model,
+        name=name,
+        concrete=concrete,
+        inputs=inputs,
+        meta_class=type(model.pipeline).__name__,
+        meta_components=set(model.pipeline.components),
+    )
 
 
 def denoiser_inputs(model, batch=1):
@@ -180,35 +235,235 @@ class TestAutomodel:
         )
         assert type(model.pipeline).__name__ == "StableDiffusionImg2ImgPipeline"
 
-    def test_an_auto_class_resolves_per_architecture(self):
-        # `AutoPipelineForImage2Image` refuses to be constructed directly and
-        # picks its class at load, so the meta build falls back to the declared
-        # one. Both hold the same components, so the envoy tree stays valid.
+    def test_automodel_stays_out_of_the_load_kwargs(self):
+        # It's a keyword-only argument of __init__, so it never joins the kwargs
+        # replayed into `from_pretrained` on dispatch — where diffusers would
+        # reject it as an unexpected component name.
         from diffusers import AutoPipelineForImage2Image
 
         model = DiffusionModel(REPO, automodel=AutoPipelineForImage2Image,
                                safety_checker=None)
+        assert "automodel" not in model.kwargs
+        assert model.automodel is AutoPipelineForImage2Image
+
+    # `DiffusionPipeline` is a subclass of itself, so a guard that only asks
+    # "was an automodel requested, and is it a pipeline?" lets the abstract base
+    # through, and building from it filters every component out. Naming the
+    # default explicitly is what a caller writes when threading a class through a
+    # variable, so it has to mean the same as not naming one.
+    def test_naming_the_default_class_explicitly_is_the_default(self):
+        # `automodel=DiffusionPipeline` says exactly what `automodel=None` means,
+        # and is what a caller passing a class through a variable ends up with.
+        from diffusers import DiffusionPipeline
+
+        model = DiffusionModel(REPO, automodel=DiffusionPipeline, safety_checker=None)
         assert type(model.pipeline).__name__ == "StableDiffusionPipeline"
 
-        with model.trace(PROMPT, image=_grey(), strength=0.5, **KWARGS):
-            denoised = model.unet.output[0].save()
+    def test_the_default_class_explicitly_still_works_on_dispatch(self):
+        # The same argument on the eager path: `_load` calls `from_pretrained` on
+        # it, which is what the default does anyway, so this one is unaffected.
+        from diffusers import DiffusionPipeline
 
+        model = DiffusionModel(REPO, automodel=DiffusionPipeline, dispatch=True,
+                               safety_checker=None)
+        assert type(model.pipeline).__name__ == "StableDiffusionPipeline"
+
+
+class TestAutoPipelines:
+    """The `AutoPipelineFor*` classes, which pick a concrete class per architecture.
+
+    Three of the four reach a real task on this repo's weights (text-to-image,
+    image-to-image, inpainting); `AutoPipelineForText2Audio` has no entry for this
+    architecture and is covered by `TestText2Audio`. None of them can be
+    constructed directly, so the meta build falls back to the class the repo
+    declares — which is only safe while that class holds the same components, so
+    that is pinned here too.
+    """
+
+    @pytest.mark.parametrize("name", [task[0] for task in AUTO_TASKS], ids=AUTO_IDS)
+    def test_the_meta_build_falls_back_to_the_declared_class(self, name):
+        import diffusers
+
+        model = DiffusionModel(REPO, automodel=getattr(diffusers, name),
+                               safety_checker=None)
+        assert type(model.pipeline).__name__ == "StableDiffusionPipeline"
+        # The envoy tree is built from the components, so it has to be whole.
+        for component in ("unet", "vae", "text_encoder"):
+            assert hasattr(model, component)
+
+    @torch.no_grad()
+    def test_dispatch_loads_the_task_class(self, auto):
+        with auto.model.trace(PROMPT, **auto.inputs(), **KWARGS):
+            denoised = auto.model.unet.output[0].save()
+        assert auto.meta_class == "StableDiffusionPipeline"
+        assert type(auto.model.pipeline).__name__ == auto.concrete
+        assert denoised.shape[0] == 2  # classifier-free guidance doubles the batch
+
+    @torch.no_grad()
+    def test_the_task_class_holds_the_same_components(self, auto):
+        # The envoy tree is built once, off the meta pipeline, and re-pointed at
+        # the dispatched one. A task class that took a different set of components
+        # would leave envoys pointing at meta modules the real run never calls.
+        auto.model.dispatch()
+        assert set(auto.model.pipeline.components) == auto.meta_components
+
+    @torch.no_grad()
+    def test_an_intervention_changes_the_task_output(self, auto):
+        with auto.model.trace(PROMPT, **auto.inputs(), **KWARGS):
+            base = auto.model.output.save()
+        with auto.model.trace(PROMPT, **auto.inputs(), **KWARGS):
+            auto.model.unet.output[0][:] = 0
+            zeroed = auto.model.output.save()
+        assert not numpy.allclose(base.images[0], zeroed.images[0])
+
+    @torch.no_grad()
+    @pytest.mark.parametrize("repo,denoiser", ARCHITECTURES, ids=["flux", "sd3", "sdxl"])
+    def test_image_to_image_picks_the_class_for_each_architecture(self, repo, denoiser):
+        # The point of an Auto class over a concrete one: the same line reaches the
+        # image-to-image task on Flux, SD3 and SDXL, whose task classes differ.
+        from diffusers import AutoPipelineForImage2Image
+
+        model = DiffusionModel(repo, automodel=AutoPipelineForImage2Image)
+        components = set(model.pipeline.components)
+        with model.trace(PROMPT, image=_grey(), strength=0.6, **KWARGS):
+            denoised = getattr(model, denoiser).output[0].save()
+        assert type(model.pipeline).__name__.endswith("Img2ImgPipeline")
+        assert set(model.pipeline.components) == components
+        assert isinstance(denoised, torch.Tensor)
+
+
+class TestText2Audio:
+    """`AutoPipelineForText2Audio`, the fourth Auto class and the odd one.
+
+    There is no end-to-end test. The only tiny text-to-audio checkpoint on the Hub
+    (`dn6/dummy-audioldm2`, 8MB) does not load in this environment — its T5
+    tokenizer is a sentencepiece model that transformers 5 routes to a tiktoken
+    reader that rejects it — and AudioLDM2 itself calls
+    `GPT2Model._update_model_kwargs_for_generation`, removed in transformers 5, so
+    the pipeline does not run under plain diffusers either. Loaded by hand from a
+    patched copy it does reach nnsight intact: the tree carries the pipeline's
+    `unet` (an `AudioLDM2UNet2DConditionModel`), which traces and takes an
+    intervention. Its lazy path is unreachable for a separate reason — CLAP's
+    encoder calls `.item()` in its constructor, which a meta tensor refuses — so an
+    audio pipeline needs `dispatch=True` whatever `automodel=` says.
+
+    What holds without a checkpoint is below.
+    """
+
+    def test_it_has_no_entry_for_an_image_architecture(self):
+        # The refusal can only arrive at dispatch: the lazy build never consults
+        # the mapping, it falls back to the class the repo declares.
+        from diffusers import AutoPipelineForText2Audio
+
+        model = DiffusionModel(REPO, automodel=AutoPipelineForText2Audio,
+                               safety_checker=None)
+        assert type(model.pipeline).__name__ == "StableDiffusionPipeline"
+        with pytest.raises(ValueError, match="can't find a pipeline"):
+            model.dispatch()
+
+    def test_it_can_only_ever_pick_the_class_the_repo_declares(self):
+        # Where the image mappings hold a different class per task, every
+        # text-to-audio architecture has exactly one pipeline. So this Auto class
+        # resolves to the declared class and never changes the task — which makes
+        # the meta build's fallback to that class exactly right rather than merely
+        # component-compatible.
+        from diffusers.pipelines.auto_pipeline import (
+            AUTO_TEXT2AUDIO_PIPELINES_MAPPING,
+            _get_task_class,
+        )
+
+        for pipeline_cls in AUTO_TEXT2AUDIO_PIPELINES_MAPPING.values():
+            assert (
+                _get_task_class(AUTO_TEXT2AUDIO_PIPELINES_MAPPING, pipeline_cls.__name__)
+                is pipeline_cls
+            )
+
+
+class TestAutomodelErrors:
+    """What a name or class that can't load looks like, and when it is raised.
+
+    The lazy build sees only what it can construct, so anything the *loader* has to
+    judge — an Auto class with no entry, a class that isn't a pipeline at all —
+    surfaces at dispatch rather than at construction.
+    """
+
+    def test_a_name_that_is_not_in_diffusers(self):
+        with pytest.raises(AttributeError, match="NoSuchPipeline"):
+            DiffusionModel(REPO, automodel="NoSuchPipeline")
+
+    def test_a_class_needing_components_the_repo_has_not_got(self):
+        # Asked for a concrete class, the meta build assembles *that* class from
+        # the repo's declared components, so a mismatch is caught while building.
+        with pytest.raises(TypeError, match="text_encoder_2"):
+            DiffusionModel(REPO, automodel="StableDiffusionXLPipeline")
+
+    def test_a_class_that_is_not_a_pipeline_survives_the_meta_build(self):
+        # The meta guard only asks whether the class can assemble a pipeline, and
+        # ignores it when it can't — so a non-pipeline is not refused, it is
+        # deferred to `from_pretrained`, where the message is about a missing
+        # config file rather than about `automodel=`.
+        model = DiffusionModel(REPO, automodel="UNet2DConditionModel")
+        assert type(model.pipeline).__name__ == "StableDiffusionPipeline"
+        with pytest.raises(OSError):
+            model.dispatch()
+
+
+class TestAutomodelInteractions:
+    """`automodel=` against the rest of DiffusionModel: renaming, single-component
+    traces, batched invokes and the remote round trip."""
+
+    @torch.no_grad()
+    def test_rename_reaches_the_task_pipeline_s_denoiser(self):
+        from diffusers import AutoPipelineForImage2Image
+
+        model = DiffusionModel(REPO, automodel=AutoPipelineForImage2Image,
+                               rename={"unet": "denoiser"}, safety_checker=None)
+        with model.trace(PROMPT, image=_grey(), strength=0.6, **KWARGS):
+            denoised = model.denoiser.output[0].save()
         assert type(model.pipeline).__name__ == "StableDiffusionImg2ImgPipeline"
-        assert denoised.shape[0] == 2   # classifier-free guidance doubles the batch
+        assert isinstance(denoised, torch.Tensor) and denoised.ndim == 4
 
-    def test_an_intervention_reaches_an_image_to_image_run(self):
+    @torch.no_grad()
+    def test_a_single_component_trace_after_an_auto_load(self):
+        # The denoiser is the same module whichever task class holds it, so
+        # tracing that envoy on its own is unaffected by the class swap.
         from diffusers import AutoPipelineForImage2Image
 
         model = DiffusionModel(REPO, automodel=AutoPipelineForImage2Image,
                                dispatch=True, safety_checker=None)
+        sample, timestep, enc = denoiser_inputs(model)
+        with model.unet.trace(sample, timestep, encoder_hidden_states=enc):
+            out = model.unet.output.save()
+        assert out.sample.shape == sample.shape
 
-        with model.trace(PROMPT, image=_grey(), strength=0.5, **KWARGS):
-            base = model.output.save()
-        with model.trace(PROMPT, image=_grey(), strength=0.5, **KWARGS):
-            model.unet.output[0][:] = 0
-            zeroed = model.output.save()
+    @torch.no_grad()
+    def test_batched_invokes_narrow_the_denoiser(self):
+        # DiffusionBatcher's guidance-doubled layout is the denoiser's, not the
+        # pipeline's, so it holds for an image-to-image run too — with one edit
+        # confined to its own invoke's rows.
+        from diffusers import AutoPipelineForImage2Image
 
-        assert not numpy.allclose(base.images[0], zeroed.images[0])
+        model = DiffusionModel(REPO, automodel=AutoPipelineForImage2Image,
+                               dispatch=True, safety_checker=None)
+        with model.trace(image=_grey(), strength=0.6, **KWARGS) as tracer:
+            with tracer.invoke("a cat"):
+                model.unet.output[0][:] = 0
+            with tracer.invoke("a dog"):
+                dog = model.unet.output[0].save()
+        assert dog.shape[0] == 2
+        assert bool((dog != 0).any())
+
+    @torch.no_grad()
+    def test_the_trace_round_trips_through_serialization(self):
+        # `automodel` lands in __getstate__'s state, so it has to be picklable —
+        # a diffusers class is, being module-level.
+        from diffusers import AutoPipelineForImage2Image
+
+        model = DiffusionModel(REPO, automodel=AutoPipelineForImage2Image,
+                               dispatch=True, safety_checker=None)
+        with model.trace(PROMPT, image=_grey(), strength=0.6, remote="local", **KWARGS):
+            denoised = model.unet.output[0].save()
+        assert isinstance(denoised, torch.Tensor) and denoised.shape[0] == 2
 
 
 class TestSeed:

--- a/tests/test_diffusion.py
+++ b/tests/test_diffusion.py
@@ -15,6 +15,8 @@ import torch
 
 pytest.importorskip("diffusers")
 
+import numpy
+
 from nnsight.modeling.diffusion import DiffusionModel, _resolve_component_class
 
 REPO = "hf-internal-testing/tiny-stable-diffusion-torch"
@@ -39,6 +41,13 @@ def sd():
 def arch(request):
     repo, denoiser = request.param
     return DiffusionModel(repo), denoiser
+
+
+def _grey():
+    """A plain input image, for the image-to-image pipelines."""
+    from PIL import Image
+
+    return Image.new("RGB", (64, 64), (127, 127, 127))
 
 
 def denoiser_inputs(model, batch=1):
@@ -140,6 +149,66 @@ class TestInterventions:
             sd.unet.output[0][:] = 0
             zeroed = sd.output.save()
         assert not np.allclose(baseline.images, zeroed.images)
+
+
+class TestAutomodel:
+    """`automodel=` chooses the diffusers class the weights are loaded through.
+
+    `DiffusionPipeline.from_pretrained` builds whatever class the repo's
+    `model_index.json` declares, which is the text-to-image one for every Stable
+    Diffusion repo whatever the caller meant to do. The same weights serve other
+    tasks through a different class, so naming one is how you reach them.
+    """
+
+    def test_the_default_is_the_declared_class(self):
+        model = DiffusionModel(REPO, dispatch=True, safety_checker=None)
+        assert type(model.pipeline).__name__ == "StableDiffusionPipeline"
+
+    def test_a_concrete_class(self):
+        from diffusers import StableDiffusionImg2ImgPipeline
+
+        model = DiffusionModel(
+            REPO, automodel=StableDiffusionImg2ImgPipeline, dispatch=True,
+            safety_checker=None,
+        )
+        assert isinstance(model.pipeline, StableDiffusionImg2ImgPipeline)
+
+    def test_a_class_named_as_a_string(self):
+        model = DiffusionModel(
+            REPO, automodel="StableDiffusionImg2ImgPipeline", dispatch=True,
+            safety_checker=None,
+        )
+        assert type(model.pipeline).__name__ == "StableDiffusionImg2ImgPipeline"
+
+    def test_an_auto_class_resolves_per_architecture(self):
+        # `AutoPipelineForImage2Image` refuses to be constructed directly and
+        # picks its class at load, so the meta build falls back to the declared
+        # one. Both hold the same components, so the envoy tree stays valid.
+        from diffusers import AutoPipelineForImage2Image
+
+        model = DiffusionModel(REPO, automodel=AutoPipelineForImage2Image,
+                               safety_checker=None)
+        assert type(model.pipeline).__name__ == "StableDiffusionPipeline"
+
+        with model.trace(PROMPT, image=_grey(), strength=0.5, **KWARGS):
+            denoised = model.unet.output[0].save()
+
+        assert type(model.pipeline).__name__ == "StableDiffusionImg2ImgPipeline"
+        assert denoised.shape[0] == 2   # classifier-free guidance doubles the batch
+
+    def test_an_intervention_reaches_an_image_to_image_run(self):
+        from diffusers import AutoPipelineForImage2Image
+
+        model = DiffusionModel(REPO, automodel=AutoPipelineForImage2Image,
+                               dispatch=True, safety_checker=None)
+
+        with model.trace(PROMPT, image=_grey(), strength=0.5, **KWARGS):
+            base = model.output.save()
+        with model.trace(PROMPT, image=_grey(), strength=0.5, **KWARGS):
+            model.unet.output[0][:] = 0
+            zeroed = model.output.save()
+
+        assert not numpy.allclose(base.images[0], zeroed.images[0])
 
 
 class TestSeed:


### PR DESCRIPTION
Closes #417.

`DiffusionModel(repo_id)` builds whatever class the repo's `model_index.json`
declares. For every Stable Diffusion repo that is the text-to-image pipeline, so
`image=` has nowhere to go even though the same weights serve image-to-image and
inpainting perfectly well.

diffusers already offers three ways in, since `from_pretrained` is one classmethod
shared by every pipeline class. On the base it reads the declared class, on a
concrete class it builds that one, and on an `AutoPipelineFor*` it picks the right
class for the architecture. `_load` hardcoded the base, so only the entry point
that ignores the caller's intent was reachable.

`automodel=` names the class instead, as a class or as a name in `diffusers`, and
threads from `__init__` through `_load` and `_load_meta`:

```python
from diffusers import AutoPipelineForImage2Image

model = DiffusionModel(repo, automodel=AutoPipelineForImage2Image)

with model.trace("a photo of a cat", image=source, strength=0.5,
                 num_inference_steps=20):
    latents = model.unet.output[0].save()
    result = model.output.save()
```

## The meta build

An `AutoPipelineFor*` refuses direct construction, so `_meta_pipeline` falls back
to the class the repo declares. That stays correct because the meta pipeline only
has to hold the same *components* as the real one, and the task variants of an
architecture share them. The tests pin that by comparing component sets across the
meta and dispatched pipelines rather than taking it on trust.

One exception found by scanning all 45 image mappings in diffusers 0.40:
`flux-controlnet`'s text-to-image variant takes `feature_extractor` and
`image_encoder` while its image-to-image and inpainting variants do not. On such a
repo the meta tree would carry an envoy the dispatched pipeline never has. That is
a stale envoy rather than a crash, and there is no tiny repo to test it against.

## Coverage

`AutoPipelineForText2Image`, `AutoPipelineForImage2Image` and
`AutoPipelineForInpainting` are each covered end to end: the meta fallback, the
dispatched class, component equality, an intervention landing, and the task input
actually changing the result. Image-to-image is also proven across Flux, SD3 and
SDXL, which is the point of an Auto class over a concrete one.

`AutoPipelineForText2Audio` is not covered, and the test class records why. One
small text-to-audio checkpoint exists on the Hub out of 193 candidates scanned,
its tokenizer will not load under transformers 5, and AudioLDM2's own generate
path is broken against transformers 5 with no nnsight involved. Separately, an
audio pipeline cannot use the lazy meta build at all, because `ClapModel.__init__`
calls `.item()` on a meta tensor. That last one is a pre-existing limitation. By
hand on a patched checkpoint the class does resolve and load, and a
single-component trace with an intervention works; only the whole-pipeline run is
unreachable.

Its mapping is also an identity, one audio pipeline per architecture, so that Auto
class can never select a class different from the one the repo declares.

## Second commit

The first commit had a bug. `DiffusionPipeline` is a subclass of itself, so
`automodel=DiffusionPipeline`, which is a no-op by definition, passed the meta
build's guard and replaced the declared class with the abstract base. That has no
components of its own, so everything was filtered out and the pipeline came back
with no `.components`. Only the lazy path was affected. It is the spelling a caller
lands on when threading a class through a variable, and the error named nothing
they wrote.

## Tests

`tests/test_diffusion.py` goes from 41 to 68. Full suite 1009 passed, 80 skipped,
1 xfailed on CPU.

The functional tests are worth calling out because the earlier ones passed for the
wrong reason. Asserting the class name, the denoiser shape, the component sets and
that an intervention changes the output all hold while `image=` is ignored, and
each fed the same uniform grey image. `TestTheTaskInputsReachTheModel` varies only
the input with the seed pinned, and I checked it fails when both legs are fed the
same input.

Raised originally by @Kmoneal in #417, which proposed a separate `Img2ImgDiffusion`
class. The generic wrapper turned out to handle it once it could be given the right
pipeline object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
