### PR TITLE
Preserve model forward signatures through Accelerate wrappers

### DIFF
--- a/src/nnsight/intervention/interleaver.py
+++ b/src/nnsight/intervention/interleaver.py
@@ -560,6 +560,11 @@ class Interleaver:
                 # e.g. accelerate's partial(new_forward, module) for device_map —
                 # unwrap to avoid reference cycle through partial.args
                 original_forward = instance_forward.func
+                introspection_signature = (
+                    inspect.signature(module._old_forward)
+                    if hasattr(module, "_old_forward")
+                    else inspect.signature(instance_forward)
+                )
             else:
                 original_forward = instance_forward
 
@@ -597,6 +602,9 @@ class Interleaver:
                 if source_accessor is not None:
                     return source_accessor(m, *args, **kwargs)
                 return m.__nnsight_forward__(m, *args, **kwargs)
+
+            if isinstance(instance_forward, partial):
+                nnsight_forward.__signature__ = introspection_signature
 
             module.forward = nnsight_forward
 

--- a/tests/test_interleaver_signature.py
+++ b/tests/test_interleaver_signature.py
@@ -1,0 +1,42 @@
+import inspect
+from functools import partial
+from types import SimpleNamespace
+
+import torch
+from transformers import GenerationMixin
+
+from nnsight.intervention.interleaver import Interleaver
+
+
+class MultimodalModule(torch.nn.Module, GenerationMixin):
+    config = SimpleNamespace(is_encoder_decoder=False)
+
+    def forward(self, input_ids=None, pixel_values=None, image_grid_thw=None):
+        return input_ids
+
+    def prepare_inputs_for_generation(self, input_ids, **kwargs):
+        return {"input_ids": input_ids, **kwargs}
+
+
+def accelerate_new_forward(module, *args, **kwargs):
+    return module._old_forward(*args, **kwargs)
+
+
+def test_accelerate_wrapped_forward_preserves_model_signature():
+    module = MultimodalModule()
+    module._old_forward = module.forward
+    module.forward = partial(accelerate_new_forward, module)
+
+    object.__new__(Interleaver).wrap_module(module)
+
+    parameters = inspect.signature(module.forward).parameters
+    assert "pixel_values" in parameters
+    assert "image_grid_thw" in parameters
+    module._validate_model_kwargs(
+        {
+            "input_ids": torch.tensor([7]),
+            "pixel_values": torch.tensor([8]),
+            "image_grid_thw": torch.tensor([9]),
+        }
+    )
+    assert module(input_ids=torch.tensor([7])).tolist() == [7]


### PR DESCRIPTION
Fixes #711.

When Accelerate replaces `module.forward` with `partial(new_forward, module)`, `Interleaver.wrap_module` currently uses the generic wrapper for both execution and introspection. Transformers generation validation then sees only `*args, **kwargs` and rejects valid multimodal inputs such as `pixel_values` and `image_grid_thw`.

This keeps execution routed through Accelerate while exposing the bound `_old_forward` signature on the NNsight wrapper. The regression uses a synthetic module and calls Transformers `_validate_model_kwargs`, so it runs on CPU without model weights or multiple GPUs.

Validation:

- focused regression: 1 passed
- pre-patch-equivalent signature rejects `pixel_values` and `image_grid_thw`
- patched signature accepts both and preserves execution
- `git diff --check`