### PR TITLE
transformers: beam search, audio models on meta, and a task transformers 5 removed

### DIFF
--- a/docs/models/transformers-model.md
+++ b/docs/models/transformers-model.md
@@ -134,7 +134,7 @@ print(ids.shape)                          # torch.Size([1, 13])  (10 prompt + 3 
 print(model.tokenizer.decode(ids[0]))     # "The Eiffel Tower is in the city of Paris, and"
 ```
 
-`generate` goes through the model with the checkpoint's own settings — **greedy by default** (no `do_sample`), unlike `pipe`, which folds in the checkpoint's `task_specific_params`. Ask for sampling explicitly with `do_sample=True`, `temperature=`, etc. Read the ids off `tracer.result` (preferred). `**kwargs` are forwarded to the model's `generate`, e.g. `max_new_tokens`, `num_return_sequences`, `generation_config=`.
+`generate` goes through the model and decodes with the checkpoint's own **`generation_config`** — not the `task_specific_params` `pipe` folds in. That config is the checkpoint's to set: gpt2 leaves it greedy, while many instruct checkpoints ship `do_sample=True` in it (`gemma-3-1b-it`, `Llama-3.1-8B-Instruct`, `Qwen3-4B-Instruct-2507` all do), so **generate samples on those unless you say otherwise**. Check `model.generation_config.do_sample`, and pass `do_sample=False` when you need determinism. Read the ids off `tracer.result` (preferred). `**kwargs` are forwarded to the model's `generate`, e.g. `max_new_tokens`, `num_return_sequences`, `generation_config=`.
 
 Called directly (no `with`), it just generates and returns the ids:
 
@@ -366,7 +366,7 @@ Aliases are honored in `tracer.cache()` keys too (`tests/test_language.py`).
 
 ## Gotchas
 
-- **`generate` vs `pipe`.** `generate` returns token ids and is greedy by default; `pipe` returns decoded records and folds in the checkpoint's sampling `task_specific_params`.
+- **`generate` vs `pipe`.** `generate` returns token ids and decodes with the checkpoint's `generation_config`, which may sample — pass `do_sample=False` for a deterministic run; `pipe` returns decoded records and folds in the checkpoint's sampling `task_specific_params`.
 - **`save()` outside a trace raises.** `.save()` / `nnsight.save(...)` raises if there's no active trace.
 - **`scan` needs `dispatch=False` to be cheap** but works either way; it never loads weights.
 - **Opaque inputs can't be batched.** A multimodal encoding (with `pixel_values`) or a raw float tensor must be a lone invoke — batching several raises `NotImplementedError`.

--- a/docs/models/transformers-model.md
+++ b/docs/models/transformers-model.md
@@ -32,6 +32,28 @@ checkpoint does not change that. Under `HF_HUB_OFFLINE=1` the first form raises
 offline mode`, so pass `task=` on an air-gapped machine or a cluster node with no
 outbound network.
 
+transformers 5 has no `summarization`, `translation`, `text2text-generation`,
+`question-answering` or `image-to-text` pipeline, so a seq2seq checkpoint (T5, BART)
+has no task of its own left: `text-generation` is the only route, and from a repo id
+that route resolves through `AutoModelForCausalLM` and builds the decoder-only class
+(`BartForCausalLM` — no encoder) without saying so. Load the model yourself and hand
+nnsight the module:
+
+```python
+from transformers import AutoTokenizer, BartForConditionalGeneration
+
+repo = "facebook/bart-base"
+model = TransformersModel(
+    BartForConditionalGeneration.from_pretrained(repo),
+    tokenizer=AutoTokenizer.from_pretrained(repo),
+)
+```
+
+A seq2seq run through `text-generation` also has `pipe` echo the prompt back rather
+than return the completion (transformers' behaviour), so an intervention measured
+through those records reads as a no-op — measure through `generate` /
+`tracer.result` instead.
+
 ### Constructor
 
 ```python

--- a/src/nnsight/modeling/transformers.py
+++ b/src/nnsight/modeling/transformers.py
@@ -116,7 +116,6 @@ _ARCH_TASK = {
     "ForMaskedLM": "fill-mask",
     "ForSequenceClassification": "text-classification",
     "ForTokenClassification": "token-classification",
-    "ForQuestionAnswering": "question-answering",
     "ForImageClassification": "image-classification",
     "ForImageTextToText": "image-text-to-text",
 }
@@ -365,11 +364,24 @@ class TransformersModel(HuggingFaceModel):
         # loads are sourced — passing a stray tokenizer source to a processor-based
         # (multimodal) pipeline, for instance, makes it reject the string.
         needed = self._loaded_preprocessors()
-        return {
+        sources = {
             attr: getattr(self, attr) or self.repo_id
             for attr in _PREPROCESSORS
             if getattr(self, attr) is not None or attr in needed
         }
+        # The audio pipelines look for a CTC decoder when the feature extractor
+        # comes in as a repo id, under a model name they derive from the model
+        # argument -- which is None when the model is pre-built (the meta path),
+        # so they fetch `huggingface.co/None/...` and die. Hand them the object
+        # instead; a feature extractor is a JSON config, no weights, so building
+        # it costs nothing on the path that exists to avoid loading weights.
+        if isinstance(sources.get("feature_extractor"), str):
+            from transformers import AutoFeatureExtractor
+
+            sources["feature_extractor"] = AutoFeatureExtractor.from_pretrained(
+                sources["feature_extractor"], revision=self.revision
+            )
+        return sources
 
     def _loaded_preprocessors(self) -> set:
         # Which of tokenizer/image_processor/feature_extractor/processor the task's
@@ -597,12 +609,22 @@ class TransformersModel(HuggingFaceModel):
         Args:
             *inputs: What to generate from — the same forms `trace` takes.
             **kwargs: Passed to the model's ``generate``, e.g. ``max_new_tokens``.
-                ``streamer`` defaults to this model's; pass it to override.
+                ``streamer`` defaults to this model's (except under beam search,
+                which transformers refuses a streamer for); pass it to override.
 
         Returns:
             The generated token ids, as a ``[batch, seq]`` tensor.
         """
-        kwargs.setdefault("streamer", self.generator.streamer._module)
+        # transformers refuses any streamer under beam search, and this one is
+        # nnsight's, not the caller's -- so only inject it when the run is
+        # single-beam. The beams can come from a passed generation_config or from
+        # the checkpoint's own, where unset reads as None rather than 1.
+        config = kwargs.get("generation_config") or getattr(
+            self.pipeline.model, "generation_config", None
+        )
+        num_beams = kwargs.get("num_beams") or getattr(config, "num_beams", None) or 1
+        if num_beams == 1:
+            kwargs.setdefault("streamer", self.generator.streamer._module)
         output = self.pipeline.model.generate(*inputs, **kwargs)
         # Pass the output through the generator module so a worker parked on
         # `model.generator.output` receives it (and can edit it). hook=True fires the

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -263,6 +263,29 @@ class TestGeneration:
         )
 
     @torch.no_grad()
+    def test_beam_search_matches_transformers(self, gpt2):
+        # nnsight injects its own streamer to give per-step token access, and
+        # transformers refuses any streamer under beam search — so beam search
+        # only runs at all if the streamer stays out of it.
+        kwargs = dict(max_new_tokens=3, num_beams=3, do_sample=False)
+        with gpt2.generate(PROMPT, **kwargs) as tracer:
+            hidden = gpt2.transformer.h[-1].output.save()
+            ids = tracer.result.save()
+        encoding = gpt2.tokenizer(PROMPT, return_tensors="pt").to(gpt2._module.device)
+        assert torch.equal(ids, gpt2._module.generate(**encoding, **kwargs))
+        # The beams are the rows a read inside the block sees.
+        assert hidden.shape[0] == 3
+
+    @torch.no_grad()
+    def test_beams_from_the_generation_config_count_too(self, gpt2, monkeypatch):
+        # A checkpoint can ask for beam search in its own generation_config, with
+        # no num_beams in the call.
+        monkeypatch.setattr(gpt2._module.generation_config, "num_beams", 3)
+        with gpt2.generate(PROMPT, max_new_tokens=3, do_sample=False) as tracer:
+            ids = tracer.result.save()
+        assert ids.shape == (1, 12)
+
+    @torch.no_grad()
     def test_save_hidden_states_and_input(self, gpt2):
         with gpt2.trace(PROMPT):
             hs_in = gpt2.transformer.h[-1].input.save()

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -935,8 +935,48 @@ class TestPreloadedModule:
         model = TransformersModel(hf_gpt2, task="text-generation", tokenizer=tok)
         assert model.tokenizer is tok
 
+    def test_question_answering_module_asks_for_a_task(self):
+        # transformers 5 has no question-answering pipeline, so there is no task to
+        # infer for a *ForQuestionAnswering module: the user has to be told to pass
+        # one, rather than getting a KeyError out of the pipeline factory.
+        from transformers import TapasForQuestionAnswering
+
+        module = TapasForQuestionAnswering.from_pretrained(
+            "hf-internal-testing/tiny-random-TapasForQuestionAnswering"
+        )
+        with pytest.raises(ValueError, match="pass task="):
+            TransformersModel(module)
+
     def test_bare_module_wraps_raw(self):
         # A non-HF module through the base HuggingFaceModel is wrapped directly.
         model = HuggingFaceModel(nn.Linear(8, 8))
         assert model.dispatched is True
         assert isinstance(model._module, nn.Linear)
+
+
+class TestMetaAudio:
+    """The lazy meta build (``dispatch=False``, the default) has to work for audio
+    tasks too. The model is pre-built there, so a feature extractor sourced as a
+    repo-id string sends the audio pipeline looking for a CTC decoder under a model
+    name it derives from the model argument — a module, so the name is None and the
+    lookup fetches `huggingface.co/None/...`."""
+
+    @pytest.mark.parametrize(
+        "repo,task",
+        [
+            (
+                "hf-internal-testing/tiny-random-Wav2Vec2ForSequenceClassification",
+                "audio-classification",
+            ),
+            (
+                "hf-internal-testing/tiny-random-WhisperForConditionalGeneration",
+                "automatic-speech-recognition",
+            ),
+        ],
+    )
+    def test_audio_model_builds_on_meta(self, repo, task):
+        model = TransformersModel(repo, task=task)
+        assert model.dispatched is False
+        assert all(p.device.type == "meta" for p in model._module.parameters())
+        # The feature extractor is a real object, loaded off the repo id.
+        assert model.feature_extractor is not None


### PR DESCRIPTION
Three findings from the agent stress sweep, all in `modeling/transformers.py`.

### What was broken

**`num_beams > 1` was impossible.** `generate` ran
`kwargs.setdefault("streamer", self.generator.streamer._module)` unconditionally, and
transformers refuses any streamer under beam search — so every beam-search call died with
`ValueError: streamer cannot be used with beam search (yet!)`, raised out of `tracer.__exit__`
and naming an argument the caller never passed. Beam search was otherwise fine: with
`streamer=None` the output matches raw HF exactly and interventions see `[num_beams, ...]` rows.

**No audio model could be built on the default `dispatch=False`.** `_preprocessor_sources`
sources each preprocessor as the repo-id *string*. On the meta path the model is pre-built, so
transformers derives `model_name` from the model argument (a module) as `None`, and the audio
path then looks for a CTC decoder at `huggingface.co/None/...`:
`OSError: None is not a local folder and is not a valid model identifier`. Every ASR and
audio-classification checkpoint hit it — `openai/whisper-tiny` and tiny-random Wav2Vec2 alike.

**`_ARCH_TASK` mapped `*ForQuestionAnswering` to a task transformers 5 no longer has**, so
inferring a task for a pre-loaded QA model got a raw `KeyError: Unknown task question-answering`
out of the pipeline factory instead of nnsight's own `ValueError` telling the user to pass `task=`.

### What changed

- `generate` resolves the effective beam count — the `num_beams` kwarg, a passed
  `generation_config`, or the checkpoint's own (where unset reads as `None`, not `1`) — and
  injects the streamer only when it is 1. An explicit `streamer=` still wins, as before.
- `_preprocessor_sources` constructs `AutoFeatureExtractor.from_pretrained(repo_id)` when the
  feature extractor would otherwise go out as a string. Only that one preprocessor: a feature
  extractor is a JSON config with no weights, so it costs nothing on the path whose point is not
  to load weights.
- Dropped the `"ForQuestionAnswering"` entry from `_ARCH_TASK`; `_infer_task` now falls through
  to its own error, which already says what to do.
- One note in `docs/models/transformers-model.md` under `## Loading`: transformers 5 has no
  `summarization` / `translation` / `text2text-generation` / `question-answering` /
  `image-to-text` pipeline, so a seq2seq checkpoint has no task of its own — from a repo id,
  `text-generation` silently builds the decoder-only class (`BartForCausalLM`, no encoder), and
  `pipe` echoes the prompt, so measure through `generate` / `tracer.result`. Load the model
  yourself and hand nnsight the module.

### Tests

New, all five verified to fail on `0.8` and pass here:

- `tests/test_language.py::TestGeneration::test_beam_search_matches_transformers` — output is
  identical to raw `transformers.generate` with the same kwargs, and a read inside the block sees
  one row per beam.
- `tests/test_language.py::TestGeneration::test_beams_from_the_generation_config_count_too`.
- `tests/test_modeling.py::TestMetaAudio::test_audio_model_builds_on_meta` — parametrized over a
  tiny Wav2Vec2 (audio-classification) and a tiny Whisper (ASR): builds on meta, undispatched,
  with a real feature extractor.
- `tests/test_modeling.py::TestPreloadedModule::test_question_answering_module_asks_for_a_task`.

Ran: `tests/test_modeling.py`, `tests/test_language.py`, `tests/test_deprecations.py`
(203 passed), `tests/test_encoder.py`, `tests/test_vision.py`, `tests/test_vlm.py`,
`tests/test_chunked_tasks.py`, `tests/test_chat.py`, `tests/test_construction_routing.py`
(79 passed, 2 skipped), and `tests/test_batching.py`, `tests/test_saving.py`,
`tests/test_interleaving.py`, `tests/test_envoy.py`, `tests/test_multiple_wrappers.py`,
`tests/test_memory.py` (256 passed). Nothing remote, vLLM or multi-GPU was run.

### Left alone deliberately

- No general guard comparing the loaded class against `config.architectures` (considered and
  declined) — the seq2seq substitution is documented, not detected.
- Only `feature_extractor` is constructed; the other three preprocessors still go out as the
  repo id.
- No doc line about `model.generator.streamer.output` being unavailable under beam search
  (declined). The `generate` docstring's `streamer` line does now say it is not injected under
  beam search, since that is the argument's own contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
