### PR TITLE
interleaver: don't let a parked worker or an early stop escape cleanup

### DIFF
--- a/docs/developing/interleaver-internals.md
+++ b/docs/developing/interleaver-internals.md
@@ -242,9 +242,14 @@ the read.
 ## `tracer.stop()` and early exit
 
 `InterleavingTracer.stop` raises `EarlyStopException` from inside the worker; it
-propagates through `switch` and unwinds the model's forward. `Interleaver.__exit__`
-swallows it. If a worker stops before the model even starts (during `__enter__`'s
-`start`), `Envoy.interleave` catches it directly.
+propagates through `switch` into `Interleaver.handle`, which treats it as control
+flow rather than an error: it holds the exception, clears that worker's `pending`,
+finishes the visit (count, `assemble_skip`, the observing caches, the other workers
+parked here, the fragment `undo`) and re-raises it on the way out, unwinding the
+model's forward from a completed visit. So the location a stop fires at is served
+and recorded, and only what follows it is lost. `Interleaver.__exit__` swallows it.
+If a worker stops before the model even starts (during `__enter__`'s `start`),
+`Envoy.interleave` catches it directly.
 
 ## Key files / classes
 

--- a/docs/developing/interleaver-internals.md
+++ b/docs/developing/interleaver-internals.md
@@ -197,7 +197,12 @@ the next run.
 mediators; that is `cancel`'s job.
 
 `cancel` releases each worker's greenlet, empties `mediators` and drops the
-`batcher`, so the next run starts clean. The controllers stay installed.
+`batcher`, so the next run starts clean. The controllers stay installed. A worker
+still `alive` — parked because the model's forward raised before reaching its
+location — is thrown a `GreenletExit` first: dropping the reference does not end a
+greenlet, and a parked one holds its frame, the block's scope and through it the
+model. An exception out of the block's own `finally` warns rather than raising, so
+it cannot hide the error that ended the run.
 
 ### check_dangling_mediators
 

--- a/docs/usage/stop-and-early-exit.md
+++ b/docs/usage/stop-and-early-exit.md
@@ -61,6 +61,51 @@ threshold, a token you were waiting for.
 loop's own bound never has to hold — an open `tracer.all()` is the natural form
 here.
 
+## The location you stop at still happens
+
+A stop ends what comes *after* the location the worker is parked on, not that
+location itself. That module has already run by the time the stop is raised, so
+the visit is finished before the forward unwinds: the value is served, any edit
+you made to it lands, and a cache observing it records it.
+
+```python
+with model.trace("Hello world") as tracer:
+    cache = tracer.cache(modules=[model.transformer.h[5]]).save()
+    model.transformer.h[5].output
+    tracer.stop()
+
+print(list(cache.keys()))   # ['model.transformer.h.5']
+```
+
+Layer 5 is there; layers 6 and up never ran, so they are not.
+
+## A stop in one invoke ends the whole batch
+
+Invokes are rows of one shared forward pass, so a `stop()` in any one of them
+ends the run for all of them — there is no way to keep going for the other rows.
+The step it fires on does finish, though: an invoke parked on the same visit is
+served in it, so every invoke records that step.
+
+```python
+with model.generate(max_new_tokens=8, do_sample=False) as tracer:
+    with tracer.invoke("The capital of France is"):
+        picks = nnsight.save([])
+        for _ in tracer.all():
+            picks.append(model.lm_head.output[0, -1].argmax(dim=-1))
+            if len(picks) == 3:
+                tracer.stop()
+    with tracer.invoke("The capital of Spain is"):
+        others = nnsight.save([])
+        for _ in tracer.all():
+            others.append(model.lm_head.output[0, -1].argmax(dim=-1))
+# len(picks) == len(others) == 3
+```
+
+The second invoke's loop was cut short by the first invoke's stop rather than by
+a bound of its own, so it warns that it asked for a step the run did not make,
+like any loop the run outruns ([iter-all-next.md](iter-all-next.md)). If the
+invokes need to stop independently, run them as separate traces.
+
 ## The run's result is gone after a stop
 
 A stop cuts the run off before it returns anything, so there is no result to
@@ -117,6 +162,10 @@ with model.trace("Hello world") as tracer:
   side effects.
 - **Anything depending on a later module won't be populated.** Requesting a module
   the run never reached (because you stopped before it) raises `OutOfOrderError`.
+  The module you stopped *at* is not one of those — it ran, and is cached.
+- **A stop in one invoke ends the batch.** One forward pass serves every invoke, so
+  the others stop where it did; their `tracer.all()` loops warn about the steps the
+  run did not make.
 - **`EarlyStopException` is not an error.** Don't wrap the trace in
   `try/except EarlyStopException` expecting to catch user errors — the interleaver
   already swallows it.

--- a/src/nnsight/intervention/interleaver.py
+++ b/src/nnsight/intervention/interleaver.py
@@ -43,7 +43,7 @@ import warnings
 import weakref
 from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Optional
 
-from greenlet import getcurrent, greenlet
+from greenlet import GreenletExit, getcurrent, greenlet
 
 from ..tracing.util import Scope
 
@@ -857,6 +857,16 @@ class Interleaver:
     def cancel(self) -> None:
         """Drop all mediators and the batcher so the next run starts clean.
 
+        A worker still [`alive`][nnsight.intervention.interleaver.Mediator.alive] —
+        parked mid-intervention because the model's forward raised before it
+        reached the location — is unwound first. Dropping the reference does not
+        end a greenlet: a parked one keeps its frame, the frame keeps the block's
+        scope, and the scope keeps the model, so a run that errors would hold the
+        weights forever. The throw runs the block's ``finally`` blocks on the way
+        out; an exception raised there only warns, because cancel runs in the
+        driver's ``finally`` with the error that ended the run already in flight,
+        and that error is the one worth surfacing.
+
         Each mediator's worker greenlet is released too, so a stored edit mediator
         replayed on a later trace is seen as never-started (``worker is None``) and
         restarts fresh rather than being skipped for still holding its finished
@@ -864,6 +874,16 @@ class Interleaver:
         [`check_dangling_mediators`][nnsight.intervention.interleaver.Interleaver.check_dangling_mediators]), handled by the driver after a run.
         """
         for mediator in self.mediators:
+            if mediator.alive:
+                try:
+                    mediator.worker.throw(GreenletExit)
+                except BaseException as thrown:
+                    warnings.warn(
+                        f"An intervention block raised {thrown!r} while it was "
+                        f"being unwound at the end of the run. It is reported "
+                        f"here rather than raised, so that it cannot hide the "
+                        f"error that ended the run."
+                    )
             mediator.worker = None
         self.mediators = []
         self.batcher = None

--- a/src/nnsight/intervention/interleaver.py
+++ b/src/nnsight/intervention/interleaver.py
@@ -772,6 +772,15 @@ class Interleaver:
         it has been served — so a worker that arrives here *during* the visit
         (released from a barrier by one that was served) asks for this occurrence
         and is served in it too, whichever order the workers were written in.
+
+        An [`EarlyStopException`][nnsight.intervention.interleaver.EarlyStopException]
+        from a worker is held back and re-raised on the way out, once the visit is
+        finished, so a ``tracer.stop()`` halts what follows the location it fires
+        at rather than the location itself: it is still counted, still assembled,
+        still recorded by the caches observing it, and the other workers parked on
+        it — a sibling invoke of the same batched run — are still served. Any other
+        exception propagates immediately, unless ``defer_exceptions`` is set, in
+        which case it is recorded on its own worker and the run continues.
         """
         occurrence = self.counts.get(provider, 0)
         observers = (
@@ -793,15 +802,24 @@ class Interleaver:
         # Serving one worker can release another into parking here (a barrier),
         # so keep serving until nobody is parked on this visit.
         served = False
+        stopped = None
         while ready := self._ready(provider):
             served = True
             for mediator in ready:
                 try:
                     value = mediator.handle(provider, value)
                 except Exception as exception:
-                    if not self.defer_exceptions:
+                    if self.defer_exceptions:
+                        mediator.exception = exception
+                    elif isinstance(exception, EarlyStopException):
+                        # An early stop is control flow, not an error: the worker
+                        # asked to halt what comes *after* this location, not to
+                        # abandon it. Hold the stop until the visit is finished —
+                        # counted, assembled, cached, and served to the workers
+                        # parked here alongside — and raise it at the end.
+                        stopped = exception
+                    else:
                         raise
-                    mediator.exception = exception
                     mediator.pending = None
         if served:
             self._reindex_parked()
@@ -827,6 +845,9 @@ class Interleaver:
         # model rather than being dropped with the gather.
         if undo is not None:
             value = undo(value)
+        # The visit is complete; now let the stop unwind the model's forward.
+        if stopped is not None:
+            raise stopped
         return value
 
     def check_dangling_mediators(self) -> None:

--- a/tests/test_interleaving.py
+++ b/tests/test_interleaving.py
@@ -188,6 +188,40 @@ class TestInterleaver:
         il.cancel()
         assert il.mediators == []
 
+    def test_cancel_unwinds_a_still_parked_worker(self):
+        # Dropping the reference doesn't end a greenlet: a worker left parked by a
+        # run that errored keeps its frame, and the frame keeps the model.
+        il = Interleaver()
+        store = {}
+        med = make_mediator(
+            "try:\n"
+            "    Mediator.value('never-reached')\n"
+            "finally:\n"
+            "    store['unwound'] = True",
+            store=store,
+        )
+        il.mediators.append(med)
+        with il:
+            assert med.alive
+        il.cancel()
+        assert store["unwound"]
+
+    def test_cancel_warns_rather_than_raises_out_of_an_unwind(self):
+        # cancel runs in the driver's `finally`, with the error that ended the run
+        # already in flight; a block's own `finally` must not displace it.
+        il = Interleaver()
+        med = make_mediator(
+            "try:\n"
+            "    Mediator.value('never-reached')\n"
+            "finally:\n"
+            "    raise RuntimeError('from the block')"
+        )
+        il.mediators.append(med)
+        with il:
+            pass
+        with pytest.warns(UserWarning, match="from the block"):
+            il.cancel()
+
     def test_parked_set_is_rebuilt_each_run(self):
         # A prior run's wait count must not leak into the next run.
         il = Interleaver()

--- a/tests/test_interleaving.py
+++ b/tests/test_interleaving.py
@@ -9,6 +9,7 @@ from nnsight.intervention.barrier import Barrier
 from nnsight.intervention.envoy import Envoy
 from nnsight.intervention.eproperty import eproperty
 from nnsight.intervention.interleaver import (
+    EarlyStopException,
     Event,
     Interleaver,
     Mediator,
@@ -221,6 +222,24 @@ class TestInterleaver:
             pass
         with pytest.warns(UserWarning, match="from the block"):
             il.cancel()
+
+    def test_early_stop_finishes_the_visit_before_it_raises(self):
+        # A stop halts what follows the location, not the location itself: the
+        # visit is still counted and the workers parked alongside are still served.
+        il = Interleaver()
+        store = {}
+        il.mediators.append(
+            make_mediator(
+                "Mediator.value('loc')\n" "raise EarlyStopException()",
+                EarlyStopException=EarlyStopException,
+            )
+        )
+        il.mediators.append(requester(store))
+        with il:
+            with pytest.raises(EarlyStopException):
+                il.handle("loc", 7)
+        assert store["got"] == 7
+        assert il.counts["loc"] == 1
 
     def test_parked_set_is_rebuilt_each_run(self):
         # A prior run's wait count must not leak into the next run.

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -433,6 +433,38 @@ class TestEarlyStop:
             tracer.stop()
         assert first_layer.shape[-1] == 768
 
+    @torch.no_grad()
+    def test_the_module_stopped_at_is_still_cached(self, gpt2):
+        # The stop ends what follows the location it fires at, not that location:
+        # layer 5 has run, and the cache observing it records it.
+        with gpt2.trace(PROMPT) as tracer:
+            cache = tracer.cache(
+                modules=[gpt2.transformer.h[4], gpt2.transformer.h[5]]
+            ).save()
+            gpt2.transformer.h[5].output
+            tracer.stop()
+        assert "model.transformer.h.5" in cache.keys()
+
+    @torch.no_grad()
+    def test_a_stop_in_one_invoke_serves_its_siblings_that_step(self, gpt2):
+        # One batched forward, so the stop ends the run for both invokes — but the
+        # step it fires on completes, and the sibling parked on the same visit is
+        # served in it.
+        with pytest.warns(UserWarning, match="never reached"):
+            with gpt2.generate(max_new_tokens=8, do_sample=False) as tracer:
+                with tracer.invoke(PROMPT):
+                    stopping = nnsight.save([])
+                    for _ in tracer.all():
+                        stopping.append(gpt2.lm_head.output[0, -1].argmax(dim=-1))
+                        if len(stopping) == 3:
+                            tracer.stop()
+                with tracer.invoke(PROMPT):
+                    sibling = nnsight.save([])
+                    for _ in tracer.all():
+                        sibling.append(gpt2.lm_head.output[0, -1].argmax(dim=-1))
+        assert len(stopping) == 3
+        assert len(sibling) == 3
+
 
 class TestIteration:
     @torch.no_grad()

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -29,6 +29,22 @@ class TwoLayer(nn.Module):
         return self.b(self.a(x))
 
 
+class Boom(nn.Module):
+    """Raises where a real forward would raise: after `a`, before `b`."""
+
+    def forward(self, x):
+        raise RuntimeError("boom")
+
+
+class RaisesMidway(TwoLayer):
+    def __init__(self):
+        super().__init__()
+        self.boom = Boom()
+
+    def forward(self, x):
+        return self.b(self.boom(self.a(x)))
+
+
 def _x():
     return torch.randn(2, 8)
 
@@ -133,6 +149,39 @@ class TestExceptionCleanup:
             return ref
 
         assert run()() is None
+
+    def test_module_freed_when_the_model_raises_mid_forward(self):
+        # The worker is still parked on `b.output` when the forward raises, and a
+        # parked greenlet is not freed by dropping the reference to it: it keeps
+        # its frame, which keeps the block's scope, which keeps the model. Not
+        # even a gc pass reaches it — a suspended greenlet's frames are invisible
+        # to the collector — so this is the one leak that needs an explicit unwind.
+        def run():
+            model = Envoy(RaisesMidway())
+            ref = weakref.ref(model._module)
+            try:
+                with model.trace(_x()):
+                    nnsight.save(model.a.output)  # served
+                    nnsight.save(model.b.output)  # still parked here
+            except RuntimeError:
+                pass
+            return ref
+
+        assert run()() is None
+
+    def test_erroring_traces_do_not_accumulate(self):
+        # The leak is cumulative: one held model per errored trace.
+        def run():
+            refs = []
+            for _ in range(5):
+                model = Envoy(RaisesMidway())
+                refs.append(weakref.ref(model._module))
+                with pytest.raises(RuntimeError):
+                    with model.trace(_x()):
+                        nnsight.save(model.b.output)
+            return refs
+
+        assert all(ref() is None for ref in run())
 
     def test_tracer_freed_when_trace_body_raises(self):
         def run():


### PR DESCRIPTION
Two findings from the agent stress sweep, items 2 and 3 in `planning/next-steps.md`. Same shape of problem — something escaping before the cleanup around it finishes — but independent fixes, so one commit each.

## 1. `cancel()` leaked a parked worker

**Broken:** `envoy.interleave` calls `check_dangling_mediators()` only on the success path; when the model's forward raises it goes straight to `finally: cancel()`, which set `mediator.worker = None` without unwinding. Dropping a reference does not end a greenlet, so the worker stayed parked, holding its frame, the block's `Scope`, and through it the model. A gc pass does not reach it either — a suspended greenlet's frames are invisible to the cyclic collector. Roughly 0.5 GiB of CUDA held per errored trace, cumulative (repro: `tasks/skip-stop-scan-corners/noskills/repro_8.py`).

**Changed:** `cancel()` throws `GreenletExit` into any worker still `alive`, which unwinds it and runs the block's `finally` blocks. An exception out of one of those warns rather than propagating, so it cannot mask the model error already in flight (`check_dangling_mediators` is the precedent for telling the two apart). `check_dangling_mediators` is deliberately still not called on the error path — it raises `OutOfOrderError`, which would bury the real error.

`cancel()` is the single choke point for `envoy.interleave`, `tracer.py` and the vLLM tracer. On the vLLM client side the workers are serialized onto requests and never started, so `alive` is False there and nothing changes.

## 2. `handle()` abandoned the visit on `tracer.stop()`

**Broken:** `EarlyStopException` subclasses `Exception` and `defer_exceptions` is False on a local trace, so the raise in the mediator loop left `Interleaver.handle` immediately — skipping the rest of `ready`, the count update, `assemble_skip`, the `observers` loop that feeds `tracer.cache`, and the fragment `undo`. Two symptoms from one cause:

- stopping at layer 5 with a cache left `model.transformer.h.5` out of the cache;
- a stop in one invoke of a batched generate cost every sibling invoke that step, so a stop after 3 steps gave `len(picks) == 3` but `len(sibling) == 2`.

**Changed:** an early stop is treated as control flow — caught, kept in a local, that mediator's `pending` cleared, the visit finished, and the exception re-raised just before the return (after `undo`). Other exceptions keep today's behaviour, and `defer_exceptions` still records a stop on its mediator rather than raising it, so the vLLM path is unchanged. The loop terminates because a mediator with no pending is not ready.

The three deliberate calls are now stated in `docs/usage/stop-and-early-exit.md` (two new sections plus two gotcha bullets): the module you stop *at* is still recorded and served; the workers parked on the same visit are still served; and a stop in one invoke ends the whole batched forward, since it is one shared run. `docs/developing/interleaver-internals.md` had two sentences describing the old behaviour of `cancel` and of stop, so both were corrected — the only file I touched outside my assignment, and it is the developer page for the function I changed.

## Tested

Environment: `nnsight-stress/env` with `PYTHONPATH` at this worktree's `src`. The optional `_c/py_mount` extension is not built there, so `.save()` as a method fails and about half the suite errors; I compiled it into the worktree (gitignored) to get a real run.

New tests, all five verified failing against `origin/0.8` and passing here:

- `tests/test_interleaving.py` — `cancel` unwinds a still-parked worker (its `finally` runs); `cancel` warns rather than raises when the unwind hits a user `finally`; an early stop finishes the visit (the sibling worker is served and the count is bumped) before it raises.
- `tests/test_memory.py` — a model that raises mid-forward frees the module afterwards; five such traces do not accumulate. CPU-only, adapted from `repro_8.py`, which needed CUDA.
- `tests/test_language.py::TestEarlyStop` — the module stopped at is still in the cache; a stop in one invoke leaves both invokes with the same step count.

Ran clean, per file: `test_interleaving`, `test_memory`, `test_language`, `test_batching`, `test_tracing`, `test_saving`, `test_editing`, `test_backward`, `test_envoy`, `test_source`, `test_fragments`, `test_modeling`, `test_vlm`, `test_diffusion`. Both new doc snippets were run verbatim and produce what the page claims. (Running several test files in one pytest invocation errors on `transformers.pipeline` for unrelated, pre-existing reasons, as does `test_serialization` on its own — both reproduce identically on `origin/0.8`.)

## Not tested / left alone

- **vLLM is not installed in this environment**, so `tests/vllm/` could not run. The `defer_exceptions` branch is unchanged by construction: a stop under deferral is still recorded on its mediator and never raised out of the handoff.
- **The fragment `undo` path** (tensor parallel) is picked up by the stop fix — `undo` now runs before the re-raise — but there is no multi-device setup here to exercise it. Per the item note, it is not skipped, just untested.
- No `check_dangling_mediators` call was added to the error path, per the decision note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)