### PR TITLE
batching: scope token-flattened rows, and warn on writes that can't be scoped

### DIFF
--- a/NNsight.md
+++ b/NNsight.md
@@ -549,7 +549,8 @@ value read in one invoke is guaranteed written into another only after the read.
 
 A single `with model.trace() as tracer:` can hold several `with tracer.invoke(x):`
 blocks, whose inputs are combined into one batched forward while each block's
-interventions see only *its* rows of every activation. Each invoke is one worker,
+interventions see its own rows of every activation the batcher can read the rows of
+(the leading dim decides it, see below). Each invoke is one worker,
 scoped to a `batch_group` — a `[start, size]` row range in the combined batch. The
 per-trace `Batcher` (`src/nnsight/intervention/batching.py`) collects the invokes,
 assigns each its group, and does the row math at run time.
@@ -559,8 +560,11 @@ The scoping is two mirror operations, driven from the worker's `handle`:
 - **On a read**, `Batcher.narrow(value, group)` slices every batched tensor down to
   the worker's rows before serving it — so an invoke over one prompt sees
   `output.shape[0] == 1` even though the real forward ran a batch of three. A tensor
-  counts as batched only when its leading dim equals the combined batch size, so
-  activations whose dim 0 is sequence length or hidden size pass through untouched.
+  counts as batched when its leading dim is the combined batch size or a whole
+  multiple of it (the token-flattened `(batch*seq, hidden)` an MoE router sees), so
+  activations whose dim 0 is sequence length or hidden size pass through untouched —
+  as does one batched on an axis the batcher cannot recognize, which is why a write
+  to a tensor it could not scope warns that it applies to the whole batch.
 - **On a write**, `Batcher.widen(full, group, edited)` splices the worker's edited
   rows back into the full batch — via `torch.cat` rather than in-place assignment, to
   keep autograd correct for leaf and view tensors and to avoid aliasing when the
@@ -1375,7 +1379,7 @@ The split of responsibility is clean. The **model** knows how to turn inputs int
 - `_batch_size(*inputs, **kwargs)` — how many batch rows an invoke contributes (`0` means params-only, e.g. an invoke that just sets `max_new_tokens=` and expects the actual data in other invokes). The base default counts any input as one row; batching models report the true row count of a prompt / list / tensor / encoding.
 - `_batch(invokes, fn)` — assemble the collected invokes into the combined `(args, kwargs)` the run will use. This is where sequence lengths are equalized (padding), because the Batcher's row math is dim-0 only.
 
-The `Batcher` (one per trace) does the rest. Each `add` records an invoke and assigns it a `batch_group` — a `[start, size]` row range in the combined batch. At run time `narrow` slices a full batched activation down to a block's rows when it reads, and `widen` splices an edit back into the full tensor. A tensor counts as batched only when its leading dim equals the combined `total`, so non-batched tensors pass through untouched. Crucially, narrowing only kicks in with two or more non-empty invokes — a lone invoke *is* the whole batch and sees every row untouched.
+The `Batcher` (one per trace) does the rest. Each `add` records an invoke and assigns it a `batch_group` — a `[start, size]` row range in the combined batch. At run time `narrow` slices a full batched activation down to a block's rows when it reads, and `widen` splices an edit back into the full tensor. A tensor counts as batched when its leading dim is the combined `total` or a whole multiple of it — the multiple covering a model that folds tokens into the batch axis before a module, as every transformers MoE block does ahead of its router — so a tensor shaped otherwise passes through untouched, and a write to one applies to the whole batch (or, for a replacement, is dropped) with a warning saying so. Crucially, narrowing only kicks in with two or more non-empty invokes — a lone invoke *is* the whole batch and sees every row untouched.
 
 A model picks its batcher through the `_batcher_class` class attribute (default `Batcher`). A model whose batch layout is not a plain dim-0 stack overrides `_narrow_tensor`/`_widen_tensor`. `DiffusionModel` does exactly this with `DiffusionBatcher`: a denoiser sees each prompt repeated `num_images_per_prompt` times and, under classifier-free guidance, the whole thing doubled (unconditional half then conditional half), so its batcher maps each invoke's plain `[start, size]` onto that expanded layout — reading and writing exactly the invoke's rows across both halves — by picking the case from the tensor's leading dim at run time.
 

--- a/docs/developing/batching-internals.md
+++ b/docs/developing/batching-internals.md
@@ -12,7 +12,8 @@ sources: [src/nnsight/intervention/batching.py, src/nnsight/intervention/tracer.
 
 A `with model.trace() as tracer:` block may contain several `with
 tracer.invoke(x):` blocks. Their inputs are combined into a single batched forward,
-and each block's interventions see only *its* rows of every activation. This doc
+and each block's interventions see its own rows of every activation the batcher can
+read the rows of — which is decided by the leading dim, see `narrow` below. This doc
 walks the `Batcher` (one per trace), the `batch_group` row ranges, and the
 `narrow`/`widen`/`gather_skip`/`assemble_skip` operations the interleaver drives.
 
@@ -67,15 +68,23 @@ batched tensor in it down to the group's rows, delegating each tensor to
 ```python
 def _narrow_tensor(self, tensor, group):
     start, size = group
-    if tensor.shape[0] == self.total:      # only actually-batched tensors
-        return tensor.narrow(0, start, size)
+    rows = tensor.shape[0] if tensor.ndim else 0
+    k = rows // self.total if rows and rows % self.total == 0 else 0
+    if k:                                  # k rows of tensor per row of batch
+        return tensor.narrow(0, start * k, size * k)
+    self.unscoped[id(tensor)] = (tensor, tensor._version, ..., rows)
     return tensor
 ```
 
-A tensor is treated as batched only when its leading dim equals `total` (the
-combined batch size), so a tensor whose dim 0 is sequence length or hidden size
-passes through untouched. `narrow` returns `value` unchanged when not batching or
-for a groupless (empty) invoke. It is called from `Mediator.handle` for every
+A tensor is treated as batched when its leading dim is `total` (the combined batch
+size) or a whole multiple of it. The multiple is the token-flattened case — a
+transformers MoE block reshapes `(batch, seq, hidden)` to `(batch*seq, hidden)`
+before its router, so every invoke's rows are still contiguous and in order, `k =
+shape[0] // total` of them per row of batch. A leading dim that is neither (a
+sequence length, a hidden size, a patch count) passes through untouched; a leading
+dim that is a multiple by coincidence is sliced, which is the cost of deciding this
+from the shape alone. `narrow` returns `value` unchanged when not batching or for a
+groupless (empty) invoke. It is called from `Mediator.handle` for every
 `Event.VALUE` (`interleaver.py`).
 
 The slice is stamped `_nnsight_batch = True`. A `.backward()` gradient hook uses
@@ -91,14 +100,33 @@ type — and hands each batched tensor pair to `_widen_tensor`, the per-tensor m
 a layout subclass overrides:
 
 ```python
-pre  = full.narrow(0, 0, start)
-post = full.narrow(0, start + size, self.total - start - size)
+pre  = full.narrow(0, 0, start * k)
+post = full.narrow(0, (start + size) * k, rows - (start + size) * k)
 return torch.cat([pre, edited, post], dim=0)
 ```
 
 `cat` (rather than in-place assignment) keeps autograd correct for leaf/view
 tensors and avoids aliasing when `edited` is itself a narrowed view of `full`.
-Called from `Mediator.handle` for every `Event.SWAP` (`interleaver.py`).
+Called from `Mediator.handle` for every `Event.SWAP` (`interleaver.py`). `k` is
+`_narrow_tensor`'s: when there is none — the leading dim is neither `total` nor a
+multiple of it — there are no rows this invoke owns, so `full` is returned
+unchanged and the dropped replacement warns.
+
+### Writes to a value that couldn't be scoped
+
+A value no row rule matched is served to every invoke whole, so a write to it acts
+on the whole batch. A replacement is caught in `_widen_tensor` above. An **in-place**
+edit never comes back through the batcher at all, so `_narrow_tensor` records what
+it served whole — the tensor, torch's `_version` counter, and the location the
+worker asking for it was parked on — and `_report_unscoped`, called at the top of
+`narrow`/`widen`, warns for anything whose version has moved since. The report is
+therefore one batcher call late (the next value served to any worker, which in a
+batched run is the next module either invoke reads), and the record is cleared each
+time, so at most one visit's values are held.
+
+Reads are deliberately not reported: a shape alone doesn't distinguish a value that
+isn't batched from one batched on an axis the batcher can't read, and the great
+majority are the former.
 
 **A replacement has to keep the group's row count.** `_widen_tensor` does not
 check it: a `cat` of the wrong height succeeds — it just builds a batch that is
@@ -167,7 +195,7 @@ See `docs/developing/vllm-integration.md` for the vLLM specifics.
 
 - `src/nnsight/intervention/batching.py` — `Batcher` (per-trace batching state):
   `add`, `batching`, `assemble`, `narrow`/`_narrow_tensor`, `widen`/`_widen_tensor`,
-  `gather_skip`, `assemble_skip`; plus `SkipParts` and `concat`.
+  `gather_skip`, `assemble_skip`, `_report_unscoped`; plus `SkipParts` and `concat`.
 - `src/nnsight/intervention/envoy.py` — `_batch_size`, `_batch`, `_batcher_class`.
 - `src/nnsight/intervention/tracer.py` — `InterleavingTracer.execute` (builds the
   batcher, adds the direct-input worker); `Invoker.execute` (adds an invoke worker).

--- a/docs/usage/invoke-and-batching.md
+++ b/docs/usage/invoke-and-batching.md
@@ -93,6 +93,48 @@ It is a fresh worker, which lets it reach a module an earlier invoke already
 passed — but within its own block it still reads in forward order, and going back
 raises `OutOfOrderError` like anywhere else.
 
+## Statements outside the invoke blocks run first
+
+In invoke mode — `model.trace()` with no input — the trace body is run once
+immediately, before any forward, to collect the `tracer.invoke(...)` blocks in it.
+Only the invoke bodies then run interleaved with the model. So a statement written
+outside an invoke has already run by the time the model starts, whatever it is
+written *after*:
+
+```python
+with model.trace() as tracer:
+    losses = nnsight.save([])
+    for t in texts:
+        with tracer.invoke(t):
+            losses.append(model.transformer.h[5].output[:, -1].sum())
+    loss = torch.stack(losses).mean()   # runs first, on the still-empty list
+# RuntimeError: stack expects a non-empty TensorList
+```
+
+Do the reduction **after** the trace instead, where the list is full:
+
+```python
+with model.trace() as tracer:
+    parts = nnsight.save([])
+    for t in texts:
+        with tracer.invoke(t):
+            parts.append(model.transformer.h[5].output[:, -1])
+
+torch.stack(parts)          # len(parts) == 2, shape (2, 1, 768)
+```
+
+If the reduced value has to feed another trace, put both traces in a
+[`session`](session.md).
+
+A `save()` written after the last invoke fails differently and further from its
+cause: saved names are pushed back out of the invokes' scopes, and the collection
+pass isn't one of them, so `nnsight.save(h)` on the last line of the body leaves
+nothing behind and reading `h` afterwards raises `NameError: name 'h' is not
+defined`. A save written *before* the invokes does come back, because each invoke's
+scope is copied from the surrounding one — which is why the rule looks arbitrary
+until you know that the body ran once on its own. Save inside the invoke that
+produces the value.
+
 ## Mixed input formats
 
 Every input format a forward accepts is batchable, and formats can be mixed
@@ -112,6 +154,29 @@ with model.trace() as tracer:
 
 Tokenizer kwargs on an invoke apply to that invoke's tokenization (not the
 model): `tracer.invoke("word " * 50, truncation=True, max_length=4)`.
+
+### Forward keywords are the batch's, not an invoke's
+
+Everything that reaches the model does so in **one** forward call, so it takes one
+set of keywords. Keywords from every invoke are merged into that call and the last
+invoke to pass one decides it for every row:
+
+```python
+with model.trace() as tracer:
+    with tracer.invoke(P1, output_hidden_states=True):
+        ...
+    with tracer.invoke(P2, output_hidden_states=False):   # wins, for both rows
+        ...
+# UserWarning: Invokes disagree on the forward keyword 'output_hidden_states' ...
+```
+
+Disagreeing invokes warn; agreeing ones (and a keyword only one invoke passes) are
+quiet. Anything that has to differ per row belongs in that invoke's *input* rather
+than its keywords — passing `{"input_ids": ..., "attention_mask": ...}` as the
+invoke's positional input collates per row correctly, while
+`attention_mask=` as a keyword replaces the collated mask for the whole batch (on
+CUDA, usually as a device-side assert from somewhere inside the model). The same
+applies to generation parameters: `max_new_tokens` on an invoke is the batch's.
 
 ## Cross-invoke value sharing
 
@@ -197,6 +262,45 @@ bound out there, the consumer reads the *old* value. Nothing raises.
 Rows sit in the batch in invoke **declaration** order: concatenating each
 invoke's saved activation in the order the invokes were written reproduces what an
 empty invoke sees.
+
+### Which values are scoped to your rows
+
+Scoping is decided by a value's **leading dimension**, not by where the value came
+from. A tensor is narrowed to the invoke's rows when its leading dim is the
+combined batch size, or a whole multiple of it. The multiple is what covers a model
+that folds tokens into the batch axis before a module — every transformers MoE
+block does, ahead of its router, so `mlp.gate.output` and `mlp.experts.input` are
+`(batch*seq, ...)` and an invoke owns `seq` of those rows for each row of batch it
+contributed. Values reached through `.source` below such a reshape are scoped the
+same way. A leading dim that is a multiple by *coincidence* — four experts against
+two invokes — is sliced too; the shape is all there is to go on.
+
+Anything else is handed to every invoke **whole**. That is correct for a value that
+is not batched at all (a causal mask, rotary `cos`/`sin`, a constant built inside
+the forward), and wrong for one that is batched along an axis nnsight cannot
+recognize: a time-major `(seq, batch, hidden)` activation, a vision tower's
+`(patches, hidden)`, a list of per-sequence tensors (containers are not split;
+only the tensors inside them are). For those, three things follow:
+
+- a **read** sees the whole batch rather than this invoke's part of it;
+- an **in-place edit** applies to every invoke;
+- a **replacement** is dropped — there is nowhere to splice it.
+
+Both writes warn, naming the location, its leading dim and the batch size:
+
+```
+UserWarning: An in-place edit to `model.visual.merger.output` applies to every
+invoke: its leading dimension (256) is neither the batch size (2) nor a multiple
+of it, so nnsight served the whole batch rather than this invoke's rows.
+```
+
+A read does **not** warn: from a shape alone a value that isn't batched is
+indistinguishable from one that is batched on an axis nnsight can't read, and most
+values in that state are the former. When the warning does fire, trace that input
+on its own — or, if the model's batch layout is genuinely a different shape, give
+it a `_batcher_class` that knows it (see
+[extending.md](extending.md#4-custom-batcher-for-non-standard-batch-layouts)),
+which is how diffusion's guidance doubling and vLLM's flat token axis are handled.
 
 ### Every invoke is padded to the whole batch's length
 
@@ -287,8 +391,9 @@ with model.generate(max_new_tokens=5, do_sample=False) as tracer:
 
 Everything an invoke reads is narrowed the same way: `.input`, `.output`,
 `tracer.result`, and a `tracer.cache(...)` opened inside the block all carry that
-invoke's rows alone. In a 1 + 2 row batch the two input invokes see
-`[1, seq, 768]` and `[2, seq, 768]`, and an empty invoke sees `[3, seq, 768]`.
+invoke's rows alone, for every value the [row rules](#which-values-are-scoped-to-your-rows)
+can scope. In a 1 + 2 row batch the two input invokes see `[1, seq, 768]` and
+`[2, seq, 768]`, and an empty invoke sees `[3, seq, 768]`.
 
 ## Implementing batching for a custom model
 
@@ -326,6 +431,16 @@ class BatchEnvoy(Envoy):
   the run. The same error covers nesting two invokes.
 - **Reading a cross-invoke name before the binder ran raises `NameError`.** Park
   the reader past the binder's location, or use a barrier — see above.
+- **Statements outside the invoke blocks run before the model does.** The body of
+  an input-less `trace()` runs once to collect the invokes, so a reduction written
+  under the loop sees empty lists, and a `save()` after the last invoke leaves
+  nothing behind. Reduce after the trace — see above.
+- **Only values whose leading dim matches the batch are scoped to an invoke.**
+  Anything else is served whole; a write to one warns and applies batch-wide (or,
+  for a replacement, is dropped). See
+  [Which values are scoped to your rows](#which-values-are-scoped-to-your-rows).
+- **Forward keywords on an invoke are batch-wide.** One forward call takes one set
+  of them, so invokes that disagree warn and the last one written wins.
 - **A batched write has to keep its rows.** A block owns its invoke's rows of the
   combined batch, and a whole-tensor write is spliced back in as given — nothing
   checks the height. A block that owns rows `0:1` of 2 and assigns a two-row

--- a/docs/usage/trace.md
+++ b/docs/usage/trace.md
@@ -75,7 +75,7 @@ with model.trace() as tracer:
         out_b = model.transformer.h[0].output.save()
 ```
 
-Each invoke's body sees only its own rows of the batch. See `docs/usage/invoke-and-batching.md` for empty invokes, batching constraints, and barriers.
+Each invoke's body sees its own rows of the batch — of every value whose leading dimension is the combined batch size or a whole multiple of it, which is how the scoping is decided. A value shaped otherwise (a time-major activation, a vision tower's patches) is served to every invoke whole, and a write to one warns rather than acting on one invoke. See `docs/usage/invoke-and-batching.md` for that rule in full, and for empty invokes, batching constraints, and barriers.
 
 ## Remote execution
 

--- a/src/nnsight/intervention/batching.py
+++ b/src/nnsight/intervention/batching.py
@@ -2,7 +2,7 @@
 
 ``with model.trace() as tracer:`` may contain several ``with tracer.invoke(x):``
 blocks. Their inputs are combined into a single batched forward, and each block's
-interventions see only *its* rows of every activation.
+interventions see its own rows of an activation the batcher can read the rows of.
 
 A [`Batcher`][nnsight.intervention.batching.Batcher] (one per trace) collects each invoke's input and assigns it a
 ``batch_group`` — a ``[start, size]`` row range in the combined batch. At run time
@@ -10,6 +10,16 @@ A [`Batcher`][nnsight.intervention.batching.Batcher] (one per trace) collects ea
 it reads, and [`Batcher.widen`][nnsight.intervention.batching.Batcher.widen] splices an edit back into the full tensor. The row math
 is dim-0 only; the model's `_batch` equalizes everything else (e.g. sequence
 length) when it builds the combined input.
+
+Which values that math applies to is decided by the leading dim, so it is a rule
+about shapes rather than about provenance. A value is scoped when its leading dim
+is the combined batch size, or a whole multiple of it — the multiple covers a model
+that folds tokens (or tokens and heads) into the batch axis before a module, as
+every transformers MoE block does ahead of its router. A leading dim that is
+neither is a layout this batcher cannot read: the value is served whole to every
+invoke, and a write to it — an in-place edit or a replacement — is reported (see
+[`Batcher.narrow`][nnsight.intervention.batching.Batcher.narrow]), because it acts
+on the whole batch rather than on the invoke that made it.
 
 Two consequences a block's author meets. Equalizing the sequence length pads every
 invoke out to the batch's longest input, so a position index counted from the left
@@ -23,6 +33,7 @@ row scoping nor that row check applies to it.
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Any, Optional
 
 import torch
@@ -94,14 +105,24 @@ class Batcher:
         # assemble() lays them over the combined call.
         self.extra_kwargs: dict = {}
         self.total = 0
+        # Tensors served whole because no row rule matched, by id: the tensor, torch's
+        # version counter at the moment it was served, the location it came from and
+        # its leading dim. `_report_unscoped` turns an edit to one into a warning, and
+        # empties this — so what is held is one visit's unscoped values, no more.
+        self.unscoped: dict[int, tuple] = {}
 
     def narrow(self, value: Any, group: BatchGroup) -> Any:
         """Slice every batched tensor in ``value`` down to ``group``'s rows.
 
-        A tensor is batched only when its leading dim equals [`total`][nnsight.intervention.batching.Batcher.total] (the
-        combined batch size), so non-batched tensors pass through untouched. Returns
-        the whole value when not actually batching or for a groupless (empty) invoke.
+        A tensor is scoped when its leading dim is [`total`][nnsight.intervention.batching.Batcher.total] (the
+        combined batch size) or a whole multiple of it; anything else passes through
+        whole and is remembered, so a write to it warns rather than acting on the
+        whole batch silently. Returns the whole value when not actually batching or
+        for a groupless (empty) invoke.
         """
+        # An in-place edit doesn't come back through the batcher, so it can only be
+        # noticed after the fact — here, next time anything is served.
+        self._report_unscoped()
         if not self.batching or group is None:
             return value
         return apply(value, lambda tensor: self._narrow_tensor(tensor, group), torch.Tensor)
@@ -109,13 +130,21 @@ class Batcher:
     def _narrow_tensor(self, tensor: torch.Tensor, group: list) -> torch.Tensor:
         """Slice one batched tensor down to ``group``'s rows.
 
-        Base layout: a tensor whose leading dim is [`total`][nnsight.intervention.batching.Batcher.total] is a dim-0 stack of
-        every invoke's rows, so narrow it to ``[start, start + size)``; anything else
-        isn't batched and passes through. Overridden for non-stacked layouts.
+        Base layout: dim 0 stacks the invokes' rows, either one row per row of batch
+        (leading dim [`total`][nnsight.intervention.batching.Batcher.total]) or ``k``
+        of them — a model that flattens tokens into the batch axis before a module
+        (an MoE router's ``(B*T, D)``) keeps the invokes in the same order, ``k =
+        shape[0] // total`` rows each, so the group scales by ``k``. A leading dim
+        that is neither passes through whole and is remembered for
+        `_report_unscoped`. Overridden for non-stacked layouts.
         """
         start, size = group
-        if tensor.shape[0] == self.total:
-            view = tensor.narrow(0, start, size)
+        rows = tensor.shape[0] if tensor.ndim else 0
+        # A leading dim of a coincidental multiple (four experts, two invokes) is
+        # sliced too; the shape is all there is to go on.
+        k = rows // self.total if self.total and rows % self.total == 0 else 0
+        if k:
+            view = tensor.narrow(0, start * k, size * k)
             # Mark the slice so a `.backward()` gradient hook can tell it apart from a
             # user-made view: it isn't in the loss graph (the model runs on the full
             # batch), so its hook must redirect to the storage-owning base that is
@@ -123,7 +152,44 @@ class Batcher:
             # keeps saved activations cheap to serialize.
             view._nnsight_batch = True
             return view
+        self.unscoped[id(tensor)] = (
+            tensor, tensor._version, self._location(group), rows
+        )
         return tensor
+
+    def _location(self, group: list) -> str:
+        """Name the location whose value is being served to ``group``, for a warning.
+
+        The worker that asked for it is parked on it for the length of the narrow
+        (or widen), so its pending request names it; a value nobody asked for — a
+        `Cache` observation — has no such worker.
+        """
+        for mediator in self.envoy.interleaver.mediators:
+            if mediator.batch_group is group and mediator.pending is not None:
+                return f"`{mediator.pending.provider}`"
+        return "a value"
+
+    def _report_unscoped(self) -> None:
+        """Warn for any value served whole that has been edited in place since.
+
+        A value no row rule matched goes to every invoke as it is, so an in-place
+        edit to it acts on the whole batch — and, unlike a replacement, it never
+        passes through `widen`, so torch's version counter is the only thing that
+        records it happened.
+        """
+        if not self.unscoped:
+            return
+        for tensor, version, location, rows in self.unscoped.values():
+            if tensor._version == version:
+                continue
+            warnings.warn(
+                f"An in-place edit to {location} applies to every invoke: its "
+                f"leading dimension ({rows}) is neither the batch size "
+                f"({self.total}) nor a multiple of it, so nnsight served the whole "
+                "batch rather than this invoke's rows. Trace this input on its own, "
+                "or give the model a `_batcher_class` that knows the layout."
+            )
+        self.unscoped.clear()
 
     def widen(self, full: Any, group: BatchGroup, edited: Any) -> Any:
         """Splice ``edited`` (a block's rows) back into ``full`` (the whole batch).
@@ -133,6 +199,7 @@ class Batcher:
         `_widen_tensor`. Returns ``edited`` unchanged when not batching or for
         a groupless invoke.
         """
+        self._report_unscoped()
         if not self.batching or group is None:
             return edited
 
@@ -160,16 +227,29 @@ class Batcher:
     def _widen_tensor(self, full: torch.Tensor, group: list, edited: torch.Tensor) -> torch.Tensor:
         """Write ``edited`` into ``full``'s ``group`` rows (base dim-0-stack layout).
 
-        A tensor is batched only when its leading dim is [`total`][nnsight.intervention.batching.Batcher.total]; otherwise it
-        passes through. Overridden for non-stacked layouts.
+        The row rule is `_narrow_tensor`'s: the leading dim is
+        [`total`][nnsight.intervention.batching.Batcher.total] or a whole multiple of
+        it. Anything else has no rows this invoke owns, so there is nowhere to splice
+        the replacement — ``full`` stands, and the drop is warned about unless the
+        block handed back what it was given. Overridden for non-stacked layouts.
         """
-        if full.shape[0] != self.total:
-            return full
         start, size = group
+        rows = full.shape[0] if full.ndim else 0
+        k = rows // self.total if self.total and rows % self.total == 0 else 0
+        if not k:
+            if edited is not full:
+                warnings.warn(
+                    f"A replacement for {self._location(group)} was dropped: its "
+                    f"leading dimension ({rows}) is neither the batch size "
+                    f"({self.total}) nor a multiple of it, so nnsight can't tell "
+                    "which rows belong to this invoke. Trace this input on its own, "
+                    "or give the model a `_batcher_class` that knows the layout."
+                )
+            return full
         # cat (not in-place) keeps autograd correct for leaves/views and avoids
         # aliasing when `edited` is a narrowed view of `full`.
-        pre = full.narrow(0, 0, start)
-        post = full.narrow(0, start + size, self.total - start - size)
+        pre = full.narrow(0, 0, start * k)
+        post = full.narrow(0, (start + size) * k, rows - (start + size) * k)
         return torch.cat([pre, edited, post], dim=0)
 
     def gather_skip(self, running: Any, group: BatchGroup, replacement: Any) -> Any:

--- a/src/nnsight/modeling/transformers.py
+++ b/src/nnsight/modeling/transformers.py
@@ -956,6 +956,27 @@ class TransformersModel(HuggingFaceModel):
                     "chunked input on its own."
                 )
             items.extend(rows)
+            # The batch is one forward call, so its keywords are the batch's, not an
+            # invoke's: an invoke that passes a different value doesn't get its own,
+            # it overwrites what the batch had. Silent otherwise — a per-invoke
+            # `attention_mask` replaces the collated one for every row.
+            for key, value in forward_kwargs.items():
+                if key not in forward:
+                    continue
+                try:
+                    agrees = forward[key] is value or bool(forward[key] == value)
+                except Exception:  # noqa: BLE001 — a tensor compares elementwise
+                    agrees = False
+                if not agrees:
+                    warnings.warn(
+                        f"Invokes disagree on the forward keyword {key!r}: a batch is "
+                        "one forward call, so what reaches the model is batch-wide — "
+                        "the last invoke to pass it decides it for every row "
+                        "(tokenizer keywords are unaffected; those apply per invoke). "
+                        "Anything that has to differ per row belongs in the invoke's "
+                        "input — a dict of input_ids/attention_mask, say — rather "
+                        "than in its keywords."
+                    )
             forward.update(forward_kwargs)
 
         encoding = self._collate(items)

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -10,6 +10,7 @@ import os
 import subprocess
 import sys
 import textwrap
+import warnings
 
 import pytest
 import torch
@@ -23,11 +24,19 @@ P1 = "the cat sat"
 P2 = "a much longer prompt appears here"
 MSG = "Madison Square Garden is located in the city of"  # greedily -> " New York City"
 ET = "The Eiffel Tower is in the city of"
+MOE = "hf-internal-testing/tiny-random-Qwen2MoeForCausalLM"
 
 
 @pytest.fixture(scope="module")
 def gpt2():
     return TransformersModel("gpt2", task="text-generation", dispatch=True)
+
+
+@pytest.fixture(scope="module")
+def moe():
+    # A mixture-of-experts block flattens (batch, seq, hidden) to (batch*seq, hidden)
+    # before its router, which is the layout row scoping has to follow.
+    return TransformersModel(MOE, task="text-generation", dispatch=True, dtype=torch.float32)
 
 
 class _MLP(nn.Module):
@@ -38,6 +47,32 @@ class _MLP(nn.Module):
 
     def forward(self, x):
         return self.fc2(torch.relu(self.fc1(x)))
+
+
+class _Flattened(nn.Module):
+    """Folds tokens into the batch axis before its submodule, the way a
+    transformers MoE block does ahead of its router: fc1 sees ``(batch*seq, 8)``."""
+
+    def __init__(self):
+        super().__init__()
+        self.fc1 = nn.Linear(8, 8)
+
+    def forward(self, x):
+        batch, seq, hidden = x.shape
+        return self.fc1(x.reshape(-1, hidden)).reshape(batch, seq, hidden)
+
+
+class _Unscopable(nn.Module):
+    """Builds a value whose leading dim has nothing to do with the batch, so no row
+    rule can scope it to an invoke."""
+
+    def __init__(self):
+        super().__init__()
+        self.fc1 = nn.Linear(8, 8)
+
+    def forward(self, x):
+        odd = torch.ones(3, 8)
+        return self.fc1(x) + odd.sum()
 
 
 class _BatchEnvoy(Envoy):
@@ -264,6 +299,155 @@ class TestWholeTensorWrites:
             envoy.fc1.output = torch.ones(5, 8)
             out = envoy.output.save()
         assert out.shape == (5, 8)
+
+
+class TestFlattenedRows:
+    """A model that folds tokens into the batch axis — every transformers MoE block
+    does it before its router — still gets per-invoke rows: the leading dim is a
+    whole multiple of the batch, so each invoke owns that many rows per row of
+    batch, in the same order."""
+
+    @torch.no_grad()
+    def test_each_invoke_reads_its_own_flattened_rows(self):
+        torch.manual_seed(0)
+        envoy = _BatchEnvoy(_Flattened())
+        with envoy.trace() as tracer:
+            with tracer.invoke(torch.randn(1, 3, 8)):
+                a = envoy.fc1.output.save()
+            with tracer.invoke(torch.randn(2, 3, 8)):
+                b = envoy.fc1.output.save()
+        # 3 tokens per row of batch: 1x3 rows and 2x3 of the 9 the module sees.
+        assert a.shape == (3, 8) and b.shape == (6, 8)
+
+    @torch.no_grad()
+    def test_an_edit_lands_only_on_its_own_flattened_rows(self):
+        torch.manual_seed(0)
+        model = _Flattened()
+        envoy = _BatchEnvoy(model)
+        xa, xb = torch.randn(1, 3, 8), torch.randn(2, 3, 8)
+        with envoy.trace() as tracer:
+            with tracer.invoke(xa):
+                envoy.fc1.output[:] = 0
+                a = envoy.output.save()
+            with tracer.invoke(xb):
+                b = envoy.output.save()
+        assert bool((a == 0).all())
+        assert torch.allclose(b, model(xb), atol=1e-5)
+
+    @torch.no_grad()
+    def test_a_replacement_lands_only_on_its_own_flattened_rows(self):
+        torch.manual_seed(0)
+        model = _Flattened()
+        envoy = _BatchEnvoy(model)
+        xa, xb = torch.randn(1, 3, 8), torch.randn(2, 3, 8)
+        with envoy.trace() as tracer:
+            with tracer.invoke(xa):
+                envoy.fc1.output = torch.ones(3, 8)
+                a = envoy.output.save()
+            with tracer.invoke(xb):
+                b = envoy.output.save()
+        assert bool((a == 1).all())
+        assert torch.allclose(b, model(xb), atol=1e-5)
+
+
+class TestUnscopedWrites:
+    """A value whose leading dim is neither the batch size nor a multiple of it has
+    no rows this invoke owns, so it is served whole. Reading one is quiet; writing
+    to one acts on the whole batch (or, for a replacement, is dropped), and warns."""
+
+    @torch.no_grad()
+    def test_reading_an_unscopable_value_is_quiet(self):
+        torch.manual_seed(0)
+        envoy = _BatchEnvoy(_Unscopable())
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with envoy.trace() as tracer:
+                with tracer.invoke(torch.randn(1, 8)):
+                    odd = envoy.source.odd_0.output.save()
+                with tracer.invoke(torch.randn(1, 8)):
+                    envoy.output.save()
+        assert odd.shape == (3, 8)  # the whole thing, not this invoke's rows
+        assert not caught
+
+    @torch.no_grad()
+    def test_an_in_place_edit_warns(self):
+        torch.manual_seed(0)
+        envoy = _BatchEnvoy(_Unscopable())
+        with pytest.warns(UserWarning, match="in-place edit to `model.source.odd_0.output`"):
+            with envoy.trace() as tracer:
+                with tracer.invoke(torch.randn(1, 8)):
+                    envoy.source.odd_0.output[:] = 5
+                    envoy.output.save()
+                with tracer.invoke(torch.randn(1, 8)):
+                    envoy.output.save()
+
+    @torch.no_grad()
+    def test_a_replacement_warns_and_is_dropped(self):
+        torch.manual_seed(0)
+        model = _Unscopable()
+        envoy = _BatchEnvoy(model)
+        xa, xb = torch.randn(1, 8), torch.randn(1, 8)
+        with pytest.warns(UserWarning, match="replacement for `model.source.odd_0.output`"):
+            with envoy.trace() as tracer:
+                with tracer.invoke(xa):
+                    envoy.source.odd_0.output = torch.zeros(3, 8)
+                    a = envoy.output.save()
+                with tracer.invoke(xb):
+                    envoy.output.save()
+        # Nowhere to splice it, so the model ran on what it built itself.
+        assert torch.allclose(a, model(xa), atol=1e-5)
+
+
+class TestMoERouterScoping:
+    """The regression the row rules exist for: an MoE router's output is
+    ``(batch*seq, experts)``, so a per-invoke edit to it used to land on the whole
+    batch's rows — one invoke's forced routing moved the others' logits."""
+
+    @torch.no_grad()
+    def test_a_router_edit_reaches_only_its_own_invoke(self, moe):
+        router = moe.model.layers[0].mlp.gate
+        with moe.trace() as tracer:
+            with tracer.invoke(P1):
+                router.output[2][-1, :] = 0  # this invoke's last token -> expert 0
+                forced = moe.output.logits[0, -1].save()
+            with tracer.invoke(P2):
+                moe.output.logits.save()
+            with tracer.invoke(P1):  # control: same prompt, no edit
+                control = moe.output.logits[0, -1].save()
+        with moe.trace(P1):
+            router.output[2][-1, :] = 0
+            solo_forced = moe.output.logits[0, -1].save()
+        with moe.trace(P1):
+            solo = moe.output.logits[0, -1].save()
+
+        assert torch.allclose(forced, solo_forced, atol=1e-5)  # the edit landed here
+        assert not torch.allclose(forced, solo, atol=1e-5)  # and it did something
+        assert torch.allclose(control, solo, atol=1e-5)  # and nowhere else
+
+
+class TestForwardKwargs:
+    """Forward keywords on an invoke are the batch's, not that invoke's: one
+    forward call takes one set of them, so disagreeing invokes warn."""
+
+    @torch.no_grad()
+    def test_disagreeing_invokes_warn(self, gpt2):
+        with pytest.warns(UserWarning, match="disagree on the forward keyword 'output_hidden_states'"):
+            with gpt2.trace() as tracer:
+                with tracer.invoke(P1, output_hidden_states=True):
+                    gpt2.output.logits.save()
+                with tracer.invoke(P2, output_hidden_states=False):
+                    gpt2.output.logits.save()
+
+    @torch.no_grad()
+    def test_agreeing_invokes_are_quiet(self, gpt2):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with gpt2.trace() as tracer:
+                with tracer.invoke(P1, output_hidden_states=True):
+                    gpt2.output.logits.save()
+                with tracer.invoke(P2, output_hidden_states=True):
+                    gpt2.output.logits.save()
+        assert not [w for w in caught if "forward keyword" in str(w.message)]
 
 
 class TestCacheAcrossInvokes:


### PR DESCRIPTION
Items 1, 13 and 14.3 from the stress-sweep decisions.

## What was broken

**Row scoping was a single shape test** (`tensor.shape[0] == self.total`). Anything
else went to every invoke whole, with three silent consequences: a read saw the
whole batch, an in-place edit landed on every invoke, and a replacement was
dropped (`_widen_tensor` returned `full` and discarded `edited`). The layout that
hits this in practice is the token-flattened one — every transformers MoE block
reshapes to `(batch*seq, hidden)` before its router, so `mlp.gate.output`,
`mlp.experts.inputs` and every `.source` op below the reshape were unscoped. On
`hf-internal-testing/tiny-random-Qwen2MoeForCausalLM`, two invokes each forcing
"their" last token onto an expert both wrote the same rows, and the third,
unedited invoke's logits moved.

**Forward keywords on an invoke were merged batch-wide**, last writer wins, with
nothing said: `output_hidden_states` came back `None` for the invoke that asked
for it, and a per-invoke `attention_mask`/`max_new_tokens` quietly became the
batch's.

`docs/usage/trace.md`, the `batching.py` module docstring and NNsight.md all
promised that each invoke "sees only its own rows of every activation".

## What changed

- `Batcher._narrow_tensor` / `_widen_tensor` take a leading dim that is a whole
  multiple of the batch size: `k = rows // total` rows per row of batch, narrowed
  and spliced at `[start*k, size*k)`. Fixes the MoE `(B*T, D)` and per-head
  `(B*T*H, D)` cases. Accepted risk, as decided: a leading dim that is a multiple
  by coincidence (four experts against two invokes) is now sliced rather than
  passed through.
- A write to a value neither rule matched warns, naming the location, its leading
  dim and the batch size. A replacement is caught in `_widen_tensor` (and only
  when the block actually handed back something different, so round-tripping the
  non-batched leaves of a tuple output stays quiet). An in-place edit never comes
  back through the batcher at all, so `_narrow_tensor` records what it served
  whole with torch's `_version` counter and `_report_unscoped` — called at the top
  of `narrow`/`widen` — warns for anything whose version moved. That makes the
  report one batcher call late (the next value served to any worker); an edit
  after which nothing at all is read is the case it can miss. Reads deliberately
  do not warn: from a shape alone, a causal mask is indistinguishable from a
  vision tower's patches, and warning on reads would fire constantly.
- `TransformersModel._batch_forward` warns when two invokes pass different values
  for the same forward keyword.
- Docs: the scoping rule, the three failure modes and the warning in
  `docs/usage/invoke-and-batching.md`; the corrected sentence in
  `docs/usage/trace.md`, the `batching.py` module docstring and NNsight.md §4.4 /
  §7.2; the internals in `docs/developing/batching-internals.md`; the
  forward-keyword rule; and (item 13, docs only) the ordering rule that statements
  outside the invoke blocks run in the collection pass, before the model — with
  the reduce-after-the-trace remedy, verified here.

## Tested

`PYTHONPATH=<worktree>/src` against the stress env's interpreter, CPU only.

- New tests in `tests/test_batching.py`: `TestFlattenedRows` (read, in-place edit
  and replacement on a `(batch*seq, hidden)` activation, pure torch),
  `TestUnscopedWrites` (in-place warns, replacement warns and is dropped, a read
  is quiet), `TestMoERouterScoping` (the tiny-random Qwen2-MoE regression: a
  forced route matches the same prompt traced alone, does something, and leaves
  the control invoke equal to its solo run), `TestForwardKwargs`. All seven
  behavioural ones fail on a `git archive HEAD` baseline and pass here.
- `tests/test_batching.py` 55 passed, 1 skipped. Also green: `test_interleaving`,
  `test_saving`, `test_backward`, `test_language`, `test_modeling`, `test_envoy`,
  `test_editing`, `test_source`, `test_tracing`, `test_encoder`, `test_vision`,
  `test_chat`, `test_chunked_tasks`, `test_multiple_wrappers`,
  `test_construction_routing`, `test_vlm`, `test_diffusion`, `test_fragments`,
  `test_util`, `test_memory`, `test_serialization`, `test_tensor_parallel_rules`,
  `test_deprecations`, `test_config` (~950 tests).
- Not run here: `tests/vllm/` and `tests/tp/` (no vLLM run, no multi-GPU). The
  vLLM batcher inherits `_narrow_tensor`, where `total` is the step's token rows;
  the modulo branch only engages for a tensor whose leading dim is a multiple of
  that, and the warning is a warning.
- Checked for false positives: batched gpt2 traces with edits, `tracer.cache()`
  (with `include_inputs=True`), batched `generate` with `tracer.iter`, and
  attention-tuple edits produce no warnings.

## Deliberately left alone

- The VLM/vision-side case (item 7). The modulo rule fixes equal-images-per-invoke
  by luck and does not address the rest; the axis table is the real answer.
- Time-major `(seq, batch, hidden)` with `seq == total`, and a list of
  per-sequence tensors: still wrong, still undetectable from a shape. Both are now
  written down in the docs.
- `docs/concepts/batching-and-invokers.md:13` and `:76` still state the old
  `== total` rule — that file belongs to another agent in this batch; it needs the
  same correction. Likewise the `nnsight:nnsight` skill's batching material,
  which lives outside this repo.
- Item 14's other two points (cache path validation, comment truncation) are not
  mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)