### PR TITLE
tracer: keep the whole block body, and say why capture failed

### DIFF
--- a/docs/developing/tracing-pipeline.md
+++ b/docs/developing/tracing-pipeline.md
@@ -110,7 +110,10 @@ once and cached in `SOURCES`. It handles three contexts:
    `<string>`, so the literal source is recovered from `sys.orig_argv` (gated on
    the exact `<string>` filename).
 3. Anything else with no source (e.g. a raw `exec` string, `<stdin>`) yields an
-   empty string, which fails the parse and raises `WithBlockNotFoundError`.
+   empty string, which fails the parse and raises `WithBlockNotFoundError`. Its
+   message is built by `_not_found_message` (`tracer.py`), which branches on
+   whether any source was recovered and whether the filename is a file still on
+   disk, since the way out differs for each.
 
 > **Running examples:** `with model.trace(...):` reads its own source to capture
 > the block, so it does **not** work from `python -c "..."`-style one-liners that
@@ -123,10 +126,13 @@ once and cached in `SOURCES`. It handles three contexts:
 `ast.AsyncWith` node that starts on `lineno`. It first tries `_parse_block`
 (`tracer.py`), which slices just the block out by indentation and bracket
 depth, dedents it to column 0, parses that, and shifts line numbers back. Getting
-the slice bound wrong is safe: too much just parses trailing statements (the
+the slice bound wrong is mostly safe: too much just parses trailing statements (the
 `with` is still `body[0]`); too little makes the slice unparseable and falls back
-to parsing the whole file. `parse` returns `None` if there's no `with` at that line
-(the site isn't a trace block).
+to parsing the whole file. The exception is a bound that cuts the body where the
+block could plausibly have ended — the slice still parses, as a `with` missing part
+of its body — which is why blank lines and comments, whose indentation Python
+ignores, never end the slice. `parse` returns `None` if there's no `with` at that
+line (the site isn't a trace block).
 
 ### Build + compile
 

--- a/docs/errors/index.md
+++ b/docs/errors/index.md
@@ -43,7 +43,7 @@ unsupported.
 | `ValueError` | ``trace() needs an input, or at least one `with tracer.invoke(...)` block`` | [cannot-access-outside-interleaving.md](cannot-access-outside-interleaving.md) |
 | `ValueError` | ``Cannot invoke while the model is already running.`` | [invoke-during-execution.md](invoke-during-execution.md) |
 | `NotImplementedError` | ``<ModelClass> does not support batching multiple invokes`` | [batching-not-implemented.md](batching-not-implemented.md) |
-| `WithBlockNotFoundError` | *(no message)* | [with-block-not-found.md](with-block-not-found.md) |
+| `WithBlockNotFoundError` | ``nnsight found no `with` statement at <file>:<line>, the line the trace was entered from. …`` | [with-block-not-found.md](with-block-not-found.md) |
 
 ## Tracing / capture errors
 
@@ -52,7 +52,9 @@ Raised while capturing the `with` block's source.
 | Exception | Message | Source / fix |
 |---|---|---|
 | `ValueError` | ``The body of a traced `with` must start on its own line; nnsight runs the body itself, and can only intercept it at the start of a line.`` | `src/nnsight/tracing/tracer.py:76`. Move the body off the `with` line: never write `with model.trace(x): out = ...`; put `out = ...` on the next, indented line. |
-| `WithBlockNotFoundError` | *(no message)* | `src/nnsight/tracing/tracer.py:306`. The tracer wasn't used as a `with` block. See [with-block-not-found.md](with-block-not-found.md). |
+| `WithBlockNotFoundError` | ``nnsight has no source for <file>, so it cannot read the body of the `with` block at line <line>. …`` | `src/nnsight/tracing/tracer.py`. There is no source to read the block from: a script piped in on stdin, or an `exec`'d string not registered in `linecache`. Run the file by name. See [with-block-not-found.md](with-block-not-found.md). |
+| `WithBlockNotFoundError` | ``nnsight found no `with` statement at <file>:<line>, the line the trace was entered from … Either the tracer wasn't used as a `with` block … or the source nnsight read for this file is stale`` | `src/nnsight/tracing/tracer.py`. The file is on disk but has no `with` at that line: the source was read before an edit moved it (restart the process), or the tracer was entered without a `with` block. |
+| `WithBlockNotFoundError` | ``nnsight found no `with` statement at <file>:<line>, the line the trace was entered from … nnsight compiles the block's own body to run it`` | `src/nnsight/tracing/tracer.py`. Source was recovered but its line numbers don't match the running code — a cell magic that rewrites the cell (`%%time`), or generated source out of step with its `linecache` entry. |
 
 ## Coordination errors
 

--- a/docs/errors/symptom-index.md
+++ b/docs/errors/symptom-index.md
@@ -39,7 +39,7 @@ worth reading: those failures raise nothing, so nothing routes you to a page.
 | ``ValueError: A traced `with` block cannot start with `try:` …`` | [A trace body that starts with try:](#a-trace-body-that-starts-with-try) |
 | ``ValueError: The body of a traced `with` must start on its own line …`` | [A body on the with line](#a-body-on-the-with-line) |
 | `ValueError: A barrier was never reached by every block it waits for …` | [docs/usage/barrier.md](../usage/barrier.md) |
-| `WithBlockNotFoundError` with no message | [with-block-not-found.md](with-block-not-found.md) |
+| ``WithBlockNotFoundError: nnsight found no `with` statement at …`` / ``no source for …`` | [with-block-not-found.md](with-block-not-found.md) |
 | `SyntaxError: 'return' outside function` | [return inside a trace body](#return-inside-a-trace-body) |
 | `NotImplementedError: <Class> does not support batching multiple invokes` | [batching-not-implemented.md](batching-not-implemented.md) |
 | `AttributeError: module 'nnsight' has no attribute 'list' / 'apply' / 'session' / …` | [docs/reference/version-history.md](../reference/version-history.md) |

--- a/docs/errors/with-block-not-found.md
+++ b/docs/errors/with-block-not-found.md
@@ -10,13 +10,28 @@ sources: [src/nnsight/tracing/tracer.py]
 
 ## Symptom
 
+One of three messages, depending on what nnsight could recover at the call site:
+
 ```
-nnsight.tracing.tracer.WithBlockNotFoundError
+WithBlockNotFoundError: nnsight has no source for <stdin>, so it cannot read the
+body of the `with` block at line 3. …
 ```
 
-The exception carries **no message** — the class docstring is the
-explanation: "The tracer call isn't used as a `with` block, so there's nothing to
-trace."
+```
+WithBlockNotFoundError: nnsight found no `with` statement at run.py:12, the line
+the trace was entered from, which reads `t.__enter__()`. Either the tracer wasn't
+used as a `with` block … or the source nnsight read for this file is stale …
+```
+
+```
+WithBlockNotFoundError: nnsight found no `with` statement at <ipython-input-3>:4,
+the line the trace was entered from. nnsight compiles the block's own body to run
+it …
+```
+
+The first means there was no source to read at all; the second that the file is on
+disk but has no `with` at that line; the third that source was recovered but its
+line numbers don't line up with the code being run.
 
 ## Cause
 

--- a/src/nnsight/tracing/tracer.py
+++ b/src/nnsight/tracing/tracer.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import ast
 import builtins
 import linecache
+import os
 import sys
 import threading
 from types import CodeType, FrameType, TracebackType
@@ -54,7 +55,57 @@ class ExitTracingException(Exception):
 
 
 class WithBlockNotFoundError(Exception):
-    """The tracer call isn't used as a ``with`` block, so there's nothing to trace."""
+    """No ``with`` block was found at the call site, so there's nothing to trace.
+
+    Either the tracer wasn't used as a ``with`` block, or the source it was
+    written in couldn't be read back as one; `_not_found_message` tells the
+    two apart for the user.
+    """
+
+
+def _not_found_message(filename: str, lineno: int) -> str:
+    """Say why no ``with`` was found at ``filename``:``lineno``, and what to do.
+
+    Several unrelated causes land on the same raise — a trace typed into stdin, an
+    ``exec``'d string, a cell magic that rewrites the cell, a file edited mid-run,
+    a tracer entered by hand — and the way out differs for each, so branch on what
+    the raise site knows: whether there is any source at all, and whether it came
+    from a file still on disk.
+    """
+    source = Tracer.source(filename).splitlines()
+    reads = ""
+    if 1 <= lineno <= len(source):
+        reads = f", which reads `{source[lineno - 1].strip()}`"
+
+    if not source:
+        return (
+            f"nnsight has no source for {filename}, so it cannot read the body of the "
+            f"`with` block at line {lineno}. It compiles the block's own source to run "
+            "it, so a trace has to live somewhere that source can be read back from: a "
+            "file on disk, a notebook cell, or `python -c`. Piping a script in on stdin "
+            "(`python < script.py`) leaves none — run the file by name instead — and "
+            "code built at runtime has to register itself in `linecache`."
+        )
+
+    if os.path.isfile(filename):
+        return (
+            f"nnsight found no `with` statement at {filename}:{lineno}, the line the "
+            f"trace was entered from{reads}. Either the tracer wasn't used as a `with` "
+            "block — nnsight compiles the block's own body to run it, so there is "
+            "nothing to capture — or the source nnsight read for this file is stale: it "
+            "reads each file once and never re-checks it, so an edit that moved this "
+            "line mid-run leaves it looking at the old text, and the process has to be "
+            "restarted."
+        )
+
+    return (
+        f"nnsight found no `with` statement at {filename}:{lineno}, the line the trace "
+        f"was entered from{reads}. nnsight compiles the block's own body to run it, so "
+        "the trace has to be written as `with model.trace(...):` in source whose line "
+        "numbers match the code being run — a cell magic that rewrites the cell "
+        "(`%%time`), or generated source out of step with its `linecache` entry, breaks "
+        "that match."
+    )
 
 
 # The statements a block can't start with (see `skip_context`). `except*` parses
@@ -352,7 +403,9 @@ class Tracer:
 
         node, compiled = BLOCKS[key]
         if node is None:
-            raise WithBlockNotFoundError()
+            raise WithBlockNotFoundError(
+                _not_found_message(code.co_filename, frame.f_lineno)
+            )
         self.node = node
         self.info = Tracer.Info(frame, compiled)
 
@@ -425,11 +478,13 @@ class Tracer:
         it stands alone, parses that, and shifts the line numbers back to the file
         so tracebacks and the skip hook still point at the real source.
 
-        Getting the bound wrong is safe: collecting *too much* just parses a few
-        trailing statements past the block (``body[0]`` is still the ``with``);
-        collecting too little makes the slice unparseable, which returns ``None``
-        and lets [`parse`][nnsight.tracing.tracer.Tracer.parse] fall back to the whole file. It never returns a wrong
-        node.
+        Getting the bound wrong is mostly safe: collecting *too much* just parses a
+        few trailing statements past the block (``body[0]`` is still the ``with``),
+        and collecting too little usually makes the slice unparseable, which returns
+        ``None`` and lets [`parse`][nnsight.tracing.tracer.Tracer.parse] fall back to the whole file. Only a bound that
+        cuts the body at a line the block could have ended on gives a wrong node
+        that still parses — which is why lines Python doesn't indent, comments and
+        blanks, can't be allowed to end it.
         """
         lines = source.splitlines(keepends=True)
         if not 1 <= lineno <= len(lines):
@@ -440,9 +495,13 @@ class Tracer:
         depth = _bracket_depth(first)
         for line in lines[lineno:]:
             stripped = line.lstrip()
-            # A non-blank line dedented back to the header's column, with no bracket
+            # A line of code dedented back to the header's column, with no bracket
             # still open, is the next statement — the block ended on the line before.
-            if depth <= 0 and stripped and len(line) - len(stripped) <= indent:
+            # Blanks and comments carry no indentation as far as Python is concerned
+            # (a commented-out line at column 0 sits happily inside an indented
+            # block), so they can't be read as the end of one.
+            statement = stripped and not stripped.startswith("#")
+            if depth <= 0 and statement and len(line) - len(stripped) <= indent:
                 break
             collected.append(line)
             depth += _bracket_depth(line)

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -12,7 +12,13 @@ import pytest
 
 import nnsight
 from nnsight.tracing.backend import Backend
-from nnsight.tracing.tracer import ExitTracingException, Tracer, save
+from nnsight.tracing.tracer import (
+    ExitTracingException,
+    Tracer,
+    WithBlockNotFoundError,
+    _not_found_message,
+    save,
+)
 
 
 class _RecordingBackend(Backend):
@@ -101,6 +107,27 @@ class TestParseBlock:
         node = self._with(src, 4)
         assert node.lineno == 4
         assert node.body[0].lineno == 5
+
+    def test_column_zero_comment_does_not_end_the_block(self):
+        # Python ignores a comment's indentation, so an editor leaves commented-out
+        # code at column 0 inside an indented block. Stopping there would still
+        # parse — as a `with` that has quietly lost the rest of its body.
+        src = (
+            "def f():\n"
+            "    with ctx:\n"
+            "        x = 1\n"
+            "# print(x)\n"
+            "        y = 2\n"
+            "    return y\n"
+        )
+        node = self._with(src, 2)
+        assert [s.lineno for s in node.body] == [3, 5]
+
+    def test_column_zero_comment_after_the_block_still_ends_it(self):
+        # The comment is collected, but the statement after it is still the end.
+        src = "with ctx:\n    x = 1\n# done\ny = 2\n"
+        node = self._with(src, 1)
+        assert [s.lineno for s in node.body] == [2]
 
     def test_parse_falls_back_to_whole_file(self, monkeypatch):
         # When the slice can't isolate the block, parse() still finds it by parsing
@@ -229,6 +256,16 @@ class TestSkip:
             ran.append("real")
         assert ran == ["real"]
 
+    def test_comment_at_column_zero_keeps_the_rest_of_the_body(self):
+        # The body is compiled from the block's own source, so a slice that ended
+        # at the comment would drop `second` — silently, since what is left still
+        # parses as a `with`.
+        with Tracer():
+            first = save(1)
+# a commented-out line, at column 0 where an editor leaves it
+            second = save(2)
+        assert (first, second) == (1, 2)
+
     def test_read_then_reassign_escapes(self):
         base = 10
         with Tracer():
@@ -250,6 +287,57 @@ class TestSkip:
             assert error.__context__ is None
         else:
             pytest.fail("expected ValueError to propagate")
+
+
+class TestNotFoundMessage:
+    """Unrelated causes reach one raise — source that can't be read, source that
+    has moved, a call that isn't a `with` — so the message has to tell them apart."""
+
+    def test_no_source_at_all(self):
+        message = _not_found_message("<stdin>", 3)
+        assert "no source for <stdin>" in message
+        assert "python < script.py" in message
+
+    def test_real_file_reports_stale_source(self, tmp_path):
+        from nnsight.tracing.globals import SOURCES
+
+        module = tmp_path / "traced.py"
+        module.write_text("value = 1\n")
+        try:
+            message = _not_found_message(str(module), 1)
+        finally:
+            SOURCES.pop(str(module), None)
+        assert f"{module}:1" in message
+        assert "stale" in message
+        assert "`value = 1`" in message  # the line it actually looked at
+
+    def test_readable_source_that_is_not_a_file(self):
+        from nnsight.tracing.globals import SOURCES
+
+        name = "<generated-block>"
+        source = "x = 1\n"
+        linecache.cache[name] = (
+            len(source),
+            None,
+            source.splitlines(keepends=True),
+            name,
+        )
+        try:
+            message = _not_found_message(name, 1)
+        finally:
+            linecache.cache.pop(name, None)
+            SOURCES.pop(name, None)
+        assert f"{name}:1" in message
+        assert "linecache" in message
+
+    def test_the_raise_carries_the_message(self):
+        def capture_here():
+            # capture()'s frame is this function's caller — the line below.
+            Tracer().capture()
+
+        with pytest.raises(WithBlockNotFoundError) as error:
+            capture_here()
+        assert "test_tracing.py" in str(error.value)
 
 
 class TestInfo:


### PR DESCRIPTION
Two findings from the agent stress sweep, both in the `with`-block capture path
(items 14.2 and 22 in the review notes).

## A column-0 comment truncated the trace body

`Tracer._parse_block` ended its slice at any non-blank line indented back to the
header's column. A comment is non-blank and Python ignores its indentation, so
commented-out code at column 0 — where every editor leaves it — cut the body
short. The truncated slice still parsed as a valid `ast.With`, so the whole-file
fallback never fired and the statements after the comment silently never ran.

Blanks and comments no longer end the slice. The docstring's "It never returns a
wrong node" was exactly wrong for this case and now says which bound is unsafe
and why.

Before / after on the repro
(`tasks/trace-body-capture-and-save/skills/repro_7_col0_comment_truncates_body.py`):
`NameError: name 'o' is not defined` → `after comment ran` / `o = 2.0`.

## `WithBlockNotFoundError` carried no message

`raise WithBlockNotFoundError()` gave the bare class name for at least five
distinct causes — a trace typed into stdin, `python -c`, an `exec`'d string not
in `linecache`, a `%%time` cell magic, an edit that shifted line numbers — and
the user could not tell them apart. `_not_found_message` now branches on what the
raise site knows:

- no source recovered at all (stdin, an `exec`'d string not in `linecache`) —
  say where a trace body has to live;
- a real file with no `with` at that line — name the file, line and the text of
  that line, and say the source looks stale (nnsight reads each file once) or
  that the tracer was entered without a `with`;
- otherwise — name file and line and explain that nnsight compiles the block's
  own body, so line numbers have to match (a `%%time` cell magic, generated
  source out of step with its `linecache` entry).

`docs/errors/index.md` now carries the real message text for all three.

Deliberately not fixed: the stale compiled-body cache itself (`BLOCKS`/`SOURCES`
never re-validated), per the review. The second branch only *reports* that the
source looks stale.

## Docs

`docs/errors/index.md`, plus the two lines my change made false —
`docs/errors/with-block-not-found.md` and `docs/errors/symptom-index.md` both
asserted the exception carries no message — and the `_parse_block` bound and
`_not_found_message` sentences in `docs/developing/tracing-pipeline.md`.

## Not in this PR

An earlier revision of this branch also restored the thread's trace function
around a block (`skip_context` clobbers it, `__exit__` sets it to `None`, so a
debugger breakpoint set after a trace never fires and coverage reports every line
after the first block as missed). The maintainer has decided against that change,
and it has been removed in full: `skip_context` installs the bare no-op and
`__exit__` keeps its unconditional `sys.settrace(None)`, exactly as on `0.8`.

## Testing

`PYTHONPATH=<worktree>/src` throughout, so the worktree is what ran.

- `tests/test_tracing.py`: 63 passed (56 before; 7 added). The two comment tests
  fail on `origin/0.8` and pass here — verified against a scratch checkout of
  `origin/0.8`'s `src`. The four `_not_found_message` tests are new-API and can
  only run here.
- Full suite minus `tests/vllm`, `tests/tp`, `tests/performance`: 1008 passed,
  3 skipped, 1 xfailed. `origin/0.8` on the same command: 1001 passed, same
  skips — the difference is exactly the 7 added tests.
- Serialization round-trips re-checked specifically (12 tests across
  `test_serialization.py`, `test_editing.py`, `test_diffusion.py`,
  `test_encoder.py`): nothing here stores anything new on the `Tracer`, and
  `__getstate__`/`__setstate__` are untouched relative to `0.8`.
- vLLM and tensor-parallel tests were not run: no vLLM in this environment and no
  multi-GPU. Neither item touches those paths.
- Both repros named in the review behave as expected.

Note: `pytest tests/test_serialization.py` on its own dumps core partway through
in this environment on `origin/0.8` too — pre-existing, unrelated, and it does
not happen in the full run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
