### PR TITLE
envoy: len, iteration and indexing answer for the same entries

### DIFF
--- a/docs/concepts/envoy.md
+++ b/docs/concepts/envoy.md
@@ -215,6 +215,46 @@ brought in, and including a container rebuilt from blocks the tree already wraps
 (`model.transformer.h = nn.ModuleList(list(model.transformer._module.h)[:4])`).
 Each such entry names the one envoy at the module's first path.
 
+## Containers that index past their entries
+
+`len(envoy)`, iteration and `envoy[k]` answer for the same entries. For torch's
+own containers — `ModuleList`, `Sequential`, `ModuleDict` — that is the envoy
+children, because the tree mirrors their entries one-for-one. Indexing resolves
+by child name, which is what keeps a shared entry at its own name and what makes
+`layers[2]` an envoy rather than a bare module.
+
+A container may instead keep its modules one level down and reach them through
+its own `__getitem__` — a set of transcoders or SAEs holding them in a child
+`ModuleList`:
+
+```python
+class TranscoderSet(nn.Module):
+    def __init__(self, transcoders):
+        super().__init__()
+        self.transcoders = nn.ModuleList(transcoders)   # the tree's one child
+
+    def __len__(self):     return len(self.transcoders)
+    def __getitem__(self, i): return self.transcoders[i]
+```
+
+Its `__len__` counts eighteen transcoders while the envoy has one child, so an
+envoy that indexed only by name would report a length whose every index raised.
+The envoy asks the container instead, and names the envoy of whatever module it
+hands back, so all three agree on the modules:
+
+```python
+len(model.transcoders)      # 18
+model.transcoders[2]        # model.transcoders.transcoders.2 -- an Envoy
+list(model.transcoders)     # the 18 transcoder envoys
+```
+
+The delegation is a fallback, not the first move: a name that resolves to a child
+wins, so nothing about torch's containers changes. It only yields an `Envoy` —
+a `__getitem__` returning a tensor element, or a module built on the fly that
+this tree does not wrap, raises rather than handing back something no trace can
+address. A container with no `__iter__` of its own is walked over the length it
+reports, so a `__getitem__` that never raises `IndexError` cannot run away.
+
 ## Module renaming (aliases)
 
 `rename={...}` on `NNsight`/`Envoy` binds aliases pointing at the same child envoy (`_bind_aliases`, `envoy.py`). A single-component path (`{"transformer": "gpt"}`) binds wherever it resolves; a multi-component path (`{"transformer.h": "layers"}`) binds on the envoy it resolves from. Aliases are ordinary attributes referencing the same object, so they survive a dispatch re-point with no rebuild.

--- a/src/nnsight/intervention/envoy.py
+++ b/src/nnsight/intervention/envoy.py
@@ -68,6 +68,18 @@ from .source import Source, install_source
 from .tracer import InterleavingTracer
 from .util import first_input, replace_first_input
 
+# Torch's containers hold their modules as their own `_modules` entries, which is
+# exactly what the envoy tree mirrors. Indexing and iterating them goes through
+# the children, so both yield envoys, and an entry sharing its module with
+# another keeps its own name. A container that keeps its modules one level down
+# — in a child list, reached by its own `__getitem__` — is what
+# `Envoy._indexes_past_children` answers for.
+_CHILD_INDEXED = (
+    torch.nn.ModuleList,
+    torch.nn.Sequential,
+    torch.nn.ModuleDict,
+)
+
 
 def traceable(method: Callable) -> Callable:
     """Make an Envoy method usable as a trace context.
@@ -906,6 +918,35 @@ class Envoy:
         else:
             object.__setattr__(self, name, value)
 
+    def _indexes_past_children(self) -> type | None:
+        """The wrapped module's class, when its own indexing reaches past the
+        entries this envoy mirrors.
+
+        A container that keeps its modules in a child list — a set of
+        transcoders behind a `ModuleList` — reads ``set[i]`` as the i-th module
+        *inside* that list, while the envoy tree's children are the container's
+        own entries (here, one: the list). Its ``__len__`` counts what its
+        ``__getitem__`` indexes, so taking it at its word is what makes
+        ``len``, iteration and indexing agree.
+
+        ``None`` for a plain module and for torch's own containers, whose
+        entries the tree mirrors one-for-one: those resolve by child name, which
+        is what keeps a shared entry at its own name and what makes indexing
+        return envoys rather than bare modules.
+        """
+        if isinstance(self._module, _CHILD_INDEXED):
+            return None
+        cls = type(self._module)
+        return cls if getattr(cls, "__getitem__", None) is not None else None
+
+    def _envoy_for(self, value: Any) -> Envoy | None:
+        """The envoy naming ``value``, or ``None`` when this tree wraps no such
+        module — a module built on the fly, or a ``__getitem__`` that returns
+        something other than a module."""
+        if not isinstance(value, torch.nn.Module):
+            return None
+        return self.interleaver.envoys.get(id(value))
+
     def __iter__(self) -> Iterator[Envoy]:
         """Iterate over this envoy's direct children.
 
@@ -913,6 +954,12 @@ class Envoy:
         `ModuleList`, so ``for layer in model.model.layers:``
         walks the layers. This is *not* recursive; use [`modules`][nnsight.intervention.envoy.Envoy.modules] to walk the
         whole subtree.
+
+        A container that indexes past its own entries
+        (`_indexes_past_children`) is iterated the way it iterates itself, so
+        what you get back matches its ``__len__`` and its indexing — still as
+        envoys. Anything it yields that this tree does not wrap drops the whole
+        delegation, and iteration falls back to the children.
 
         Yields:
             Envoy: Each direct child envoy, in order.
@@ -923,6 +970,24 @@ class Envoy:
                 for layer in model.model.layers:
                     print(layer.path)
         """
+        cls = self._indexes_past_children()
+        if cls is not None:
+            if getattr(cls, "__iter__", None) is not None:
+                values = list(cls.__iter__(self._module))
+            elif getattr(cls, "__len__", None) is not None:
+                # No `__iter__` of its own. Python would synthesize one from
+                # `__getitem__`, which stops only on `IndexError`; walk the
+                # length the container reports instead, so a `__getitem__` that
+                # raises something else cannot run away.
+                values = [
+                    cls.__getitem__(self._module, index)
+                    for index in range(len(self._module))
+                ]
+            else:
+                values = []
+            envoys = [self._envoy_for(value) for value in values]
+            if envoys and all(envoy is not None for envoy in envoys):
+                return iter(envoys)
         return iter([child for _, child in self._named_children()])
 
     def __getitem__(self, key: Any) -> Envoy:
@@ -932,6 +997,13 @@ class Envoy:
         indexes it — ``layers[2]`` is the module `layers` holds at ``"2"``, even
         when an earlier entry is a module the tree already wraps elsewhere and so
         has no envoy of its own here.
+
+        When no child answers to that name, a container that indexes past its own
+        entries (`_indexes_past_children`) is asked, and the envoy naming the
+        module it returns is the result — so a set holding its modules in a child
+        list indexes as itself, one envoy per module. A key it cannot answer with
+        a module this tree wraps raises, rather than handing back a bare module
+        that no trace can address.
 
         Args:
             key: An index the wrapped module accepts (an int, or a str), or a
@@ -945,10 +1017,24 @@ class Envoy:
             return [child for _, child in self._named_children()][key]
         if isinstance(key, int) and key < 0:
             key += len(self)
-        return getattr(self, str(key))
+        try:
+            return getattr(self, str(key))
+        except AttributeError:
+            cls = self._indexes_past_children()
+            if cls is None:
+                raise
+            envoy = self._envoy_for(cls.__getitem__(self._module, key))
+            if envoy is None:
+                raise
+            return envoy
 
     def __len__(self) -> int:
-        """The number of entries in the wrapped module (e.g. a ``ModuleList``'s length)."""
+        """The number of entries in the wrapped module (e.g. a ``ModuleList``'s length).
+
+        The count the module keeps, which is the count indexing and iteration
+        honour: for a container holding its modules in a child list, all three
+        speak of the modules, not of the one entry that holds them.
+        """
         return len(self._module)
 
     def get(self, path: str) -> Any:

--- a/tests/test_envoy.py
+++ b/tests/test_envoy.py
@@ -759,3 +759,134 @@ class TestMultipleWrappers:
         with w2.trace(x):
             a2 = w2.a.output.save()
         assert torch.allclose(a1, a2)
+
+
+class TranscoderSet(nn.Module):
+    """A container that keeps its modules one level down, behind its own
+    ``__getitem__`` — the shape a set of transcoders or SAEs takes."""
+
+    def __init__(self, n: int = 4):
+        super().__init__()
+        self.items = nn.ModuleList([nn.Linear(8, 8) for _ in range(n)])
+
+    def __len__(self):
+        return len(self.items)
+
+    def __getitem__(self, index):
+        return self.items[index]
+
+    def __iter__(self):
+        return iter(self.items)
+
+
+class IndexedNoIter(nn.Module):
+    """Indexes and counts, but leaves iteration to Python's ``__getitem__``
+    protocol."""
+
+    def __init__(self, n: int = 3):
+        super().__init__()
+        self.items = nn.ModuleList([nn.Linear(8, 8) for _ in range(n)])
+
+    def __len__(self):
+        return len(self.items)
+
+    def __getitem__(self, index):
+        return self.items[index]
+
+
+class IndexesATensor(nn.Module):
+    """``__getitem__`` that means something other than a submodule."""
+
+    def __init__(self):
+        super().__init__()
+        self.w = nn.Parameter(torch.zeros(3))
+
+    def __getitem__(self, index):
+        return self.w[index]
+
+
+class IndexesAFreshModule(nn.Module):
+    """``__getitem__`` returning a module this tree does not wrap."""
+
+    def __getitem__(self, index):
+        return nn.Linear(8, 8)
+
+
+class Container(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = nn.ModuleList([nn.Linear(8, 8) for _ in range(3)])
+        self.seq = nn.Sequential(nn.Linear(8, 8), nn.ReLU())
+        self.dct = nn.ModuleDict({"a": nn.Linear(8, 8)})
+        self.tset = TranscoderSet()
+        self.noiter = IndexedNoIter()
+        self.tensor_indexed = IndexesATensor()
+        self.fresh = IndexesAFreshModule()
+
+    def forward(self, x):
+        for layer in self.layers:
+            x = layer(x)
+        return self.tset[1](x)
+
+
+class TestContainerDunders:
+    """``len``, iteration and indexing answer for the same entries.
+
+    Torch's containers hold their modules as their own entries, so all three go
+    through the envoy children. A container holding them one level down counts
+    and indexes the modules, and the envoy follows it there rather than
+    reporting a length whose every index raises.
+    """
+
+    @pytest.fixture
+    def envoy(self):
+        return Envoy(Container())
+
+    def test_torch_containers_index_by_child_name(self, envoy):
+        assert envoy.layers[1] is getattr(envoy.layers, "1")
+        assert envoy.seq[0]._module is envoy._module.seq[0]
+        assert envoy.dct["a"]._module is envoy._module.dct["a"]
+
+    def test_torch_containers_agree_across_dunders(self, envoy):
+        for child in (envoy.layers, envoy.seq, envoy.dct):
+            assert len(child) == len(list(child))
+
+    def test_a_delegating_container_agrees_across_dunders(self, envoy):
+        assert len(envoy.tset) == 4
+        assert len(list(envoy.tset)) == 4
+        assert [child.path for child in envoy.tset] == [
+            f"model.tset.items.{index}" for index in range(4)
+        ]
+
+    def test_indexing_a_delegating_container_names_the_module_it_returns(self, envoy):
+        assert envoy.tset[2] is envoy.tset.items[2]
+        assert envoy.tset[2]._module is envoy._module.tset[2]
+
+    def test_a_negative_index_delegates(self, envoy):
+        assert envoy.tset[-1] is envoy.tset.items[3]
+
+    def test_iteration_is_bounded_by_len_without_dunder_iter(self, envoy):
+        assert len(envoy.noiter) == 3
+        assert [child.path for child in envoy.noiter] == [
+            f"model.noiter.items.{index}" for index in range(3)
+        ]
+
+    def test_a_non_module_index_raises(self, envoy):
+        # Handing back the tensor element would break the contract that indexing
+        # an envoy yields an envoy.
+        with pytest.raises(AttributeError):
+            envoy.tensor_indexed[0]
+
+    def test_an_untracked_module_raises(self, envoy):
+        with pytest.raises(AttributeError):
+            envoy.fresh[0]
+
+    def test_a_delegating_container_traces(self, envoy):
+        x = torch.randn(1, 8)
+        with envoy.trace(x):
+            second = envoy.tset[1].output.save()
+        module = envoy._module
+        expected = x
+        for layer in module.layers:
+            expected = layer(expected)
+        assert torch.allclose(second, module.tset[1](expected))


### PR DESCRIPTION
## The bug

A container may keep its modules one level down and reach them through its own `__getitem__` — a set of transcoders or SAEs holding them in a child `ModuleList`:

```python
class TranscoderSet(nn.Module):
    def __init__(self, transcoders):
        super().__init__()
        self.transcoders = nn.ModuleList(transcoders)   # the tree's one child

    def __len__(self):        return len(self.transcoders)
    def __getitem__(self, i): return self.transcoders[i]
```

`Envoy.__len__` delegates to the module, while `__iter__` and `__getitem__` go through the envoy children. For this shape those disagree three ways:

| | before | |
|---|---|---|
| `len(envoy)` | **18** | the module's `__len__` |
| `len(list(envoy))` | **1** | envoy children |
| `envoy[0]` | `AttributeError` | child names |

So the envoy reported a length whose every index raised.

## The change

Indexing asks the container when no child answers to the name, and names the envoy of the module it returns. Iteration walks it the same way. `__len__` already delegated — it was the other two that disagreed with it.

```python
len(model.transcoders)      # 18
model.transcoders[2]        # model.transcoders.transcoders.2 — an Envoy
list(model.transcoders)     # the 18 transcoder envoys
```

**Torch's own containers are untouched.** `ModuleList`, `Sequential` and `ModuleDict` hold their modules as their own entries, so a name always resolves and the delegation never runs. That is what keeps a shared entry at its own name (#721) and what keeps `layers[2]` an envoy rather than a bare module.

The delegation only ever yields an `Envoy`. A `__getitem__` returning a tensor element, or a module built on the fly that this tree does not wrap, raises rather than handing back something no trace can address. A container with no `__iter__` of its own is walked over the length it reports, since Python would otherwise synthesize iteration from `__getitem__` and stop only on `IndexError`.

## Behaviour

| | `len` | `iter` | `[k]` |
|---|---|---|---|
| `ModuleList` / `Sequential` / `ModuleDict` | unchanged | unchanged | unchanged, by child name |
| shared entry, negative index, slice | unchanged | unchanged | unchanged |
| container indexing past its entries | 4 | 4 envoys | `tset.items[2]` |
| container with no `__iter__` | 3 | 3 envoys | delegates |
| `__getitem__` → tensor element | — | children | `AttributeError` |
| `__getitem__` → untracked module | — | children | `AttributeError` |

## How this surfaced

`circuit-tracer`'s `TranscoderSet` is exactly this shape. Before #721, `model.transcoders[0]` indexed `_children` positionally and returned the ModuleList — the container's sole entry — so `for t in model.transcoders[0]` iterated the transcoders by accident. #721 moved indexing to by-name, correctly, and the accident became an `AttributeError`.

Note this PR does **not** restore that expression: under these semantics `transcoders[0]` correctly means *the first transcoder*, not the list. Downstream code relying on the old positional accident still needs updating — that is the right outcome, and this PR is about the `len`/`iter`/`[]` disagreement rather than about restoring it.

## Tests

Nine tests in a new `TestContainerDunders` class covering the torch containers, a delegating container, one with no `__iter__`, negative indexing, both raising cases, and tracing through a delegated index. `tests/test_envoy.py`: **110 passed**.

Full suite (excluding `tests/vllm`, not installed here): **1040 passed**. The 16 failures and 29 errors are all `tests/tp/*` and `test_tensor_parallel_rules.py`, which need `torchrun` on a multi-GPU box — byte-identical sets with and without this change (`comm` on the sorted lists is empty in both directions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)