### PR TITLE
modeling: rebuild PEFT envoy paths on environment swap

### DIFF
--- a/src/nnsight/modeling/transformers.py
+++ b/src/nnsight/modeling/transformers.py
@@ -713,11 +713,22 @@ class TransformersModel(HuggingFaceModel):
                 and value is not self
                 and value._module not in submodules
             }
+            # The new wrapper may retain the base model as one of its descendants
+            # (PEFT does). Remove the old tree's registrations before rebuilding,
+            # or those modules resolve to envoys carrying their pre-wrap paths and
+            # the new wrapper's subtree is never constructed.
+            for old_module in submodules:
+                self.interleaver.envoys.pop(id(old_module), None)
             for name, value in list(self.__dict__.items()):
                 if isinstance(value, Envoy) and value is not self:
                     del self.__dict__[name]
             Envoy.__init__(
-                self, module, path=self.path, interleaver=self.interleaver, rename=self._rename
+                self,
+                module,
+                path=self.path,
+                interleaver=self.interleaver,
+                rename=self._rename,
+                envoys=self._envoys,
             )
             for name, child in standalone.items():
                 self.__dict__[name] = child

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -862,6 +862,11 @@ class TestPeft:
 
         model._remoteable_set_env({"peft": lora_adapter})  # None -> X
         assert model.peft == lora_adapter and _has_lora(model)
+        assert model.base_model.model.transformer.h[0].path == (
+            "model.base_model.model.transformer.h.0"
+        )
+        assert model.base_model._children
+        assert "transformer" not in model.__dict__
 
         module_after_load = model._module
         model._remoteable_set_env({"peft": lora_adapter})  # X -> X (no-op)


### PR DESCRIPTION
## What changed

- remove the previous Hugging Face module tree from the shared Envoy registry before rebuilding after a PEFT wrap or unwrap
- preserve custom Envoy mappings across the rebuild
- assert that the server-side adapter path matches construction with `peft=` and that stale root paths are gone

PEFT retains the base model as a descendant of its wrapper. Without clearing the old registry entries, rebuilding reuses Envoys carrying pre-wrap paths and never constructs the `base_model.model` subtree.

Closes #726.

## Tests

- fail-before: `test_set_env_transitions` reported `model.transformer.h.0` instead of `model.base_model.model.transformer.h.0`
- `CUDA_VISIBLE_DEVICES="" pytest tests/test_language.py::TestPeft -q` — 5 passed
- `git diff --check`